### PR TITLE
Fix ping on Windows

### DIFF
--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -172,7 +172,7 @@ def openFolderDialog(initialdir, title, mpl):
 
 
 
-def ping(host):
+def ping(host, count=1):
     """ Ping the host and return True if reachable. 
         Remember that a host may not respond to a ping (ICMP) request even if the host name is valid.
 
@@ -186,10 +186,10 @@ def ping(host):
     """
 
     # Ping command count option as function of OS
-    param = '-n 1' if platform.system().lower()=='windows' else '-c 1'
+    param = '-n' if platform.system().lower()=='windows' else '-c'
 
     # Building the command. Ex: "ping -c 1 google.com"
-    command = ['ping', param, host]
+    command = ['ping', param, str(count), host]
 
     # Pinging
     return subprocess.call(command) == 0


### PR DESCRIPTION
This fixes ping on Windows 10 using  Python 3.9.1. The method subprocess.call didn't like "-n 1" (two parameters) as a single element in the array and the IP address is not being passed to ping command:

>>> import subprocess
>>> subprocess.call(["ping", "-n 1", "192.168.42.10"])
O endereço IP deve ser especificado.
1
