### PR TITLE
Fix running RMSExternalScript manually on machines with multiple stations

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -182,10 +182,9 @@ def loadConfigFromDirectory(cml_args_config, dir_path):
             # Load the config file from the full path
             config_file = os.path.abspath(cml_args_config[0].replace('"', ''))
 
-
-        if config_file is None:
+        if config_file is None or os.path.exists(config_file) is False:
             raise FileNotFoundError("A config file could not be found in directory: {:s}, {:s}".format(
-                dir_path, cml_args_config
+                dir_path, cml_args_config[0]
                 )
             )
 

--- a/RMS/RunExternalScript.py
+++ b/RMS/RunExternalScript.py
@@ -78,11 +78,15 @@ if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser(description=""" Run external script.
         """)
 
-    arg_parser.add_argument('captured_path', nargs=1, metavar='CAPTURED_PATH', type=str, \
+    arg_parser.add_argument('-c', '--config', nargs=1, metavar='CONFIG_PATH', type=str,
+        help="Path to a config file which will be used instead of the default one.")
+
+    arg_parser.add_argument('captured_path', nargs=1, metavar='CAPTURED_PATH', type=str,
         help='Path to Captured night directory.')
 
-    arg_parser.add_argument('archived_path', nargs=1, metavar='ARCHIVED_PATH', type=str, \
+    arg_parser.add_argument('archived_path', nargs=1, metavar='ARCHIVED_PATH', type=str,
         help='Path to Archived night directory.')
+
 
     # Parse the command line arguments
     cml_args = arg_parser.parse_args()
@@ -94,7 +98,11 @@ if __name__ == "__main__":
     log.addHandler(out_hdlr)
 
     # Load config file
-    config = cr.parse(".config")
+    try:
+        config = cr.loadConfigFromDirectory(cml_args.config, cml_args.captured_path[0])
+    except FileNotFoundError as e:
+        print('ERROR: ' + str(e))
+        exit(1)
 
     # Run the external script
     runExternalScript(cml_args.captured_path[0], cml_args.archived_path[0], config)


### PR DESCRIPTION
Adds --config/-c parameter that can be used to provide a different RMS configuration file instead of using the default one. This is
useful when there are multiple stations running on the same machine.

Also fixes an error handling when the provided config file is not found.

Reported by: William Schauff and  Washington Oliveira