### PR TITLE
Add meteor to end of bin video - fix for multi meteors on same fits file

### DIFF
--- a/Utils/FRbinViewer.py
+++ b/Utils/FRbinViewer.py
@@ -90,7 +90,7 @@ def view(dir_path, ff_path, fr_path, config, save_frames=False, extract_format=N
         else:
             background = ff_file.maxpixel
         if append_ff_to_video:
-            meteor_image = ff_file.maxpixel
+            meteor_image = np.copy(ff_file.maxpixel)
         timestampTitle = ""
         if add_timestamp:
             timestampTitle = getTimestampTitle(ff_path)

--- a/Utils/FRbinViewer.py
+++ b/Utils/FRbinViewer.py
@@ -333,16 +333,23 @@ def addShowerNameToImage(image, title):
 
 
 def getMeteorShowerTitle(video, frFile, ffPath, associations, fps):
+    title = "Meteor shower : Unknown"
+    # use time offset 100mls (~2 frames) in case if video capture started later or sopped earlier
+    mls = 100
+    # convert seconds to days
+    timeOffset = mls/1000/(24*60*60)
+    # get start and end time of video
     frFrameTimeStart, frFrameTimeEnd = getVideoStartAndEndTime(video, frFile, ffPath, fps)
+    # get all available meteors for current FF file
     fileName = os.path.basename(ffPath)
     meteorsForFile = [key for key in associations if key[0].startswith(fileName)]
-    title = "Meteor shower : Unknown"
+    # search first suitable by time range
     for meteor in meteorsForFile:
         frameTimes = associations[meteor][0].jd_array
         meteorTimeStart = frameTimes[0]
         meteorTimeEnd = frameTimes[-1]
-        # meteor time should be inside video time
-        if meteorTimeStart >= frFrameTimeStart and meteorTimeEnd <= frFrameTimeEnd:
+        # meteor time should be inside video time +- 100 mls for error
+        if meteorTimeStart >= frFrameTimeStart - timeOffset and meteorTimeEnd <= frFrameTimeEnd + timeOffset:
             shower = associations[meteor][1]
             if shower is not None:
                 title = "Meteor shower : [{:s}] - {:s}".format(shower.name, shower.name_full)


### PR DESCRIPTION
This is a fix for cases when we have several tracked meteors on on same fits file and identification was wrong as it took first meteor from list

Implemented solution:
Usage of meteor start and end time to compare with start and time of bin video (calculated by frame number)
If meteor time range inside video time range - this is the best candidate.

Also during testing found that video could start with small lag (1 or 2 frames later) .
To fix it was introduced time offset for 100mls before and after video start (if fps is 25 then 1 frame ~40mls )
It fixed issue on my test suite.

What was not tested:
As  I can see bin file could be multi lines and I don't have such example and don't know when such file could be created, also exists option '--split' which also could affect calculation.

This solution will not work for simultaneous two or more meteors at same time but I think it is very rare case and need identification meteor by coordinates on video (very complex for me).