### PR TITLE
Convert height from EGM96 to WGS84 for CAMS

### DIFF
--- a/RMS/Formats/CAL.py
+++ b/RMS/Formats/CAL.py
@@ -6,6 +6,7 @@ from __future__ import print_function, division, absolute_import
 import os
 import copy
 import math
+import pyproj
 
 
 from RMS.Astrometry.Conversions import jd2Date
@@ -86,6 +87,8 @@ def writeCAL(night_dir, config, platepar):
         platepar.y_poly_fwd[k] = math.sin(math.radians(platepar.pos_angle_ref))*x_prime \
             - math.cos(math.radians(platepar.pos_angle_ref))*y_prime
 
+    egm96_to_wgs84 = pyproj.Transformer.from_crs("EPSG:4979+5773", "EPSG:4979")
+    elev_wgs84 = egm96_to_wgs84.transform(platepar.lat, platepar.lon, platepar.elev)
 
     # Open the file
     with open(os.path.join(night_dir, file_name), 'w') as f:
@@ -100,7 +103,7 @@ def writeCAL(night_dir, config, platepar):
         s +=" Calibration time (UT)    = {:s}\n".format(calib_time)
         s +=" Longitude +west (deg)    = {:9.5f}\n".format(-platepar.lon)
         s +=" Latitude +north (deg)    = {:9.5f}\n".format(platepar.lat)
-        s +=" Height above WGS84 (km)  = {:8.5f}\n".format(platepar.elev/1000)
+        s +=" Height above WGS84 (km)  = {:8.5f}\n".format(elev_wgs84 / 1000)
         s +=" FOV dimension hxw (deg)  =   {:.2f} x   {:.2f}\n".format(platepar.fov_v, platepar.fov_h)
         s +=" Plate scale (arcmin/pix) = {:8.3f}\n".format(arcminperpixel)
         s +=" Plate roll wrt Std (deg) = {:8.3f}\n".format(rot_std)


### PR DESCRIPTION
Currently in the CAL-files for CAMS, the height from the RMS config file is written as if it were the WGS84-height. From the documentation in the config file, the RMS height is w.r.t. the EGM96 datum. This code converts between the two (an alternative fix would be to add a WGS84 height in the config).

This introduces a dependency on pyproj, but since it's only for full CAMS compatibility it may not be necessary to add to the requirements.