### PR TITLE
Timesync

### DIFF
--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -86,3 +86,4 @@ echo "0" > $UPDATEINPROGRESSFILE
 
 echo "Update finished! Update exiting in 5 seconds..."
 sleep 5
+

--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -86,4 +86,3 @@ echo "0" > $UPDATEINPROGRESSFILE
 
 echo "Update finished! Update exiting in 5 seconds..."
 sleep 5
-

--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -19,7 +19,7 @@ do
   echo "Wait for real time clock to sync - system time is $(date)"
   sleep 60
 done
-echo "System clock is synced - sytem time is $(date)"
+echo "System clock is synced           - system time is $(date)"
 
 echo "Updating RMS code..."
 

--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -25,8 +25,6 @@ echo "System clock is synced - sytem time is $(date)"
 
 echo "Updating RMS code..."
 
-
-
 # Make the backup directory
 mkdir $RMSBACKUPDIR
 
@@ -88,3 +86,4 @@ echo "0" > $UPDATEINPROGRESSFILE
 
 echo "Update finished! Update exiting in 5 seconds..."
 sleep 5
+

--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -13,7 +13,19 @@ RMSBACKUPDIR=~/.rms_backup
 # File for indicating that the update is in progress
 UPDATEINPROGRESSFILE=$RMSBACKUPDIR/update_in_progress
 
+while [ $(timedatectl | grep "synchronized" | cut -d":" -f2 | xargs) != 'yes' ]
+
+do
+  echo "Wait for real time clock to sync - system time is $(date)"
+  sleep 60
+done
+echo "System clock is synced - sytem time is $(date)"
+
+
+
 echo "Updating RMS code..."
+
+
 
 # Make the backup directory
 mkdir $RMSBACKUPDIR

--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -21,8 +21,6 @@ do
 done
 echo "System clock is synced - sytem time is $(date)"
 
-
-
 echo "Updating RMS code..."
 
 # Make the backup directory


### PR DESCRIPTION
This fixes a problem when a brand new station cannot execute RMS_Update.sh successfully because the RTC is too far out. This has occurred every time at one location. It may be an issue which is unique, and hence not be a suitable candidate for a pull. However I have noticed other stations sometimes appear to start and end capture at strange times. It may also block capture if there is no internet connection. 



