### PR TITLE
Telemetry for capture module 

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -100,6 +100,10 @@ class BufferedCapture(Process):
         if self.telemetry is not None:
             self.telemetry.set_data(self.telemetry_data)
 
+    def updateTelemetryFrame(self, frame):
+        if self.telemetry is not None:
+            self.telemetry.set_data_frame(frame)
+
 
     def startCapture(self, cameraID=0):
         """ Start capture using specified camera.
@@ -435,6 +439,7 @@ class BufferedCapture(Process):
             self.telemetry_data['frame_time_average'] = round(t_frame_total/block_frames, 3)
             self.telemetry_data['last_frame_block'] = datetime.datetime.utcnow().isoformat()
             self.updateTelemetry()
+            self.updateTelemetryFrame(frame) # copy the latest frame read
 
             # Switch the frame block buffer flags
             first = not first

--- a/RMS/TelemetryServer.py
+++ b/RMS/TelemetryServer.py
@@ -1,0 +1,50 @@
+""" Generic Telemetry web service """
+
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
+import json
+from socketserver import BaseRequestHandler
+import time
+import threading
+from typing import Callable, Tuple
+
+class TelemetryServer(ThreadingHTTPServer):
+    data = {}
+
+    def __init__(self, ip, port):
+        super().__init__((ip, port), TelemetryHandler)
+        
+
+    def set_data(self, data_obj):
+        self.data = data_obj
+
+    def run(self):
+        server_thread = threading.Thread(target=self.serve_forever)
+        server_thread.daemon_threads = True
+        server_thread.start()
+
+class  TelemetryHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+
+        self.wfile.write(bytes(json.dumps(self.server.data), "utf-8"))
+        self.wfile.flush()
+
+
+if __name__ == "__main__":
+    server = TelemetryServer('127.0.0.1', 5000)
+    server.run()
+
+    print("server started")
+    server.set_data({'hello': 'world', 'received': 'ok'})
+
+
+    input("Press any key to terminate the program")
+    server.set_data({'hello': 'world', 'received': 'err'})
+    input("Press any key to terminate the program")
+
+    server.shutdown() 
+    print("Server stopped.")        
+


### PR DESCRIPTION
**This  is a work in progress (draft pull request)**

Implements "telemetry" module so external applications can retrieve data from current capture session without disturbing it.
The data can be used by a monitoring application to generate statistics and also detect failures. As example, it could detect last frame block was processed a long time ago, so capture is stuck and action is required.

command:
```bash
$ curl http://127.0.0.1:2100
```
output:
```json
{
	"status": "capturing",
	"fps_expected": 25.0,
	"fps_estimated": 19.7,
	"block_frames": 256,
	"dropped_frames": 85,
	"frame_time_average": 0.049,
	"capture_start_time": "2021-05-18T06:12:44.820058",
	"last_frame_block": "2021-05-18T06:13:28.868691"
}
```

TODO wish list:
- add config option to enable/disable web service
- add config option to customize web service listen IP and port
- add a webservice endpoint to retrieve the last frame in the 256 block (http://127.0.0.1/last_frame)
- retrieve data from Stars and Meteor detection engine (number of stars and meteor count)
- limit number of connections to avoid DoS