### PR TITLE
small change to SkyFit2 to save the FF name in the state file.

### DIFF
--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -2162,9 +2162,11 @@ class PlateTool(QtWidgets.QMainWindow):
         # Currently, any important variables should be initialized in the constructor (and cannot be classes
         # that inherit). Anything that can be generated for that information should be done in setupUI.
 
+        img_name = self.img_handle.name()
         to_remove = []
 
         dic = copy.copy(self.__dict__)
+        # print('input path', dic['input_path'])
         for k, v in dic.items():
 
             if (v.__class__.__bases__[0] is not object) and (not isinstance(v, bool)) and \
@@ -2176,6 +2178,9 @@ class PlateTool(QtWidgets.QMainWindow):
         for remove in to_remove:
             del dic[remove]
 
+        if os.path.isdir(self.input_path):
+            real_input_path = os.path.join(self.input_path, img_name)
+            dic['input_path'] = real_input_path
         savePickle(dic, self.dir_path, 'skyFitMR_latest.state')
         print("Saved state to file")
 


### PR DESCRIPTION
I've amended skyfit2 to include the FF filename in the state file. 
Now, if you run SkyFit2 on a folder containing more than one FF file, you can either
a) use the folder as before, move between FF files and then work on the one you want to use; or
b) load the state file. In this case, the right FF file is automatically loaded for further analysis

I've done some testing with fireballs without any issues, but would appreciate further review / input.

Closes #262 