### PR TITLE
iStream- improve logging and modify reboot/lock mechanism

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -725,7 +725,7 @@ if __name__ == "__main__":
                 # Check if the reboot lock file exists
                 reboot_lock_file_path = os.path.join(config.data_dir, config.reboot_lock_file)
                 if os.path.exists(reboot_lock_file_path):
-                    log.info("Reboot delayed for 1 minute becase the lock file exists: {:s}".format(reboot_lock_file_path))
+                    log.info("Reboot delayed for 1 minute because the lock file exists: {:s}".format(reboot_lock_file_path))
                     reboot_go = False
 
 

--- a/iStream/iStream.py
+++ b/iStream/iStream.py
@@ -1,29 +1,61 @@
 #!/usr/bin/python
 import os
-import getpass
+import subprocess
 import datetime
+import logging
 from RMS.CaptureDuration import captureDuration
-
-# Get the current user
-user = getpass.getuser()
-
+from RMS.Logger import initLogging
 
 def rmsExternal(captured_night_dir, archived_night_dir, config):
+    initLogging(config, 'iStream_')
+    log = logging.getLogger("logger")
+    log.info('iStream external script started')
 
-	# Compute the capture duration from now
-	start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation)
+    # create lock file to avoid RMS rebooting the system
+    lockfile = os.path.join(config.data_dir, config.reboot_lock_file)
+    with open(lockfile, 'w') as fp:
+        pass
 
-	timenow = datetime.datetime.utcnow()
-	remaining_seconds = 0
+    # Compute the capture duration from now
+    start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation)
 
-	# Compute how long to wait before capture
-	if start_time != True:
-		
-		waitingtime = start_time - timenow
-		remaining_seconds = int(waitingtime.total_seconds())		
+    timenow = datetime.datetime.utcnow()
+    remaining_seconds = 0
 
-	# Run the Istrastream shell script
-	script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "iStream.sh")
-	os.system(script_path + " {:s} {:s} {:s} {:.6f} {:.6f} {:.1f} {:d} {:d} {:d}".format(config.stationID, \
-		captured_night_dir, archived_night_dir, config.latitude, config.longitude, config.elevation, \
-		config.width, config.height, remaining_seconds))
+    # Compute how long to wait before capture
+    if start_time != True:
+        waitingtime = start_time - timenow
+        remaining_seconds = int(waitingtime.total_seconds())		
+
+    # Run the Istrastream shell script
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "iStream.sh")
+    log.info('Calling {}'.format(script_path))
+
+    command = [
+            script_path,
+            config.stationID,
+            captured_night_dir,
+            archived_night_dir,
+            '{:.6f}'.format(config.latitude),
+            '{:.6f}'.format(config.longitude),
+            '{:.1f}'.format(config.elevation),
+            str(config.width),
+            str(config.height),
+            str(remaining_seconds)
+            ]
+
+    proc = subprocess.Popen(command,stdout=subprocess.PIPE)
+   
+    # Read iStream script output and append to log file
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            break
+        log.info(line.rstrip().decode("utf-8"))
+
+    exit_code = proc.wait()
+    log.info('Exit status: {}'.format(exit_code))
+    log.info('iStream external script finished')
+
+    # relase lock file so RMS is authorized to reboot, if needed
+    os.remove(lockfile)

--- a/iStream/iStream.sh
+++ b/iStream/iStream.sh
@@ -298,8 +298,3 @@ if [ $VAR_1 = $VAR_2 ]; then
 fi
 echo "END EXTERNAL SCRIPT..."
 echo ""
-if [ $USER = "pi" ]; then
-	echo "REBOOTING SYSTEM..."
-	echo ""
-	sudo shutdown -r now
-fi


### PR DESCRIPTION
istream.sh output used to go to stdout only, getting lost across reboots and when terminal buffer replaces it.
Ths patch makes use of RMS standard log mechanism to preserve log of execution by creating its own file with prefix iStream_log_ in ~/RMS_data/logs/.
Also, makes use of RMS ExternalScript lock file mechanism, respecting user-configurable option "reboot_after_processing".