### PR TITLE
v4l2 control of usbtv kernel module.

### DIFF
--- a/devices
+++ b/devices
@@ -8,6 +8,9 @@ usage:
 restrictions:
  - only 720x576@25fps
 
+Brightness/contrast/saturation/hue of usbtv kernel module can be controlled by v4l2-ctl (from v4l-utils) with 
+e.g. v4l2-ctl --set-ctrl=brightness=512. Default values in Ubuntu 16.04 are too dark by default.
+
 Somagic
 userspace module
 USB ID(non-initized): 1c88:0007


### PR DESCRIPTION
Fushicai USBTV007 grabbers (1b71:3002) return very dark images in Ubuntu 16.04 and later due to bug fix of v4l2 controls ([https://github.com/torvalds/linux/commit/c53a846c48f21c909102677c127ece94b1247668](url)). Brightness and contrast values of the usbtv kernel module can be controlled by v4l2-ctl from the v4l-utils package.