### PR TITLE
Update GenerateMP4s.py

### DIFF
--- a/Utils/GenerateMP4s.py
+++ b/Utils/GenerateMP4s.py
@@ -240,4 +240,4 @@ if __name__ == "__main__":
         if len(ftps) == 0:
             print('no usable ftpdetect file present')
         else:
-            generateMP4s(dir_path, ftps[0], shower_code=cml_args.shower, min_mag=cml_args.minmag, config=config)
+            generateMP4s(dir_path, os.path.basename(ftps[0]), shower_code=cml_args.shower, min_mag=cml_args.minmag, config=config)


### PR DESCRIPTION
Patch to pass bare filename of FTPdetectinfo file to GenerateMP4s, to keep consistency with previous behaviour and avoid a crash if dir_path is relative.  If dir_path is a relative path, it gets prepended to the ftpfile_name in loadFTPdetectinfo(), and so if the latter already contains a path, then the path is prepended twice!