### PR TITLE
python3.10+ compatibility fix

### DIFF
--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -811,7 +811,7 @@ class CursorItem(pg.GraphicsObject):
             painter.drawEllipse(QtCore.QPoint(0, 0), r, r)
         painter.end()
 
-        rect = QtCore.QRect(-3*self.r, -3*self.r, 6*self.r, 6*self.r)
+        rect = QtCore.QRect(-3*int(self.r), -3*int(self.r), 6*int(self.r), 6*int(self.r))
         self.picture.setBoundingRect(rect)
 
     def paint(self, painter, option, widget=None):


### PR DESCRIPTION
auto data type retyping from float to int is not supported by python3.10+