### PR TITLE
Support UYVY pixelformat

### DIFF
--- a/.config
+++ b/.config
@@ -43,6 +43,7 @@ force_v4l2: false
 width: 1280
 height: 720
 fps: 25.0 ; frames per second
+uyvy_pixelformat: false
 report_dropped_frames: false
 
 ; Region of interest, left limit. -1 to disable

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -345,7 +345,9 @@ class BufferedCapture(Process):
                     if frame.shape[2] == 3:
 
                         gray = frame[:, :, 1]
-
+                    # if UYVY image given, take luma (Y) channel
+                    elif frame.shape[2] == 2 and self.config.uyvy_pixelformat:
+                        gray = frame[:, :, 1]
                     else:
                         gray = frame[:, :, 0]
 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -234,6 +234,7 @@ class Config:
         self.width_device = self.width
         self.height_device = self.height
         self.fps = 25.0
+        self.uyvy_pixelformat = False
 
         self.report_dropped_frames = False
 
@@ -770,6 +771,9 @@ def parseCapture(config, parser):
 
     if parser.has_option(section, "fps"):
         config.fps = parser.getfloat(section, "fps")
+
+    if parser.has_option(section, "uyvy_pixelformat"):
+        config.uyvy_pixelformat = parser.getboolean(section, "uyvy_pixelformat")
 
     if parser.has_option(section, "ff_format"):
         config.ff_format = parser.get(section, "ff_format")

--- a/Utils/ShowLiveStream.py
+++ b/Utils/ShowLiveStream.py
@@ -112,6 +112,9 @@ if __name__ == "__main__":
                     if frame.shape[2] == 3:
                         # Get green channel
                         frame = frame[:, :, 1]
+                    # if UYVY image given, take luma (Y) channel
+                    elif frame.shape[2] == 2 and config.uyvy_pixelformat:
+                        frame = frame[:, :, 1]
                     else:
                         frame = frame[:, :, 0]
 


### PR DESCRIPTION
This PR allows the use of cameras that provide images in the UYVY pixel format. For an example [YEVE IMX 327](http://wiki.veye.cc/index.php/VEYE-MIPI-290/327) provide image only in UYVY format.
With config like this 
`device: v4l2src device=/dev/video0 ! video/x-raw,format=UYVY,width=1920,height=1080,framerate=30/1 ! appsink sync=1`
openCV receive frames in UYVY format. This format have 2 channels and only second channel (Y or luma) is important. 