### PR TITLE
iStream: add time limit for generating timelapses

### DIFF
--- a/iStream/iStream.sh
+++ b/iStream/iStream.sh
@@ -93,15 +93,16 @@ function generate_captured_stack {
 	fi
 }
 
-function generate_timelapse {	
+function generate_timelapse {
+	$SECONDS_LIMIT=$($REMAINING_SECONDS - 120)
 	if ($LEVEL_1); then
 		cd ~/source/RMS
-		python -m Utils.GenerateTimelapse $CAPTURED_DIR_NAME
+		timeout -k 10 $SECONDS_LIMIT python -m Utils.GenerateTimelapse $CAPTURED_DIR_NAME
 		mv $TMP_VIDEO_FILE $VIDEO_FILE
 	fi
 	if ($LEVEL_2); then
 		cd ~/source/RMS
-		python -m Utils.GenerateTimelapse $CAPTURED_DIR_NAME
+		timeout -k 10 $SECONDS_LIMIT python -m Utils.GenerateTimelapse $CAPTURED_DIR_NAME
 		mv $TMP_VIDEO_FILE $VIDEO_FILE
 	fi
 }


### PR DESCRIPTION
ffmpeg is being seem stuck using 100% of a CPU for +12 hours and
affecting next capture night, probably due to a bug in ffmpeg.
This change works around it making sure timelapse video generation
have a hard stop 120 seconds before next night session starts.