### PR TITLE
Plot, score, and log timestamp intervals for analysis

### DIFF
--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -401,7 +401,8 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
         log.info('Timestamp Intervals Analysis: Jitter Quality: {:.1f}%, Dropped Frame Rate: {:.1f}%'.format(
             jitter_quality, dropped_frame_rate))
         # Add the timelapse to the extra files
-        extra_files.append(intervals_path)
+        if intervals_path is not None:
+            extra_files.append(intervals_path)
 
     except Exception as e:
         log.debug('Plotting timestamp interval failed with message:\n' + repr(e))

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -397,8 +397,8 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
     # Plot timestamp intervals
     try:
-        score, intervals_path =  analyze_timestamps(night_data_dir, fps=config.fps)
-        log.info(f'Timestamp Intervals Score: {score}')
+        jitter_quality, dropped_frame_rate, intervals_path = analyze_timestamps(night_data_dir, fps=config.fps)
+        log.info('Timestamp Intervals Analysis: Jitter Quality: {:.1f}%, Dropped Frame Rate: {:.1f}%'.format(jitter_quality, dropped_frame_rate))
         # Add the timelapse to the extra files
         extra_files.append(intervals_path)
 

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -395,14 +395,12 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
     log.info('Plotting timestamp intervals...')
 
-    # Plot timestamp interval
+    # Plot timestamp intervals
     try:
-        analyze_timestamps(night_data_dir)
-
-        timelapse_path = os.path.join(night_data_dir, timelapse_file_name)
-
+        score, intervals_path =  analyze_timestamps(night_data_dir)
+        log.info(f'Timestamp Intervals Score: {score}')
         # Add the timelapse to the extra files
-        extra_files.append(timelapse_path)
+        extra_files.append(intervals_path)
 
     except Exception as e:
         log.debug('Plotting timestamp interval failed with message:\n' + repr(e))

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -35,7 +35,7 @@ from Utils.MakeFlat import makeFlat
 from Utils.PlotFieldsums import plotFieldsums
 from Utils.RMS2UFO import FTPdetectinfo2UFOOrbitInput
 from Utils.ShowerAssociation import showerAssociation
-
+from Utils.PlotTimeIntervals import analyze_timestamps
 
 # Get the logger from the main module
 log = logging.getLogger("logger")
@@ -393,6 +393,20 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
             log.debug('Generating a timelapse failed with message:\n' + repr(e))
             log.debug(repr(traceback.format_exception(*sys.exc_info())))
 
+    log.info('Plotting timestamp intervals...')
+
+    # Plot timestamp interval
+    try:
+        analyze_timestamps(night_data_dir)
+
+        timelapse_path = os.path.join(night_data_dir, timelapse_file_name)
+
+        # Add the timelapse to the extra files
+        extra_files.append(timelapse_path)
+
+    except Exception as e:
+        log.debug('Plotting timestamp interval failed with message:\n' + repr(e))
+        log.debug(repr(traceback.format_exception(*sys.exc_info())))
 
 
     ### Add extra files to archive

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -397,7 +397,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
     # Plot timestamp intervals
     try:
-        score, intervals_path =  analyze_timestamps(night_data_dir)
+        score, intervals_path =  analyze_timestamps(night_data_dir, fps=config.fps)
         log.info(f'Timestamp Intervals Score: {score}')
         # Add the timelapse to the extra files
         extra_files.append(intervals_path)

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -35,7 +35,7 @@ from Utils.MakeFlat import makeFlat
 from Utils.PlotFieldsums import plotFieldsums
 from Utils.RMS2UFO import FTPdetectinfo2UFOOrbitInput
 from Utils.ShowerAssociation import showerAssociation
-from Utils.PlotTimeIntervals import analyze_timestamps
+from Utils.PlotTimeIntervals import plotFFTimeIntervals
 
 # Get the logger from the main module
 log = logging.getLogger("logger")
@@ -397,8 +397,9 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
     # Plot timestamp intervals
     try:
-        jitter_quality, dropped_frame_rate, intervals_path = analyze_timestamps(night_data_dir, fps=config.fps)
-        log.info('Timestamp Intervals Analysis: Jitter Quality: {:.1f}%, Dropped Frame Rate: {:.1f}%'.format(jitter_quality, dropped_frame_rate))
+        jitter_quality, dropped_frame_rate, intervals_path = plotFFTimeIntervals(night_data_dir, fps=config.fps)
+        log.info('Timestamp Intervals Analysis: Jitter Quality: {:.1f}%, Dropped Frame Rate: {:.1f}%'.format(
+            jitter_quality, dropped_frame_rate))
         # Add the timelapse to the extra files
         extra_files.append(intervals_path)
 

--- a/Utils/FluxAuto.py
+++ b/Utils/FluxAuto.py
@@ -456,7 +456,7 @@ def fluxAutoRun(config, data_path, ref_dt, days_prev=2, days_next=1, all_prev_ye
     metadata_dir=None, output_dir=None, csv_dir=None, index_dir=None, generate_website=False, 
     website_plot_url=None, shower_code=None, shower_suffix_filename=None, custom_binning_dict=None,
     cpu_cores=1, excluded_stations_file="excluded_stations.txt",
-    skip_allyear=False):
+    skip_allyear=False, publication_quality=False):
     """ Given the reference time, automatically identify active showers and produce the flux graphs and
         CSV files.
 
@@ -487,6 +487,7 @@ def fluxAutoRun(config, data_path, ref_dt, days_prev=2, days_next=1, all_prev_ye
         excluded_stations_file: [str] File with excluded stations and periods. It should be in the metadata
             directory.
         skip_allyear: [bool] Skip computing the flux with all years.
+        publication_quality: [bool] Produce plots in publication quality. False by default.
     """
 
 
