### PR TITLE
Video read error handling

### DIFF
--- a/RMS/Formats/FrameInterface.py
+++ b/RMS/Formats/FrameInterface.py
@@ -824,9 +824,11 @@ class InputTypeVideo(InputType):
         ff_struct_fake = FFMimickInterface(self.nrows, self.ncols, np.uint8)
 
         # If there are no frames to read, return an empty array
-        if frames_to_read == 0:
+        if frames_to_read == 0 or frames_to_read == -1:
             print('There are no frames to read!')
             return ff_struct_fake
+
+        print('Frames to read: ' + str(frames_to_read))
 
         # Load the chunk of frames
         for i in range(frames_to_read):

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -3404,7 +3404,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
         if self.v_zoom_left:
             if self.show_key_help != 2:
-                self.v_zoom.move(QtCore.QPoint(self.label1.boundingRect().width(), 0))
+                self.v_zoom.move(QtCore.QPoint(int(self.label1.boundingRect().width()), 0))
             else:
                 self.v_zoom.move(QtCore.QPoint(0, 0))
 


### PR DESCRIPTION
I have these two changes locally for a long time, just realized that.
One silences a deprecation warning, making sure the value is integer.
The second one avoids crashing when reading a broken video recorded by UFO Capture, it continues gracefully instead.

(I tried to create the pull request against "dev" branch but looks like it's out of sync with master)