### PR TITLE
Update RMSInstaller.sh

### DIFF
--- a/Scripts/MultiCamLinux/RMSInstaller.sh
+++ b/Scripts/MultiCamLinux/RMSInstaller.sh
@@ -18,12 +18,12 @@ liblapack-dev at-spi2-core libopencv-dev libffi-dev libssl-dev socat ntp \
 libxml2-dev libxslt-dev imagemagick ffmpeg cmake unzip
 
 sudo pip3 install --upgrade pip
-sudo pip3 install virtualenv
+sudo apt install python3-virtualenv
 cd ~
 virtualenv vRMS
 source ~/vRMS/bin/activate
 pip install -U pip setuptools
-pip install numpy
+pip install numpy==1.23.5
 pip install Pillow
 pip install gitpython cython pyephem astropy 
 pip install scipy==1.8.1


### PR DESCRIPTION
Interim fix to stop propagation of numpy/imreg_dft errors in linux builds. This will streamlined when requirements.txt gets fixed to accommodate python 3.11 as installed on Debian-12 distros