### PR TITLE
bugfix for condition where bz and arc to keep are both zero

### DIFF
--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -365,7 +365,8 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
 
 def deleteOldArchivedDirs(data_dir, config):
     archived_dir = os.path.join(data_dir, config.archived_dir)
-
+    orig_count = 0
+    final_count = 0
     if config.arch_dirs_to_keep > 0:
         archdir_list = getNightDirs(archived_dir, config.stationID)
         orig_count = len(archdir_list)


### PR DESCRIPTION
Bug reported by Rick Hewett
Tested on UK0006 by setting the config variables to zero, then commenting them out to simulate an unupdated file, then setting them to 20 to simulate a manual override
```
(vRMS) pi@uk0006:~/source/RMS $ egrep "bz2|arch_dirs_to_keep" .config
; how many ArchivedFiles and bz2 files to keep
arch_dirs_to_keep: 0
bz2_files_to_keep: 0
(vRMS) pi@uk0006:~/source/RMS $ python -m RMS.DeleteOldObservations
Loading config file: /home/pi/source/RMS/.config
2024/01/20 14:28:29-INFO-DeleteOldObservations-line:447 - deleting obs from /home/pi/RMS_data
2024/01/20 14:28:29-INFO-DeleteOldObservations-line:230 - clearing down log files
2024/01/20 14:28:29-INFO-DeleteOldObservations-line:234 - clearing down old data from ArchivedFiles
2024/01/20 14:28:29-INFO-DeleteOldObservations-line:376 - Purged 0 older folders from ArchivedFiles
2024/01/20 14:28:29-INFO-DeleteOldObservations-line:385 - Purged 0 older bz2 files from ArchivedFiles
2024/01/20 14:28:29-INFO-DeleteOldObservations-line:273 - Need 23.18 GB for next night

(vRMS) pi@uk0006:~/source/RMS $ egrep "bz2|arch_dirs_to_keep" .config
; how many ArchivedFiles and bz2 files to keep
;arch_dirs_to_keep: 0
;bz2_files_to_keep: 0
(vRMS) pi@uk0006:~/source/RMS $ python -m RMS.DeleteOldObservations
Loading config file: /home/pi/source/RMS/.config
2024/01/20 14:29:53-INFO-DeleteOldObservations-line:447 - deleting obs from /home/pi/RMS_data
2024/01/20 14:29:53-INFO-DeleteOldObservations-line:230 - clearing down log files
2024/01/20 14:29:53-INFO-DeleteOldObservations-line:234 - clearing down old data from ArchivedFiles
2024/01/20 14:29:53-INFO-DeleteOldObservations-line:376 - Purged 0 older folders from ArchivedFiles
2024/01/20 14:29:53-INFO-DeleteOldObservations-line:385 - Purged 0 older bz2 files from ArchivedFiles
2024/01/20 14:29:53-INFO-DeleteOldObservations-line:273 - Need 23.18 GB for next night

(vRMS) pi@uk0006:~/source/RMS $ egrep "bz2|arch_dirs_to_keep" .config
; how many ArchivedFiles and bz2 files to keep
arch_dirs_to_keep: 20
bz2_files_to_keep: 20
(vRMS) pi@uk0006:~/source/RMS $ python -m RMS.DeleteOldObservations
Loading config file: /home/pi/source/RMS/.config
2024/01/20 14:30:21-INFO-DeleteOldObservations-line:447 - deleting obs from /home/pi/RMS_data
2024/01/20 14:30:21-INFO-DeleteOldObservations-line:230 - clearing down log files
2024/01/20 14:30:21-INFO-DeleteOldObservations-line:234 - clearing down old data from ArchivedFiles
2024/01/20 14:30:21-INFO-DeleteOldObservations-line:376 - Purged 0 older folders from ArchivedFiles
2024/01/20 14:30:21-INFO-DeleteOldObservations-line:385 - Purged 0 older bz2 files from ArchivedFiles
2024/01/20 14:30:21-INFO-DeleteOldObservations-line:273 - Need 23.18 GB for next night
(vRMS) pi@uk0006:~/source/RMS $
```