### PR TITLE
Improvements to script to set camera parameters

### DIFF
--- a/Scripts/RMS_SetCameraParams.ps1
+++ b/Scripts/RMS_SetCameraParams.ps1
@@ -10,8 +10,22 @@ if ( $args.count -eq 0 ){
     write-output "    and the address of your router." 
     exit 1
 }
+Write-Output "------------------------"
+Write-Output "this script assumes that the RMS config file has not been changed and the"
+Write-Output "device string still contains the IP address 192.168.42.10"
+Write-Output ""
+Write-Output "if this is not the case, press Ctrl-C and edit it before proceeding"
+read-host -prompt "or press any other key to continue"
 
-$currip=$(python -m Utils.CameraControl GetIP)
+Write-Output "updating config file to use factory IP address 192.168.1.10"
+$currip="192.168.42.10"
+$defaultip="192.168.1.10"
+
+(Get-Content .config).replace("$currip", "$defaultip") | Set-Content tmp.tmp
+Move-Item .config .config.orig -force
+Move-Item tmp.tmp .config -force
+
+#$currip=$(python -m Utils.CameraControl GetIP)
 if ($args[0] -eq "DIRECT"){
     write-output Setting direct connection
     write-output Warning: you will lose connection to the camera once this completes
@@ -79,9 +93,8 @@ if ($args[0] -eq "DIRECT"){
 }
 write-output "------------------------"
 write-output "updating config file"
-(Get-Content .config).replace("$currip", "$camip") | Set-Content tmp.tmp
-Move-Item .config .config.orig -force
-Move-Item tmp.tmp .config
+(Get-Content .config).replace("$defaultip", "$camip") | Set-Content tmp.tmp
+Move-Item tmp.tmp .config -force
 write-output "------------------------"
 write-output "the camera will now reboot.... "
 Start-Sleep 5

--- a/Scripts/RMS_SetCameraParams.ps1
+++ b/Scripts/RMS_SetCameraParams.ps1
@@ -29,6 +29,7 @@ Move-Item tmp.tmp .config -force
 if ($args[0] -eq "DIRECT"){
     write-output Setting direct connection
     write-output Warning: you will lose connection to the camera once this completes
+    $camip=$currip
 }else{
     if ($args.count -lt 2){
         write-output "direct mode requires you to provide a Camera IP address and your routers IP address"
@@ -85,7 +86,7 @@ write-output "------------------------"
 write-output "about to update the camera IP address. You will see a timeout message"
 if ($args[0] -eq "DIRECT"){
     python -m Utils.CameraControl SetParam Network GateWay 192.168.42.1
-    python -m Utils.CameraControl SetParam Network HostIP 192.168.42.10
+    python -m Utils.CameraControl SetParam Network HostIP $camip
     python -m Utils.CameraControl SetParam Network EnableDHCP 1
 }else{
     python -m Utils.CameraControl SetParam Network GateWay $routerip

--- a/Scripts/RMS_SetCameraParams.sh
+++ b/Scripts/RMS_SetCameraParams.sh
@@ -28,6 +28,7 @@ mv -f tmp.tmp .config
 if [ "$1" == "DIRECT" ] ; then
     echo Setting direct connection
     echo Warning: you will lose connection to the camera once this completes
+    camip=$currip
 else
     if [ $# -lt 2 ] ; then 
         echo direct mode requires you to provide a Camera IP address and your routers IP address

--- a/Scripts/RMS_SetCameraParams.sh
+++ b/Scripts/RMS_SetCameraParams.sh
@@ -11,8 +11,20 @@ if [ $# -lt 1 ] ; then
     echo "    and the address of your router." 
     exit 1
 fi 
+echo "------------------------"
+echo "this script assumes that the RMS config file has not been changed and the"
+echo "device string still contains the IP address 192.168.42.10"
+echo ""
+echo "if this is not the case, press Ctrl-C and edit it before proceeding"
+read -p "or press any other key to continue" key
 
-currip=$(python -m Utils.CameraControl GetIP)
+echo "updating config file to use factory IP address 192.168.1.10"
+currip=192.168.42.10
+defaultip=192.168.1.10
+cat .config | sed "s/$currip/$defaultip/g" > tmp.tmp
+mv -f .config .config.orig
+mv -f tmp.tmp .config
+
 if [ "$1" == "DIRECT" ] ; then
     echo Setting direct connection
     echo Warning: you will lose connection to the camera once this completes
@@ -81,9 +93,8 @@ else
 fi
 echo "------------------------"
 echo "updating config file"
-cat .config | sed "s/$currip/$camip/g" > tmp.tmp
-mv .config .config.orig
-mv tmp.tmp .config
+cat .config | sed "s/$defaultip/$camip/g" > tmp.tmp
+mv -f tmp.tmp .config
 
 echo "------------------------"
 echo "the camera will now reboot.... "

--- a/Scripts/RMS_SetCameraParams.sh
+++ b/Scripts/RMS_SetCameraParams.sh
@@ -10,7 +10,7 @@ if [ $# -lt 1 ] ; then
     echo "    the two parameters are the IP address you want the camera to have"
     echo "    and the address of your router." 
     exit 1
-end if 
+fi 
 
 currip=$(python -m Utils.CameraControl GetIP)
 if [ "$1" == "DIRECT" ] ; then


### PR DESCRIPTION
Tested in the following scenarios:
1) Script run from PC. Camera plugged into PC, PC ethernet port set to 192.168.1.x range as per video by Denis Vida.
2) Script run from Pi. Camera plugged into router. Home network range 192.168.1.x 

NOT tested and not expected to work yet
3) script run from Pi, camera plugged into Pi.  

