### PR TITLE
Fix for remote reprocessing

### DIFF
--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -62,7 +62,7 @@ def getPlatepar(config, night_data_dir):
     # Load the default platepar from the RMS if it is available
     platepar = None
     platepar_fmt = None
-    platepar_path = os.path.join(os.getcwd(), config.platepar_name)
+    platepar_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(night_data_dir))),'source','RMS',config.platepar_name)
     if os.path.exists(platepar_path):
         platepar = Platepar()
         platepar_fmt = platepar.read(platepar_path, use_flat=config.use_flat)

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -462,8 +462,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
 
 
-    night_archive_dir = os.path.join(os.path.abspath(config.data_dir), config.archived_dir, 
-        night_data_dir_name)
+    night_archive_dir = night_archive_dir = os.path.join(os.path.dirname(os.path.dirname(night_data_dir)), 'ArchivedFiles', night_data_dir_name)
 
 
     log.info('Archiving detections to ' + night_archive_dir)

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -462,7 +462,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
 
 
-    night_archive_dir = night_archive_dir = os.path.join(os.path.dirname(os.path.dirname(night_data_dir)), 'ArchivedFiles', night_data_dir_name)
+    night_archive_dir = os.path.join(os.path.dirname(os.path.dirname(night_data_dir)), 'ArchivedFiles', night_data_dir_name)
 
 
     log.info('Archiving detections to ' + night_archive_dir)


### PR DESCRIPTION
Archive and platepar path should correspond to Captured path. This is the fix for remote reprocessing e.g. via SMB or NFS