### PR TITLE
Fix Dropped Frames Count Reporting in StartCapture

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -388,10 +388,10 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
 
     # Stop the capture
     log.debug('Stopping capture...')
+    dropped_frames = bc.dropped_frames
     bc.stopCapture()
     log.debug('Capture stopped')
 
-    dropped_frames = bc.dropped_frames
     log.info('Total number of late or dropped frames: ' + str(dropped_frames))
 
 


### PR DESCRIPTION
This PR addresses the problem described in issue #249, where `dropped_frames` was always reported as zero due to its assignment occurring after `bc.stopCapture()` in `startCapture.py`. The proposed change ensures that the correct number of dropped frames is reported in the logs.

Changes made:
- Moved the assignment of `dropped_frames` from after `bc.stopCapture()` to just before it. This change ensures that `dropped_frames` is accurately reported before the capture stops.

Fixes #249
