### PR TITLE
[WIP] Use python-dvr directly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "python-dvr"]
-	path = python-dvr
-	url = https://github.com/NeiroNx/python-dvr.git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RPi Meteor Station
 
-Open source powered meteor station. We are currently using the Raspberry Pi 3 (and 4!) as the main development platform and use digital IP cameras. **The code also works on Linux PCs, and everything but the detection works under Windows.** We are slowly phasing out the support for analog cameras, but they should work well regardless.
+Open source powered meteor station. We are currently using the Raspberry Pi 4 as the main development platform, and we use digital IP cameras. **The code also works on Linux PCs, and everything but the detection works under Windows.** We are slowly phasing out the support for analog cameras, but they should work well regardless.
 The software is still in the development phase, but here are the current features:
 
 1. Automated video capture - start at dusk, stop at dawn. **IP cameras with resolution of up to 720p supported on the Pi 3 and 4, and up to 1080p on Linux PCs.**
@@ -25,8 +25,7 @@ This guide will assume basic knowledge of electronics, the Unix environment, and
 
 #### RPi control box
 
-1. **Raspberry Pi 3 B+ or 4 single-board computer.**
-The code will NOT work on Raspberry Pi 1.
+1. **Raspberry Pi 4 single-board computer.**
 
 1. **Class 10 microSD card, 64GB or higher.** 
 The recorded data takes up a lot of space, as much as several gigabytes per night. To be able to store at least one week of data on the system, a 64GB SD card is the minimum.
@@ -68,37 +67,9 @@ The code was designed to run on a RPi, but it will also run an some Linux distri
 
 The recording **will not** run on Windows, but most of other submodules will (astrometric calibration, viewing the data, manual reduction, etc.). The problem under Windows is that for some reason the logging module object cannot be pickled when parallelized by the multiprocessing library. **We weren't able to solve this issue, but we invite people to try to take a stab at it.**
 
-Here we provide installation instructions for the RPi, but the procedure should be the same for any Debian-based Linux distribution.
+Here we provide installation instructions for the RPi, but the procedure should be the same for any Debian-based Linux distribution: [LINK](https://docs.google.com/document/d/19ImeNqBTD1ml2iisp5y7CjDrRV33wBeF9rtx3mIVjh4/edit)
 
-Set up your Raspberry Pi 3B+ with Raspbian Jessie operating system (gstreamer does not really work on Stretch, and it's necessary if you want to run an IP camera). For the Pi 4, you need to install Raspbian Buster. Here's the guide which explains how to do just that: [Installing Raspbian](https://www.raspberrypi.org/documentation/installation/installing-images/).
-
-**RPi3/Jessie is stuck using Python 2 because of some memory assignment issues in Python 3.6. We were not able to install newer version of Python under Jessie. NOTE that Raspbian Buster can run Python 3.7 and everything works fine there.**
-
-Furthermore, you will need the following software and libraries to run the code:
-
-- git
-- mplayer
-- Python2.7 (or 3.7)
-- python2.7-dev (or 3.7)
-- libblas-dev liblapack-dev
-- libffi-dev libssl-dev
-- Python libraries:
-	- gitpython
-	- astropy
-	- OpenCV 3 for Python
-	- PIL (i.e. python-imaging-tk)
-	- numpy (1.14.0 or later)
-	- scipy (1.0.0 or later)
-	- matplotlib (2.0.0 or later)
-	- cython (0.25.2 or later)
-	- pyephem (3.7.6.0 or later)
-	- paramiko
-	- imageio
-
-	
-All python libraries will be installed when you run the setup.py script (instructions below). If you want use IP cameras, you need to install a special compilation of OpenCV that supports gstreamer. Run the opencv4_install.sh script that is provided in this repository to install this.
-
-Alternatively, if you are using Anaconda Python, you can install all libraries except OpenCV by running:
+Alternatively, if you are using Anaconda Python on your Linux PC, you can install all libraries except OpenCV by running:
 
 ```
 conda install -y numpy scipy gitpython cython matplotlib

--- a/Utils/CameraControl.py
+++ b/Utils/CameraControl.py
@@ -70,23 +70,7 @@ from time import sleep
 # if not present, force update of the submodule
 
 if sys.version_info.major > 2:
-    import git
-    import importlib  #used to import python-dvr as it has a dash in the name
-    try:
-        sys.path.append(os.path.abspath('.')) 
-        dvr = importlib.import_module("python-dvr.dvrip")
-    except:
-        print("updating python-dvr")
-        rmsloc = os.path.abspath('.')
-        rmsrepo=git.Repo(rmsloc)
-        for sm in rmsrepo.submodules:
-            sm.update(init=True, force=True)
-        try:
-            sys.path.append(os.path.abspath('.')) 
-            dvr = importlib.import_module("python-dvr.dvrip")
-        except:
-            print('unable to update python-dvr - can\'t continue')
-            exit()
+    import dvrip as dvr
 else:
     # Python2 compatible version with much restricted capabilities
     import Utils.CameraControl27 as cc27

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ scipy>=1.0.0
 Pillow>=4.3.0
 astropy>=2.0.3
 imreg_dft
-onvif_zeep
+onvif; python_version=='2.7'
+onvif_zeep; python_version>='3.6'
 configparser==4.0.2
 imageio==2.6.1
+git+https://github.com/NeiroNx/python-dvr@87924a5ee2a0b175e1af3f783b61b74b2904bc99#egg=python-dvr; python_version>='3.6'

--- a/setup.py
+++ b/setup.py
@@ -25,36 +25,13 @@ kht_module = Extension("kht_module",
 # Read requirements file
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
+# drop unsupported git refs for install_requires https://github.com/pypa/setuptools/issues/1052
+for requirement in requirements:
+    if requirement.startswith("git+"):
+        requirements.remove(requirement)
 
 # Init the submodules (python-dvr)
 x = subprocess.call(['git','submodule','update','--init'])
-
-
-### HANDLE DIFFERENT ONVIF LIBRARIES FOR Py 2 AND 3 ###
-
-# Python 2 uses the 'onvif' library and Python 3 uses the onvif_zeep library
-if sys.version_info[0] < 3:
-
-    onvif_str = 'onvif_zeep'
-    onvif_proper = 'onvif'
-
-else:
-    onvif_str = 'onvif'
-    onvif_proper = 'onvif_zeep'
-
-
-# Strip version numbers from requirements
-reqs_stripped = [req.split('==')[0] for req in requirements]
-reqs_stripped = [req.split('>=')[0] for req in reqs_stripped]
-reqs_stripped = [req.split('<=')[0] for req in reqs_stripped]
-
-if onvif_str in reqs_stripped:
-    onvif_index = reqs_stripped.index(onvif_str)
-
-    # Replace the onvif module with the correct module for this version
-    requirements[onvif_index] = onvif_proper
-
-### ###
 
 
 # Cython modules which will be compiled on setup


### PR DESCRIPTION
Drop git module and pin python-dvr to the latest commit.
After https://github.com/NeiroNx/python-dvr/pull/24 was merged,
python-dvr can be pip installed directly from git.

Note that git refs do not work for setuptools install_requires,
so pip install -r requirements.txt is required to be executed before
python setup.py install !