### PR TITLE
Clear down RMS logs

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -264,6 +264,9 @@ class Config:
         self.captured_dir = "CapturedFiles"
         self.archived_dir = "ArchivedFiles"
 
+        # days of logfiles to keep
+        self.logdays_to_keep = 30
+
         # Extra space to leave on disk for the archive (in GB) after the captured files have been taken
         #   into account
         self.extra_space_gb = 3
@@ -695,6 +698,9 @@ def parseCapture(config, parser):
 
     if parser.has_option(section, "log_dir"):
         config.log_dir = parser.get(section, "log_dir")
+
+    if parser.has_option(section, "logdays_to_keep"):
+        config.logdays_to_keep = parser.get(section, "logdays_to_keep")
 
     if parser.has_option(section, "captured_dir"):
         config.captured_dir = parser.get(section, "captured_dir")

--- a/iStream/iStream.sh
+++ b/iStream/iStream.sh
@@ -173,7 +173,9 @@ function upload_fieldsums {
 
 function upload_report_astrometry {
 	REPORT_ASTROMETRY_FILE="$(ls $CAPTURED_DIR_NAME/*.jpg | grep 'report_astrometry.jpg')"
-	if [ -f "$REPORT_ASTROMETRY_FILE" ]; then			
+	TMP_REPORT_ASTROMETRY_FILE="$CAPTURED_DIR_NAME/report_astrometry.jpg"
+	if [ -f "$REPORT_ASTROMETRY_FILE" ]; then
+		cp $REPORT_ASTROMETRY_FILE $TMP_REPORT_ASTROMETRY_FILE
 		curl --user-agent $AGENT -F"operation=upload" -F"file=@$REPORT_ASTROMETRY_FILE" "$SERVER/$SYSTEM/?station_id=$STATION_ID&type=report_astrometry&action=upload&level=$ACTIVE_LEVEL"
 	else
 		curl --user-agent $AGENT "$SERVER/$SYSTEM/?station_id=$STATION_ID&type=no_report_astrometry&action=upload&level=$ACTIVE_LEVEL"


### PR DESCRIPTION
Add functionality to clear down the RMS logs. 
New parameter in config file "logdays_to_keep". 
If new parameter missing, default 30 days is used. 
Only clears down files matching pattern "log*.log*"


