### PR TITLE
implemented using bscale for storing std

### DIFF
--- a/RMS/CompressionCy.pyx
+++ b/RMS/CompressionCy.pyx
@@ -157,8 +157,9 @@ def compressFrames(np.ndarray[INT8_TYPE_t, ndim=3] frames, int deinterlace_order
             # Subtract average squared sum of all values (acc*mean = acc*acc/frames_num_minus_four)
             var -= acc*mean    
 
-            # Compute the standard deviation
-            var = <unsigned int> sqrt(var/frames_num_minus_five)
+            # Compute 10 times the standard deviation (to keep one decimal when rounding to uint8)
+            # In FFbin and FFfits, the standard deviation is divided by 10 again
+            var = <unsigned int> (10 * sqrt(var/frames_num_minus_five))
 
             # Make sure that the stddev is not 0, to prevent divide by zero afterwards
             if var == 0:

--- a/RMS/Formats/FFbin.py
+++ b/RMS/Formats/FFbin.py
@@ -130,7 +130,7 @@ def write(ff, directory, filename, version=2):
             arr[0] = ff.maxpixel
             arr[1] = ff.maxframe
             arr[2] = ff.avepixel
-            arr[3] = ff.stdpixel
+            arr[3] = np.round(0.1 * ff.stdpixel)
         
         # Extract only the number from the camera code
         camno_num = int(re.findall('\d+', str(ff.camno))[0])
@@ -172,4 +172,3 @@ def write(ff, directory, filename, version=2):
 
         # Write image arrays
         arr.tofile(fid)
-        

--- a/RMS/Formats/FFfile.py
+++ b/RMS/Formats/FFfile.py
@@ -1,4 +1,4 @@
-""" Functions for reading/writing FF files with respet to the rheir format (.bin for .fits). """
+""" Functions for reading/writing FF files with respect to their format (.bin for .fits). """
 
 
 from __future__ import print_function, division, absolute_import

--- a/RMS/Formats/FFfits.py
+++ b/RMS/Formats/FFfits.py
@@ -76,6 +76,8 @@ def write(ff, directory, filename):
     
     Arguments:
         ff: [ff bin struct] FF bin file loaded in the FF structure
+            In this FF structure, the standard deviation is an uint8 with ten
+            times the actual value
         directory: [str] path to the directory where the file will be written
         filename: [str] name of the file which will be written
     
@@ -115,7 +117,10 @@ def write(ff, directory, filename):
     maxpixel_hdu = fits.ImageHDU(ff.maxpixel, name='MAXPIXEL')
     maxframe_hdu = fits.ImageHDU(ff.maxframe, name='MAXFRAME')
     avepixel_hdu = fits.ImageHDU(ff.avepixel, name='AVEPIXEL')
-    stdpixel_hdu = fits.ImageHDU(ff.stdpixel, name='STDPIXEL')
+    stdpixel_hdu = fits.ImageHDU(0.1 * ff.stdpixel, name='STDPIXEL')
+    # Set BSCALE in fits metadata, so FITS readers will understand the scaling and
+    # return e.g. 4.3 when the number 43 is stored as uint8
+    stdpixel_hdu.scale('uint8', bscale=0.1)
     
     # Create the primary part
     prim = fits.PrimaryHDU(header=head)
@@ -152,7 +157,7 @@ if __name__ == "__main__":
 
     maxpixel = np.zeros((ht, wid), dtype=np.uint8)
     avepixel = np.zeros((ht, wid), dtype=np.uint8) + 10
-    stdpixel = np.zeros((ht, wid), dtype=np.uint8) + 20
+    stdpixel = np.zeros((ht, wid), dtype=np.uint8) + 201 # Scaled by 10, so this represents 20.1
     maxframe = np.zeros((ht, wid), dtype=np.uint8) + 30
 
     ff.array = np.stack([maxpixel, maxframe, avepixel, stdpixel], axis=0)


### PR DESCRIPTION
This stores the standard deviation as uint8 with the standard FITS keyword `BSCALE=0.1`, which means all stored values will be scaled down by a factor 10 by all FITS-compliant software (including Astropy). This means that the values for the standard deviation with this change are limited to the range 0 to 25.5, and have one digit of precision.

I have tested this on my camera NL000D, so far everything works as expected, but I'll report back when I've had a clear night.

A side effect of this is that when opening FITS files with astropy and writing them back (something that RMS and CMN_binviewer do not) the values will be stored as floating point numbers, increasing the file size. This can be avoided by opening them with `astropy.io.fits.open(FFbla.fits, scale=True)` (note that the scaling always happens, this refers only to the writing behavior).

As suggested by @cbassa in #74