### PR TITLE
SkyFit2: silence deprecation warnings on python 3.8

### DIFF
--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1332,7 +1332,7 @@ class PlateTool(QtWidgets.QMainWindow):
         filtered_indices, _ = self.filterCatalogStarsInsideFOV(self.catalog_stars)
 
         # Create a mask to filter out all stars outside the image and the FOV
-        filter_indices_mask = np.zeros(len(cat_stars_xy), dtype=np.bool)
+        filter_indices_mask = np.zeros(len(cat_stars_xy), dtype=bool)
         filter_indices_mask[filtered_indices] = True
         filtered_indices_all = filter_indices_mask & (cat_stars_xy[:, 0] > 0) \
                                                 & (cat_stars_xy[:, 0] < self.platepar.X_res) \
@@ -2170,12 +2170,12 @@ class PlateTool(QtWidgets.QMainWindow):
             if mp.x() > (range_[1] - range_[0])/2 + range_[0]:
                 self.v_zoom_left = True
                 if self.show_key_help != 2:
-                    self.v_zoom.move(QtCore.QPoint(self.label1.boundingRect().width(), 0))
+                    self.v_zoom.move(QtCore.QPoint(int(self.label1.boundingRect().width()), 0))
                 else:
                     self.v_zoom.move(QtCore.QPoint(0, 0))
             else:
                 self.v_zoom_left = False
-                self.v_zoom.move(QtCore.QPoint(self.img_frame.size().width() - self.show_zoom_window_size, 0))
+                self.v_zoom.move(QtCore.QPoint(int(self.img_frame.size().width() - self.show_zoom_window_size), 0))
 
             self.updateBottomLabel()
 

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1664,7 +1664,7 @@ class PlateTool(QtWidgets.QMainWindow):
                     photom_resid_txt = "{:.2f}".format(fit_diff)
 
                     # Determine the size of the residual text, larger the residual, larger the text
-                    photom_resid_size = 8 + np.abs(fit_diff)/(np.max(np.abs(fit_resids))/5.0)
+                    photom_resid_size = int(8 + np.abs(fit_diff)/(np.max(np.abs(fit_resids))/5.0))
 
                     if self.stdev_text_filter*std <= abs(fit_diff):
                         text1 = TextItem(photom_resid_txt, anchor=(0.5, -0.5))


### PR DESCRIPTION
Silence warnings like implicit convertion to int, and the one bellow:

/mnt/c/Users/thund/source/RMS/Utils/SkyFit2.py:1335: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  filter_indices_mask = np.zeros(len(cat_stars_xy), dtype=np.bool)