### PR TITLE
Fix timestamps in GenerateMP4s

### DIFF
--- a/Utils/FFtoFrames.py
+++ b/Utils/FFtoFrames.py
@@ -159,7 +159,7 @@ def FFtoFrames(file_path, out_dir, file_format, deinterlace_mode, first_frame=0,
 
         # No deinterlace
         else:
-            frame_name, frame_dt = saveFrame(frame, i-first_frame, out_dir, file_name_saving, file_format, ff_dt, fps)
+            frame_name, frame_dt = saveFrame(frame, i, out_dir, file_name_saving, file_format, ff_dt, fps)
             frame_name_time_list.append([frame_name, frame_dt])
 
     # If the frames are saved for METAL, the times have to be given in a separate file

--- a/Utils/GenerateMP4s.py
+++ b/Utils/GenerateMP4s.py
@@ -113,7 +113,7 @@ def generateMP4s(dir_path, ftpfile_name):
             root = os.path.dirname(__file__)
             ffmpeg_path = os.path.join(root, "ffmpeg.exe")
             # Construct the ecommand for ffmpeg           
-            com = ffmpeg_path + " -y -f image2 -pattern_type sequence -i " + temp_img_path +" " + mp4_path
+            com = ffmpeg_path + " -y -f image2 -pattern_type sequence -start_number " + str(first_frame) + " -i " + temp_img_path +" " + mp4_path
             print("Creating timelapse using ffmpeg...")
         else:
             # If avconv is not found, try using ffmpeg
@@ -122,12 +122,12 @@ def generateMP4s(dir_path, ftpfile_name):
             if os.system(software_name + " --help > /dev/null"):
                 software_name = "ffmpeg"
                 # Construct the ecommand for ffmpeg           
-                com = software_name + " -y -f image2 -pattern_type sequence -i " + temp_img_path +" " + mp4_path
+                com = software_name + " -y -f image2 -pattern_type sequence -start_number " + str(first_frame) + " -i " + temp_img_path +" " + mp4_path
                 print("Creating timelapse using ffmpeg...")
             else:
                 print("Creating timelapse using avconv...")
                 com = "cd " + dir_path + ";" \
-                    + software_name + " -v quiet -r 30 -y -i " + temp_img_path \
+                    + software_name + " -v quiet -r 30 -y -start_number " + str(first_frame) + " -i " + temp_img_path \
                     + " -vcodec libx264 -pix_fmt yuv420p -crf 25 -movflags faststart -g 15 -vf \"hqdn3d=4:3:6:4.5,lutyuv=y=gammaval(0.97)\" " \
                     + mp4_path
 


### PR DESCRIPTION
The timestamps in GenerateMP4s (which since #63 update every second) still refer to the beginning of the FF-file. This fixes that bug.

I think @markmac99 [used](https://github.com/CroatianMeteorNetwork/RMS/commit/bd8f2e0cc5f7b35ed909c33aaa700fe2e0e931ff#diff-10fc682193c6d4db0d6b9e90e011cd3f37e749215b3b2838aada1af737e5132dL163) `i-first_frame` in the call to `saveFrame` to make the output JPGs start counting at 0 to make the input to ffmpeg easier. There are two problems with this:
- It's inconsistent with the interlaced variants
- It messes up the timestamps

Since both ffmpeg and avconv support specifying the number of the first frame, it's also not necessary.