### PR TITLE
[RFC] Optional tmux session in StartCapture

### DIFF
--- a/Scripts/RMS_StartCapture.sh
+++ b/Scripts/RMS_StartCapture.sh
@@ -15,7 +15,12 @@ mkdir -p $LOGPATH
 # Log the output to a file (warning: this breaks Ctrl+C passing to StartCapture)
 #python -m RMS.StartCapture 2>&1 | tee $LOGFILE
 
-python -m RMS.StartCapture "$@"
+# start a new tmux session if not already inside one and tmux is available
+if [ -z "$TMUX" ] && type tmux >/dev/null 2>&1; then
+  tmux new-session -s RMS python -m RMS.StartCapture "$@"
+else
+  python -m RMS.StartCapture "$@"
+fi
 
 read -p "Press any key to continue... "
 


### PR DESCRIPTION
tmux[1] allows access to the running session from another local shell:
(vRMS) pi@hr0017:~/source/RMS $ tmux ls
RMS: 2 windows (created Sun Feb 20 21:46:55 2022) [80x23]

(vRMS) pi@hr0017:~/source/RMS $ tmux attach -t RMS

[1] tmux is a terminal multiplexer. https://github.com/tmux/tmux/wiki