### PR TITLE
fix: bump imreg_dft to remove deprecated np.bool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cython>=0.27.3
 scipy>=1.0.0
 Pillow>=4.3.0
 astropy>=2.0.3
-imreg_dft
+imreg_dft @ git+https://github.com/matejak/imreg_dft@master#egg=imreg_dft
 configparser==4.0.2
 imageio==2.6.1
 python-dvr>=0.0.1 ; python_version >='3.6'


### PR DESCRIPTION
Fix deprecated np.bool error on newer numpy version: 

![screenshot_2023-05-16_at_9 51 03](https://github.com/CroatianMeteorNetwork/RMS/assets/10259593/54472465-f315-48be-bfc4-15231bc47a12)

(Try to open the screenshot image on the new tab if the message is too small, sorry!)

Steps-to-reproduce: 
1. Install deps from requirements.txt
2. Install latest numpy version (e.g. v1.24.0)
3. Install latest imreg_dft (v2.0.0) from pypi
4. Try to reprocess the pickle

The latest commit on the source already has a fix for the deprecated np.bool, but not published to pypi yet. 