### PR TITLE
Get rid of warning

### DIFF
--- a/Scripts/RMS_StartCapture.sh
+++ b/Scripts/RMS_StartCapture.sh
@@ -5,12 +5,12 @@ source ~/vRMS/bin/activate
 cd ~/source/RMS
 
 # Init log file
-LOGPATH="~/RMS_data/logs/"
+LOGPATH=~/RMS_data/logs/
 LOGDATE=$(date +"%Y%m%d_%H%M%S")
 LOGSUFFIX="_log.txt"
 LOGFILE=$LOGPATH$LOGDATE$LOGSUFFIX
 
-mkdir $LOGPATH
+mkdir -p $LOGPATH
 
 # Log the output to a file (warning: this breaks Ctrl+C passing to StartCapture)
 #python -m RMS.StartCapture 2>&1 | tee $LOGFILE


### PR DESCRIPTION
This should get rid of warnings like `mkdir: cannot create directory ‘~/RMS_data/logs/’: No such file or directory` and `mkdir: cannot create directory ‘/home/pi/RMS_data/logs/’: File exists`.