### PR TITLE
Fix bug in deleteOldObservations

### DIFF
--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -213,8 +213,8 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
 
         # Initialize the observer and find the time of next noon
         o = ephem.Observer()  
-        o.lat = config.latitude
-        o.long = config.longitude
+        o.lat = str(config.latitude)
+        o.long = str(config.longitude)
         o.elevation = config.elevation
         sun = ephem.Sun()
 


### PR DESCRIPTION
lat and long passed to ephem() must either be radians as a float, or degrees as a string eg 0.91 or "51.8".  

However we're currently passing the value in degrees as a float which is then interpreted as a value in radians. Ephem normalises it  to the range -pi/2 to pi/2 so for example 51.8 converts to 1.5345, which is equal to 87.9 degrees north.  Not the desired latitude ! 

The subsequent call to work out sunrise is then failing for half the year since the sun never rises at this latitude. As a result, deleteOldObservations is silently failing and no space is freed. 
This patch fixes it by converting the lat/long values to strings, as we do elsewhere in the code. An alternative would be to convert to radians, but its simpler and more consistent with other code to use str() 