### PR TITLE
Stop reprocessing if capture time

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -670,6 +670,14 @@ def processIncompleteCaptures(config, upload_manager):
             log.error(repr(e))
             log.error(repr(traceback.format_exception(*sys.exc_info())))
 
+        # If capture should have started do not process any more incomplete directories
+        start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation)
+        if isinstance(start_time, bool):
+            if start_time:
+                log.info("Stopping reprocess, capture due to start")
+                break
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Wrt to Issue #171, allows at least one directory to be reprocessed, but it it is time to capture does not allow any more to be processed, until the next day.