### PR TITLE
Bugfix - desktop link to Binviewer doesn't work

### DIFF
--- a/Scripts/GenerateDesktopLinks.sh
+++ b/Scripts/GenerateDesktopLinks.sh
@@ -13,7 +13,7 @@ DIR=$(realpath $DIR)
 DESKTOP=$(realpath ~/Desktop)
 
 # Create links to scripts, so they can be updated
-ln -sf $DIR/CMNbinViewer.sh $DESKTOP/.
+ln -sf $DIR/CMNbinViewer_env.sh $DESKTOP/CMNbinViewer.sh
 ln -sf $DIR/DownloadOpenVPNconfig.sh $DESKTOP/.
 ln -sf $DIR/RMS_FirstRun.sh $DESKTOP/.
 ln -sf $DIR/RMS_ShowLiveStream.sh $DESKTOP/.


### PR DESCRIPTION
Pete Eschman reported that the desktop link for BinViewer doesn't work. Confirmed and fixed - needs to run Scripts/CMNbinViewer_env.sh so that the python virtualenv is activated. 