### PR TITLE
Handle zero length .config file

### DIFF
--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -1776,7 +1776,23 @@ class EventMonitor(multiprocessing.Process):
             # If there is a .config file then parse it as evcon - not the station config
             for file in file_list:
                 if file.endswith(".config"):
-                    ev_con = cr.parse(file)
+                    log.info("Attempt to parse {} as the .config for the event".format(file))
+                    if os.path.isfile(file):
+                        log.info("Contemporary .config file found")
+                        if os.path.getsize(file) != 0:
+                            try:
+                                ev_con = cr.parse(file)
+                            except:
+                                log.warning("Unknown error loading .config file; reverting to station .config")
+                                ev_con = cr.parse(self.syscon.config_file_name)
+                        else:
+                            log.warning("Zero size .config file found")
+                            ev_con = cr.parse(self.syscon.config_file_name)
+                            log.warning("Used the station .config file as night directory .config file had zero length")
+                    else:
+                        log.info("No .config file found at {}".format(file))
+                        ev_con = cr.parse(self.syscon.config_file_name)
+                        log.warning("Used the station .config file as no contemporary .config file was found")
 
             # Look for the station code in the stations_required string
             if observed_event.stations_required.find(ev_con.stationID) != -1:

--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -1775,7 +1775,7 @@ class EventMonitor(multiprocessing.Process):
 
             # If there is a .config file then parse it as evcon - not the station config
             for file in file_list:
-                if file.endswith(".config"):
+                if file.endswith(self.syscon.config_file_name):
                     log.info("Attempt to parse {} as the .config for the event".format(file))
                     if os.path.isfile(file):
                         log.info("Contemporary .config file found")


### PR DESCRIPTION
https://github.com/CroatianMeteorNetwork/RMS/issues/213

Report of a crash of EventMonitor following parsing a zero length .config file found in a CapturedFiles directory. This fix uses the station .config file in this event. 