@@ -850,7 +851,8 @@ def fluxAutoRun(config, data_path, ref_dt, days_prev=2, days_next=1, all_prev_ye
                 compute_single=False,
                 show_plot=False,
                 xlim_shower_limits=True,
-                sol_marker=sol_ref
+                sol_marker=sol_ref,
+                publication_quality=publication_quality
             )
 
             # Save the batch flux plot (full metadata)
@@ -862,7 +864,8 @@ def fluxAutoRun(config, data_path, ref_dt, days_prev=2, days_next=1, all_prev_ye
                 compute_single=False,
                 show_plot=False,
                 xlim_shower_limits=True,
-                sol_marker=None
+                sol_marker=None,
+                publication_quality=publication_quality
             )
 
             # Save the results to a CSV file
@@ -969,6 +972,9 @@ if __name__ == "__main__":
 
     arg_parser.add_argument('--skipallyear', action="store_true", \
         help="""Skip computing multi-year fluxes. Only compute fluxes for the given year.""")
+    
+    arg_parser.add_argument('--publication', action="store_true", \
+        help="""Produce plots in publication quality.""")
 
 
     # Parse the command line arguments
@@ -1018,7 +1024,9 @@ if __name__ == "__main__":
             website_plot_url=cml_args.weburl, shower_code=cml_args.shower, \
             shower_suffix_filename=cml_args.suffix, custom_binning_dict=custom_binning_dict,
             cpu_cores=cml_args.cpucores,
