### PR TITLE
Updates to make use of dvrip directly

### DIFF
--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -56,6 +56,9 @@ git pull
 # Activate the virtual environment
 source ~/vRMS/bin/activate
 
+# make sure the correct requirements are installed
+pip install -r requirements.txt
+
 # Run the python setup
 python setup.py install
 

--- a/Utils/CameraControl.py
+++ b/Utils/CameraControl.py
@@ -520,8 +520,8 @@ def setAutoReboot(cam, opts):
         hour = int(spls[1])
     if day not in ['Everyday','Monday','Tuesday','Wednesday','Thursday','Friday', 
             'Saturday','Sunday','Never'] or hour < 0 or hour > 23:
-        print('usage: setAutoReboot dayofweek,hour')
-        print('  where dayofweek is Never, EveryDay, Monday, Tuesday, Wednesday etc')
+        print('usage: SetAutoReboot dayofweek,hour')
+        print('  where dayofweek is Never, Everyday, Monday, Tuesday, Wednesday etc')
         print('  and hour is a number between 0 and 23')
         return
 

--- a/Utils/CameraControl.py
+++ b/Utils/CameraControl.py
@@ -631,7 +631,7 @@ def cameraControl(camera_ip, cmd, opts=''):
         opts (array of strings): Optional array of field, subfield and value for the SetParam command
     """
     # Process the IP camera control command
-    cam = dvr.DVRIPCam(camera_ip, "admin", "")
+    cam = dvr.DVRIPCam(camera_ip)
     if cam.login():
         try:
             dvripCall(cam, cmd, opts)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import subprocess
 
 import numpy
 
@@ -45,13 +44,6 @@ else:
 
     else:
         requirements.append("rawpy")
-
-### ###
-
-
-# Init the submodules (python-dvr)
-x = subprocess.call(['git','submodule','update','--init'])
-
 
 # Cython modules which will be compiled on setup
 cython_modules = [


### PR DESCRIPTION
As per previous pull request by apevec, its possible to use dvrip as a standard module rather than as a submodule. While testing this i realised that the syntax has changed slightly, and as noted by apevec, its necessary to call pip install -r requirements.txt before running setup,py so that the modules are all installed as expected. This pull request addresses these points.

I've tested the changes on both my Pi3/Jessie/Py2.7 and Pi4/buster/Py3.7 without any issues.  As expected, with python 2.7 the dvrip module was not installed. 

ps also fixed some typos in the help info for SetAutoReboot
 