-            skip_allyear=cml_args.skipallyear)
+            skip_allyear=cml_args.skipallyear,
+            publication_quality=cml_args.publication
+            )
 
 
         ### <// DETERMINE NEXT RUN TIME ###

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -1,0 +1,93 @@
+import os
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+from datetime import datetime
+import sys
+
+def analyze_timestamps(folder_path):
+    timestamps = []
+    for file in os.listdir(folder_path):
+        if file.endswith('.jpg'):
+            try:
+                timestamp_str = file.split('_')[2] + file.split('_')[3] + file.split('_')[4].split('.')[0]
+                timestamp = datetime.strptime(timestamp_str, '%Y%m%d%H%M%S%f')
+                timestamps.append(timestamp)
+            except ValueError:
+                print(f"Skipping file with incorrect format: {file}")
+
+    timestamps.sort()
+    differences = [(timestamps[i+1] - timestamps[i]).total_seconds() for i in range(len(timestamps) - 1)]
+    df = pd.DataFrame({'Timestamp': timestamps[:-1], 'Difference': differences})
+
+    # Calculate mean and standard deviation
+    mean_diff = df['Difference'].mean()
+    std_diff = df['Difference'].std()
+
+    # Define outlier threshold based on standard deviation (e.g., 2 or 3 sigma)
+    sigma = 10
+    lower_bound = mean_diff - (sigma * std_diff)
+    upper_bound = mean_diff + (sigma * std_diff)
+
+    # Identify outliers
+    df['Outlier'] = (df['Difference'] < lower_bound) | (df['Difference'] > upper_bound)
+
+
+    # Calculate average excluding outliers
+    average_difference = df[~df['Outlier']]['Difference'].mean()
+
+    # Plotting
+    plt.figure(figsize=(12, 6))
+
+    # Scatter plot for differences
+    plt.scatter(df['Timestamp'], df['Difference'], label='Normal', c=df['Outlier'].map({True: 'red', False: 'gray'}), s=10, alpha=0.5)
+
+    # Expected and Average lines
+    plt.axhline(y=5.12, color='green', linestyle='-', label='Expected Interval (5.12s)')
+    plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval ({average_difference:.4f}s)')
+
+    # Find the minimum difference and round down to nearest 0.1
+    min_difference = df['Difference'].min()
+    rounded_min_difference = np.floor(min_difference * 10) / 10
+
+    # Find the maximum difference and round up to nearest 0.1
+    max_difference = df['Difference'].max()
+    rounded_max_difference = np.ceil(max_difference * 10) / 10
+
+    # Setting gridlines
+    # Horizontal grid every 0.1 seconds
+    y_ticks = np.arange(rounded_min_difference, rounded_max_difference + 0.1, 0.1)
+    plt.yticks(y_ticks)
+    plt.grid(axis='y', linestyle='-', alpha=0.7)
+
+    # Vertical grid every hour
+    plt.gca().xaxis.set_major_locator(mdates.HourLocator())
+    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%H:%M'))
+    plt.grid(axis='x', linestyle='-', alpha=0.7)
+
+    # Labeling
+    plt.xlabel('Timestamp')
+    plt.ylabel('Time Difference (seconds)')
+    plt.title('Time Differences Between Consecutive Video Frames')
+    plt.legend()
+
+    # Save the plot in the folder_path
+    plot_filename = os.path.join(folder_path, 'time_difference_plot.png')
+    plt.savefig(plot_filename, format='png', dpi=300)
+    plt.show()
+
+    return df
+
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python script.py <folder_path>")
+        sys.exit(1)
+
+    folder_path = sys.argv[1]
+    analyze_timestamps(folder_path)
+
+if __name__ == "__main__":
+    main()

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -1,28 +1,42 @@
 """ Plot the intervals between timestamps from FF file and scores the timing performance.
-Usage:
-  python -m Utils.PlotTimeIntervals /path/to/directory --fps 25
-
-Arguments:
-  <dir_path>  The path to the folder containing the files to analyze.
-  [fps]          Frames per second. Optional argument. Default is 25.
 
 This script analyzes the timestamps in the files located in the specified folder.
 The optional fps argument allows specifying the frames per second for the analysis.
 If fps is not provided, the default value of 25 is used.
 
- """
+"""
+
 import os
 import argparse
 import tarfile
+import math
+import datetime
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
-import math
-from datetime import datetime
+
 import RMS.ConfigReader as cr
 
 
-def analyze_timestamps(dir_path, fps=25.0):
+def plotFFTimeIntervals(dir_path, fps=25.0, ff_block_size=256, ma_window_size=50):
+    """ Plot the intervals between timestamps from FF file and scores the timing performance.
+    
+    Arguments:
+        dir_path: [str] The path to the folder containing the files to analyze. FS files will be recursively
+            in all directories within dir_path.
+    
+    Keyword Arguments:
+        fps: [float] The expected frames per second. (default: 25.0)
+        ff_ff_block_size: [int] The number of frames in each FF file. (default: 256)
+        ma_window_size: [int] The window size for the moving average. (default: 50)
+
+    Returns:
+        jitter_quality: [float] The jitter quality score.
+        dropped_frame_rate: [float] The dropped frame rate score.
+        plot_filename: [str] The filename of the plot that was saved.
+
+    """
 
     # Extract the subdir_name from dir_path
     subdir_name = os.path.basename(dir_path.rstrip('/\\'))
@@ -36,31 +50,35 @@ def analyze_timestamps(dir_path, fps=25.0):
 
     if not tar_file_path:
         print("Tar file not found.")
+
     else:
+
         # Open the tar file
         with tarfile.open(tar_file_path, 'r:bz2') as tar:
+
             timestamps = []
+
             # Iterate through its members
             for member in tar.getmembers():
+
                 # Check if the current member is a .bin file
                 if member.isfile() and member.name.endswith('.bin'):
+
                     try:
                         # Extract timestamp from the file name
                         file_name_parts = member.name.split('_')
                         timestamp_str = file_name_parts[2] + file_name_parts[3] + file_name_parts[4].split('.')[0]
-                        timestamp = datetime.strptime(timestamp_str, '%Y%m%d%H%M%S%f')
+                        timestamp = datetime.datetime.strptime(timestamp_str, '%Y%m%d%H%M%S%f')
                         timestamps.append(timestamp)
+
                     except ValueError:
                         print("Skipping file with incorrect format: {}".format(member.name))
 
 
     timestamps.sort()
 
-    # set the number of frames in each FF file
-    block_size = 256
-
     # Calculate intervals, starting from the second timestamp as the first is unreliable
-    intervals = [(timestamps[i+1] - timestamps[i]).total_seconds() for i in range(1, len(timestamps) - 1)]
+    intervals = [(timestamps[i + 1] - timestamps[i]).total_seconds() for i in range(1, len(timestamps) - 1)]
     timestamps = timestamps[1:-1]
 
     # Convert timestamps to a NumPy array for boolean indexing
@@ -73,26 +91,23 @@ def analyze_timestamps(dir_path, fps=25.0):
     #mean_interval = np.mean(intervals) if intervals else None
     median_interval = np.median(intervals_np)
     std_intervals_seconds = np.std(intervals_np)
-    std_intervals_frames = std_intervals_seconds * fps
-    expected_interval = block_size / fps
+    std_intervals_frames = std_intervals_seconds*fps
+    expected_interval = ff_block_size/fps
 
     # Calculate average fps
-    # average_fps = block_size / mean_interval
-    median_fps = block_size / median_interval
-
-    # Set the window size for the moving average
-    window_size = 50
+    # average_fps = ff_block_size/mean_interval
+    median_fps = ff_block_size/median_interval
 
     # Calculate moving average
-    moving_avg = np.convolve(intervals_np, np.ones(window_size), 'valid') / window_size
+    moving_avg = np.convolve(intervals_np, np.ones(ma_window_size), 'valid')/ma_window_size
 
     # Insert padding at the start to line up with timestamps
-    padding = np.full(window_size-1, expected_interval)
+    padding = np.full(ma_window_size - 1, expected_interval)
     padded_moving_avg = np.concatenate([padding, moving_avg])
 
     # Set the threshold above which to tag for possible dropped frames
     tolerance = 1
-    threshold = (block_size + tolerance) / fps
+    threshold = (ff_block_size + tolerance)/fps
 
     # Create a boolean mask where the moving average exceeds the threshold
     above_threshold = padded_moving_avg > threshold
@@ -104,10 +119,10 @@ def analyze_timestamps(dir_path, fps=25.0):
     # Don't compute scores if there's not enough data
     if len(intervals) > 60:
         # Calculate Jitter Quality
-        count_within_tolerance = sum(1 for interval in intervals if abs(interval - expected_interval) <= tolerance / fps)
-        jitter_quality = (count_within_tolerance / len(intervals)) * 100 if intervals else 0
+        count_within_tolerance = sum(1 for interval in intervals if abs(interval - expected_interval) <= tolerance/fps)
+        jitter_quality = (count_within_tolerance/len(intervals))*100 if intervals else 0
         # Calculate Dropped Frame Rate
-        dropped_frame_rate = (np.sum(above_threshold) / len(padded_moving_avg)) * 100
+        dropped_frame_rate = (np.sum(above_threshold)/len(padded_moving_avg))*100
 
     else:
         jitter_quality = None
@@ -128,36 +143,45 @@ def analyze_timestamps(dir_path, fps=25.0):
     intervals_above_threshold = intervals_np[combined_condition]
 
     # Calculating the lower and upper interval values for plotting
-    lower_interval = (block_size - 1) / fps
-    upper_interval = (block_size + 1) / fps
+    lower_interval = (ff_block_size - 1)/fps
+    upper_interval = (ff_block_size + 1)/fps
 
     plt.figure()
 
     # Plot grey points (below threshold)
-    plt.scatter(timestamps_below_threshold, intervals_below_threshold, label='Intervals, max ({:.3f}s), min ({:.3f}s)'.format(max_interval, min_interval), c='gray', s=10, alpha=0.5, zorder=3)
+    plt.scatter(timestamps_below_threshold, intervals_below_threshold, 
+                label='Intervals, max ({:.3f}s), min ({:.3f}s)'.format(max_interval, min_interval), 
+                c='gray', s=10, alpha=0.5, zorder=3)
 
     # Plot red points (above threshold) at the highest z-order
-    plt.scatter(timestamps_above_threshold, intervals_above_threshold, label='Possible Dropped Frames', c='red', s=10, alpha=0.5, zorder=5)
+    plt.scatter(timestamps_above_threshold, intervals_above_threshold, 
+                label='Possible Dropped Frames', 
+                c='red', s=10, alpha=0.5, zorder=5)
 
     # Plot Expected and Median lines
-    plt.axhline(y=expected_interval, color='lime', linestyle='-', label='Expected ({:.3f}s), ({:.2f} fps)'.format(expected_interval, fps), zorder=4)
+    plt.axhline(y=expected_interval, color='lime', linestyle='-', 
+                label='Expected ({:.3f}s), ({:.2f} fps)'.format(expected_interval, fps), zorder=4)
     # plt.axhline(y=mean_interval, color='blue', linestyle='--', label='Mean ({:.3f}s), ({:.2f} fps)'.format(mean_interval, average_fps), zorder=4)
-    plt.axhline(y=median_interval, color='green', linestyle='--', label='Median ({:.3f} +/- {:.3f} s), ({:.2f} +/- {:.2f} fps)'.format(median_interval, std_intervals_seconds, median_fps, std_intervals_frames), zorder=4)
+    plt.axhline(y=median_interval, color='green', linestyle='--', 
+                label='Median ({:.3f} +/- {:.3f} s), ({:.2f} +/- {:.2f} fps)'.format(
+                    median_interval, std_intervals_seconds, median_fps, std_intervals_frames), zorder=4)
 
     # Determine grid interval dynamically
     difference_range = max_interval - min_interval
-    raw_interval = difference_range / 11
+    raw_interval = difference_range/11
 
     # Round the interval up to the nearest 0.1, 1, or 10
     if raw_interval < 0.1:
-        grid_interval = math.ceil(raw_interval * 10) / 10
+        grid_interval = math.ceil(raw_interval*10)/10
         grid_color = 'grey'
-        rounded_min_interval = np.floor(min_interval * 10) / 10
-        rounded_max_difference = np.ceil(max_interval * 10) / 10
+        rounded_min_interval = np.floor(min_interval*10)/10
+        rounded_max_difference = np.ceil(max_interval*10)/10
 
         # Only draw lower and upper interval lines if the scale is fine enough
-        plt.axhline(y=lower_interval, color='lime', linestyle='--', label='-1/fps Interval ({:.3f}s)'.format(lower_interval), zorder=4)
-        plt.axhline(y=upper_interval, color='lime', linestyle='--', label='+1/fps Interval ({:.3f}s)'.format(upper_interval), zorder=4)
+        plt.axhline(y=lower_interval, color='lime', linestyle='--', 
+                    label='-1/fps Interval ({:.3f}s)'.format(lower_interval), zorder=4)
+        plt.axhline(y=upper_interval, color='lime', linestyle='--', 
+                    label='+1/fps Interval ({:.3f}s)'.format(upper_interval), zorder=4)
 
     elif raw_interval < 1:
         grid_interval = math.ceil(raw_interval)
@@ -166,10 +190,10 @@ def analyze_timestamps(dir_path, fps=25.0):
         rounded_max_difference = np.ceil(max_interval)
 
     else:
-        grid_interval = math.ceil(raw_interval / 10) * 10
+        grid_interval = math.ceil(raw_interval/10)*10
         grid_color = '#FFBF00'
-        rounded_min_interval = np.floor(min_interval / 10) * 10
-        rounded_max_difference = np.ceil(max_interval / 10) * 10
+        rounded_min_interval = np.floor(min_interval/10)*10
+        rounded_max_difference = np.ceil(max_interval/10)*10
 
     # Ensure grid_interval is not too small
     minimum_allowed_interval = 0.1
@@ -190,9 +214,12 @@ def analyze_timestamps(dir_path, fps=25.0):
     plt.ylabel('Intervals (seconds)')
 
     # Title and subtitle
-    plt.title('Timestamp Intervals - {}'.format(subdir_name), pad=30)
-    subtitle_text = 'Jitter Quality (intervals within +/-1 frame): {:.1f}%'.format(round(jitter_quality, 1))
-    subtitle_text_2 = 'Dropped Frame Rate (intervals >{} frames late within {} FF files): {:.1f}%'.format(tolerance, window_size, dropped_frame_rate)
+    plot_title = subdir_name.replace("_detected", "")
+    plt.title('Timestamp Intervals - {}'.format(plot_title), pad=30)
+    subtitle_text = 'Jitter Quality (intervals within +/-1 frame): {:.1f}%'.format(
+        round(jitter_quality, 1))
+    subtitle_text_2 = 'Dropped Frame Rate (intervals >{} frames late within {} FF files): {:.1f}%'.format(
+        tolerance, ma_window_size, dropped_frame_rate)
 
     plt.figtext(0.5, 0.925, subtitle_text, ha='center', va='top', fontsize=8)
     plt.figtext(0.5, 0.895, subtitle_text_2, ha='center', va='top', fontsize=8)
@@ -202,8 +229,8 @@ def analyze_timestamps(dir_path, fps=25.0):
     plt.tight_layout()
 
     # Save the plot in the dir_path
-    plot_filename = os.path.join(dir_path, '{}_intervals_scores_{:.0f}-{:.0f}.png'.format(subdir_name, jitter_quality, dropped_frame_rate))
-    plt.savefig(plot_filename, format='png', dpi=150)
+    plot_filename = os.path.join(dir_path, '{}_ff_intervals.png'.format(plot_title))
+    plt.savefig(plot_filename, dpi=150)
     plt.close()
 
     return jitter_quality, dropped_frame_rate, plot_filename
@@ -214,13 +241,13 @@ if __name__ == '__main__':
     ### COMMAND LINE ARGUMENTS
 
     # Init the command line arguments parser
-    arg_parser = argparse.ArgumentParser(description="Generate interval plots on all subfoler where a FS*tar.gz2 is found.")
+    arg_parser = argparse.ArgumentParser(description="Generate interval plots on all subdirectories where a FS*tar.bz2 is found. FPS will be taken from config files unless it is manually overridden.")
 
     arg_parser.add_argument('dir_path', metavar='DIR_PATH', type=str, \
         help='Path to directory with FS*tar.bz2 files.')
 
     arg_parser.add_argument('--fps', metavar='FPS', type=float, default=25.0, required=False, \
-        help='Expected fps (default: 25.0).')
+        help='Expected fps (default: taken from config file, 25.0 if config not found).')
 
      # Parse the command line arguments
     cml_args = arg_parser.parse_args()
@@ -237,4 +264,4 @@ if __name__ == '__main__':
                     fps = cml_args.fps
                 tar_file_path = os.path.join(root, file)
                 print("Processing {}".format(tar_file_path))
-                analyze_timestamps(root, fps)
+                plotFFTimeIntervals(root, fps)

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -1,3 +1,4 @@
+""" Plot the intervals between timestamps from FF file and scores the variability. """
 import os
 import pandas as pd
 import numpy as np
@@ -22,7 +23,7 @@ def calculate_score(differences, alpha=1.5):
     return int(round(score))
 
 
-def analyze_timestamps(folder_path):
+def analyze_timestamps(folder_path, fps=25):
     timestamps = []
 
     # Extract the subdir_name from folder_path
@@ -73,7 +74,7 @@ def analyze_timestamps(folder_path):
     plt.scatter(outlier_points['Timestamp'], outlier_points['Difference'], label='Outliers', c='red', s=10, alpha=0.5)
 
     # Expected and Average lines
-    # plt.axhline(y=1/fps, color='green', linestyle='-', label='Expected Interval (5.12s)')
+    plt.axhline(y=1/fps, color='green', linestyle='-', label='Expected Interval from .config fps')
     plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval ({average_difference:.4f}s), Average ({average_fps:.1f} fps)')
 
     # Find the minimum difference and round down to nearest 0.1

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -50,30 +50,32 @@ def plotFFTimeIntervals(dir_path, fps=25.0, ff_block_size=256, ma_window_size=50
 
     if not tar_file_path:
         print("Tar file not found.")
+        return None, None, None
 
-    else:
+    timestamps = []
 
-        # Open the tar file
-        with tarfile.open(tar_file_path, 'r:bz2') as tar:
+    # Open the tar file
+    with tarfile.open(tar_file_path, 'r:bz2') as tar:
 
-            timestamps = []
+        # Iterate through its members
+        for member in tar.getmembers():
 
-            # Iterate through its members
-            for member in tar.getmembers():
+            # Check if the current member is a .bin file
+            if member.isfile() and member.name.endswith('.bin'):
 
-                # Check if the current member is a .bin file
-                if member.isfile() and member.name.endswith('.bin'):
+                try:
+                    # Extract timestamp from the file name
+                    file_name_parts = member.name.split('_')
+                    timestamp_str = file_name_parts[2] + file_name_parts[3] + file_name_parts[4].split('.')[0]
+                    timestamp = datetime.datetime.strptime(timestamp_str, '%Y%m%d%H%M%S%f')
+                    timestamps.append(timestamp)
 
-                    try:
-                        # Extract timestamp from the file name
-                        file_name_parts = member.name.split('_')
-                        timestamp_str = file_name_parts[2] + file_name_parts[3] + file_name_parts[4].split('.')[0]
-                        timestamp = datetime.datetime.strptime(timestamp_str, '%Y%m%d%H%M%S%f')
-                        timestamps.append(timestamp)
+                except ValueError:
+                    print("Skipping file with incorrect format: {}".format(member.name))
 
-                    except ValueError:
-                        print("Skipping file with incorrect format: {}".format(member.name))
-
+    if len(timestamps) < 2:
+        print("Insufficient timestamps. At least two timestamps are required.")
+        return None, None, None
 
     timestamps.sort()
 

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -111,7 +111,7 @@ def analyze_timestamps(folder_path, fps=25):
     plt.scatter(outlier_points['Timestamp'], outlier_points['Difference'], label='Outliers', c='red', s=10, alpha=0.5)
 
     # Expected and Average lines
-    plt.axhline(y=expected_interval, color='green', linestyle='-', label=f'Expected Interval from .config fpsv({expected_interval:.4f}s)')
+    plt.axhline(y=expected_interval, color='green', linestyle='-', label=f'Expected Interval from .config fps ({expected_interval:.4f}s)')
     plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval ({average_difference:.4f}s), Average ({average_fps:.1f} fps)')
 
     # Find the minimum difference and round down to nearest 0.1

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -3,13 +3,33 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
+import math
 from datetime import datetime
+from RMS.ConfigReader import Config
 import sys
+
+
+def calculate_score(differences, alpha=1.5):
+    """
+    Calculate a score using an exponential decay function based on the standard deviation.
+    A higher standard deviation results in a lower score.
+    The alpha parameter controls the rate of decay.
+    """
+    current_std_dev = np.std(differences)
+    
+    score = 1000 * np.exp(-alpha * current_std_dev)
+
+    return int(round(score))
+
 
 def analyze_timestamps(folder_path):
     timestamps = []
+
+    # Extract the subdir_name from folder_path
+    subdir_name = os.path.basename(folder_path.rstrip('/\\'))
+
     for file in os.listdir(folder_path):
-        if file.endswith('.jpg'):
+        if file.endswith('.fits'):
             try:
                 timestamp_str = file.split('_')[2] + file.split('_')[3] + file.split('_')[4].split('.')[0]
                 timestamp = datetime.strptime(timestamp_str, '%Y%m%d%H%M%S%f')
@@ -20,6 +40,8 @@ def analyze_timestamps(folder_path):
     timestamps.sort()
     differences = [(timestamps[i+1] - timestamps[i]).total_seconds() for i in range(len(timestamps) - 1)]
     df = pd.DataFrame({'Timestamp': timestamps[:-1], 'Difference': differences})
+
+    score = calculate_score(differences)
 
     # Calculate mean and standard deviation
     mean_diff = df['Difference'].mean()
@@ -37,29 +59,62 @@ def analyze_timestamps(folder_path):
     # Calculate average excluding outliers
     average_difference = df[~df['Outlier']]['Difference'].mean()
 
+    # Calculate average fps
+    average_fps = 256 / average_difference
+
     # Plotting
     plt.figure(figsize=(12, 6))
 
-    # Scatter plot for differences
-    plt.scatter(df['Timestamp'], df['Difference'], label='Normal', c=df['Outlier'].map({True: 'red', False: 'gray'}), s=10, alpha=0.5)
+    # Separate scatter plots for normal points and outliers
+    normal_points = df[~df['Outlier']]
+    outlier_points = df[df['Outlier']]
+
+    plt.scatter(normal_points['Timestamp'], normal_points['Difference'], label='Normal', c='gray', s=10, alpha=0.5)
+    plt.scatter(outlier_points['Timestamp'], outlier_points['Difference'], label='Outliers', c='red', s=10, alpha=0.5)
 
     # Expected and Average lines
-    plt.axhline(y=5.12, color='green', linestyle='-', label='Expected Interval (5.12s)')
-    plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval ({average_difference:.4f}s)')
+    # plt.axhline(y=1/fps, color='green', linestyle='-', label='Expected Interval (5.12s)')
+    plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval ({average_difference:.4f}s), Average ({average_fps:.1f} fps)')
 
     # Find the minimum difference and round down to nearest 0.1
     min_difference = df['Difference'].min()
-    rounded_min_difference = np.floor(min_difference * 10) / 10
 
     # Find the maximum difference and round up to nearest 0.1
     max_difference = df['Difference'].max()
-    rounded_max_difference = np.ceil(max_difference * 10) / 10
 
     # Setting gridlines
-    # Horizontal grid every 0.1 seconds
-    y_ticks = np.arange(rounded_min_difference, rounded_max_difference + 0.1, 0.1)
+    # Determine grid interval dynamically
+    difference_range = df['Difference'].max() - df['Difference'].min()
+    raw_interval = difference_range / 11
+
+
+    # Round the interval up to the nearest 0.1, 1, or 10
+    if raw_interval < 0.1:
+        grid_interval = math.ceil(raw_interval * 10) / 10
+        grid_color = 'grey'
+        rounded_min_difference = np.floor(min_difference * 10) / 10
+        rounded_max_difference = np.ceil(max_difference * 10) / 10
+
+    elif raw_interval < 1:
+        grid_interval = math.ceil(raw_interval)
+        grid_color = '#FFBF00'  # Corrected color format
+        rounded_min_difference = np.floor(min_difference)
+        rounded_max_difference = np.ceil(max_difference)
+
+    else:
+        grid_interval = math.ceil(raw_interval / 10) * 10
+        grid_color = 'red'
+        rounded_min_difference = np.floor(min_difference / 10) * 10
+        rounded_max_difference = np.ceil(max_difference / 10) * 10
+
+    # Ensure grid_interval is not too small
+    minimum_allowed_interval = 0.1
+    grid_interval = max(grid_interval, minimum_allowed_interval)
+
+
+    y_ticks = np.arange(rounded_min_difference, rounded_max_difference + grid_interval, grid_interval)
     plt.yticks(y_ticks)
-    plt.grid(axis='y', linestyle='-', alpha=0.7)
+    plt.grid(axis='y', color=grid_color, linestyle='-', alpha=0.7)
 
     # Vertical grid every hour
     plt.gca().xaxis.set_major_locator(mdates.HourLocator())
@@ -69,15 +124,15 @@ def analyze_timestamps(folder_path):
     # Labeling
     plt.xlabel('Timestamp')
     plt.ylabel('Time Difference (seconds)')
-    plt.title('Time Differences Between Consecutive Video Frames')
+    plt.title(f'Frame Intervals {subdir_name} - Score: {score}')
     plt.legend()
 
     # Save the plot in the folder_path
-    plot_filename = os.path.join(folder_path, 'time_difference_plot.png')
+    plot_filename = os.path.join(folder_path, f'{subdir_name}_intervals_score_{score}.png')
     plt.savefig(plot_filename, format='png', dpi=300)
-    plt.show()
+    #plt.show()
 
-    return df
+    return score, plot_filename
 
 
 

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -42,14 +42,19 @@ def plotFFTimeIntervals(dir_path, fps=25.0, ff_block_size=256, ma_window_size=50
     subdir_name = os.path.basename(dir_path.rstrip('/\\'))
 
     # Find the FS*.tar.bz2 file in the specified directory
-    tar_file_path = None
-    for file in os.listdir(dir_path):
-        if file.endswith('.tar.bz2') and file.startswith('FS'):
-            tar_file_path = os.path.join(dir_path, file)
-            break
+    try:
+        tar_file_path = None
+        for file in os.listdir(dir_path):
+            if file.endswith('.tar.bz2') and file.startswith('FS'):
+                tar_file_path = os.path.join(dir_path, file)
+                break
 
-    if not tar_file_path:
-        print("Tar file not found.")
+        if not tar_file_path:
+            print("Tar file not found.")
+            return None, None, None
+
+    except FileNotFoundError:
+        print("Directory not found: {}".format(dir_path))
         return None, None, None
 
     timestamps = []
@@ -246,10 +251,6 @@ def plotFFTimeIntervals(dir_path, fps=25.0, ff_block_size=256, ma_window_size=50
     # Draw a horizontal line at 0
     ax_res.axhline(y=0, color='lime', linestyle='-', zorder=4)
 
-    # Plot +/- 1 frame lines
-    ax_res.axhline(y=-1/fps, color='lime', linestyle='--', zorder=4)
-    ax_res.axhline(y=1/fps, color='lime', linestyle='--', zorder=4)
-
     # Plot the median
     median_residual = median_interval - expected_interval
     ax_res.axhline(y=median_residual, color='green', linestyle='--', zorder=4)
@@ -265,7 +266,8 @@ def plotFFTimeIntervals(dir_path, fps=25.0, ff_block_size=256, ma_window_size=50
     plt.subplots_adjust(top=0.90, hspace=0.05)
 
     # Save the plot in the dir_path
-    plot_filename = os.path.join(dir_path, '{}_ff_intervals.png'.format(plot_title))
+    suffix = "_ff_intervals_flagged.png" if dropped_frame_rate > 0.1 else "_ff_intervals.png"
+    plot_filename = os.path.join(dir_path, '{}{}'.format(plot_title, suffix))
     plt.savefig(plot_filename, dpi=150)
     plt.close()
 

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -64,7 +64,9 @@ def analyze_timestamps(folder_path, fps=25):
     average_difference = df[~df['Outlier']]['Difference'].mean()
 
     # Calculate average fps
-    average_fps = 256 / average_difference
+    block_size = 256
+    average_fps = block_size / average_difference
+    expected_interval = block_size / fps
 
     # Plotting
     plt.figure(figsize=(12, 6))
@@ -77,7 +79,7 @@ def analyze_timestamps(folder_path, fps=25):
     plt.scatter(outlier_points['Timestamp'], outlier_points['Difference'], label='Outliers', c='red', s=10, alpha=0.5)
 
     # Expected and Average lines
-    plt.axhline(y=1/fps, color='green', linestyle='-', label='Expected Interval from .config fps')
+    plt.axhline(y=expected_interval, color='green', linestyle='-', label=f'Expected Interval from .config fpsv({(expected_interval:.4f}s)')
     plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval ({average_difference:.4f}s), Average ({average_fps:.1f} fps)')
 
     # Find the minimum difference and round down to nearest 0.1

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -79,7 +79,7 @@ def analyze_timestamps(folder_path, fps=25):
     plt.scatter(outlier_points['Timestamp'], outlier_points['Difference'], label='Outliers', c='red', s=10, alpha=0.5)
 
     # Expected and Average lines
-    plt.axhline(y=expected_interval, color='green', linestyle='-', label=f'Expected Interval from .config fpsv({(expected_interval:.4f}s)')
+    plt.axhline(y=expected_interval, color='green', linestyle='-', label=f'Expected Interval from .config fpsv({expected_interval:.4f}s)')
     plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval ({average_difference:.4f}s), Average ({average_fps:.1f} fps)')
 
     # Find the minimum difference and round down to nearest 0.1

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -111,8 +111,8 @@ def analyze_timestamps(folder_path, fps=25):
     plt.scatter(outlier_points['Timestamp'], outlier_points['Difference'], label='Outliers', c='red', s=10, alpha=0.5)
 
     # Expected and Average lines
-    plt.axhline(y=expected_interval, color='green', linestyle='-', label=f'Expected Interval from .config fps ({expected_interval:.4f}s)')
-    plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval ({average_difference:.4f}s), Average ({average_fps:.1f} fps)')
+    plt.axhline(y=expected_interval, color='green', linestyle='-',  label=f'Expected Interval ({expected_interval:.3f}s), ({fps:.1f} fps)')
+    plt.axhline(y=average_difference, color='blue', linestyle='--', label=f'Average Interval   ({average_difference:.3f}s), ({average_fps:.1f} fps)')
 
     # Find the minimum difference and round down to nearest 0.1
     min_difference = df['Difference'].min()

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -173,6 +173,14 @@ def analyze_timestamps(folder_path, fps=25):
     return score, plot_filename
 
 
+def process_directory(directory, fps):
+    # Process each .tar.bz2 file in the directory
+    for file in os.listdir(directory):
+        if file.endswith('.tar.bz2') and file.startswith('FS'):
+            tar_file_path = os.path.join(directory, file)
+            print(f"Processing {tar_file_path}")
+            analyze_timestamps(directory, fps)
+
 
 def main():
     if len(sys.argv) not in [2, 3]:
@@ -182,7 +190,8 @@ def main():
     folder_path = sys.argv[1]
     fps = int(sys.argv[2]) if len(sys.argv) == 3 else 25
 
-    analyze_timestamps(folder_path, fps)
+    for root, dirs, files in os.walk(folder_path):
+        process_directory(root, fps)
 
 if __name__ == "__main__":
     main()

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -56,8 +56,11 @@ def analyze_timestamps(folder_path, fps=25):
                         print(f"Skipping file with incorrect format: {member.name}")
 
     timestamps.sort()
-    differences = [(timestamps[i+1] - timestamps[i]).total_seconds() for i in range(len(timestamps) - 1)]
-    df = pd.DataFrame({'Timestamp': timestamps[:-1], 'Difference': differences})
+    # Calculate differences, starting from the second timestamp as the first is unreliable
+    differences = [(timestamps[i+1] - timestamps[i]).total_seconds() for i in range(1, len(timestamps) - 1)]
+    
+    # Create a DataFrame, starting from the second timestamp for the 'Timestamp' column
+    df = pd.DataFrame({'Timestamp': timestamps[1:-1], 'Difference': differences})
 
     if len(differences) > 10:
         score = calculate_score(differences)

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -42,7 +42,10 @@ def analyze_timestamps(folder_path, fps=25):
     differences = [(timestamps[i+1] - timestamps[i]).total_seconds() for i in range(len(timestamps) - 1)]
     df = pd.DataFrame({'Timestamp': timestamps[:-1], 'Difference': differences})
 
-    score = calculate_score(differences)
+    if len(differences) > 10:
+        score = calculate_score(differences)
+    else:
+        score = None
 
     # Calculate mean and standard deviation
     mean_diff = df['Difference'].mean()

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -1,4 +1,16 @@
-""" Plot the intervals between timestamps from FF file and scores the variability. """
+""" Plot the intervals between timestamps from FF file and scores the variability.
+Usage:
+  python -m Utils.PlotTimeIntervals "$input_path" "$fps"
+
+Arguments:
+  <folder_path>  The path to the folder containing the files to analyze.
+  [fps]          Frames per second. Optional argument. Default is 25.
+
+This script analyzes the timestamps in the files located in the specified folder.
+The optional fps argument allows specifying the frames per second for the analysis.
+If fps is not provided, the default value of 25 is used.
+
+ """
 import os
 import tarfile
 import pandas as pd
@@ -163,12 +175,14 @@ def analyze_timestamps(folder_path, fps=25):
 
 
 def main():
-    if len(sys.argv) != 2:
-        print("Usage: python script.py <folder_path>")
+    if len(sys.argv) not in [2, 3]:
+        print("Usage: python script.py <folder_path> [fps]")
         sys.exit(1)
 
     folder_path = sys.argv[1]
-    analyze_timestamps(folder_path)
+    fps = int(sys.argv[2]) if len(sys.argv) == 3 else 25
+
+    analyze_timestamps(folder_path, fps)
 
 if __name__ == "__main__":
     main()

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -71,7 +71,9 @@ def analyze_timestamps(dir_path, fps=25.0):
     min_interval = min(intervals) if intervals else None
     max_interval = max(intervals) if intervals else None
     #mean_interval = np.mean(intervals) if intervals else None
-    median_interval = np.median(intervals_np) if intervals_np.size > 0 else None
+    median_interval = np.median(intervals_np)
+    std_intervals_seconds = np.std(intervals_np)
+    std_intervals_frames = std_intervals_seconds * fps
     expected_interval = block_size / fps
 
     # Calculate average fps
@@ -140,7 +142,7 @@ def analyze_timestamps(dir_path, fps=25.0):
     # Plot Expected and Median lines
     plt.axhline(y=expected_interval, color='lime', linestyle='-', label='Expected ({:.3f}s), ({:.2f} fps)'.format(expected_interval, fps), zorder=4)
     # plt.axhline(y=mean_interval, color='blue', linestyle='--', label='Mean ({:.3f}s), ({:.2f} fps)'.format(mean_interval, average_fps), zorder=4)
-    plt.axhline(y=median_interval, color='green', linestyle='--', label='Median ({:.3f}s), ({:.2f} fps)'.format(median_interval, median_fps), zorder=4)
+    plt.axhline(y=median_interval, color='green', linestyle='--', label='Median ({:.3f} +/- {:.3f} s), ({:.2f} +/- {:.2f} fps)'.format(median_interval, std_intervals_seconds, median_fps, std_intervals_frames), zorder=4)
 
     # Determine grid interval dynamically
     difference_range = max_interval - min_interval

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -244,6 +244,10 @@ def plotFFTimeIntervals(dir_path, fps=25.0, ff_block_size=256, ma_window_size=50
     # Draw a horizontal line at 0
     ax_res.axhline(y=0, color='lime', linestyle='-', zorder=4)
 
+    # Plot +/- 1 frame lines
+    ax_res.axhline(y=-1/fps, color='lime', linestyle='--', zorder=4)
+    ax_res.axhline(y=1/fps, color='lime', linestyle='--', zorder=4)
+
     # Plot the median
     median_residual = median_interval - expected_interval
     ax_res.axhline(y=median_residual, color='green', linestyle='--', zorder=4)

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -2163,9 +2163,11 @@ class PlateTool(QtWidgets.QMainWindow):
         # Currently, any important variables should be initialized in the constructor (and cannot be classes
         # that inherit). Anything that can be generated for that information should be done in setupUI.
 
+        img_name = self.img_handle.name()
         to_remove = []
 
         dic = copy.copy(self.__dict__)
+        # print('input path', dic['input_path'])
         for k, v in dic.items():
 
             if (v.__class__.__bases__[0] is not object) and (not isinstance(v, bool)) and \
@@ -2177,6 +2179,9 @@ class PlateTool(QtWidgets.QMainWindow):
         for remove in to_remove:
             del dic[remove]
 
+        if os.path.isdir(self.input_path):
+            real_input_path = os.path.join(self.input_path, img_name)
+            dic['input_path'] = real_input_path
         savePickle(dic, self.dir_path, 'skyFitMR_latest.state')
         print("Saved state to file")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,3 @@ pyyaml; python_version>='3.6'
 tflite-runtime; python_version>='3.6' and python_version<'3.10'
 # workaround till tensorflow-lite supports python 3.10 on Debian/Ubuntu
 tflite-runtime @ https://github.com/hjonnala/snippets/raw/main/wheels/python3.10/tflite_runtime-2.5.0.post1-cp310-cp310-linux_x86_64.whl ; python_version=='3.10'
-pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pyyaml; python_version>='3.6'
 tflite-runtime; python_version>='3.6' and python_version<'3.10'
 # workaround till tensorflow-lite supports python 3.10 on Debian/Ubuntu
 tflite-runtime @ https://github.com/hjonnala/snippets/raw/main/wheels/python3.10/tflite_runtime-2.5.0.post1-cp310-cp310-linux_x86_64.whl ; python_version=='3.10'
+pandas


### PR DESCRIPTION
This PR introduces `PlotTimeIntervals.py`, a utility that generates a plot displaying the intervals between FF file timestamps. It also assigns a score ranging from 0 to 1000, with higher scores indicating less variability in the timestamps.

During reprocessing, this utility is invoked on the `night_dir`, logging a score and incorporating it into the plot's filename. If insufficient intervals are present to calculate a meaningful score, none is returned. The plot and score aim to function as diagnostic tools for identifying timestamping and dropped frame issues.

The utility uses Pandas to find outliers, and `pandas` has been added to requirements.txt. If this is a pain point, the utility can be redisigned without this feature.

The scoring is somewhat arbritary and designed to offer what feels like the right sensitivity.
What are your thoughts?

Edit: Denis, thank you for suggesting to use tar.bz2 - I've incorporated that suggestion.