### PR TITLE
Update opencv4_install.sh

### DIFF
--- a/opencv4_install.sh
+++ b/opencv4_install.sh
@@ -7,7 +7,7 @@ fi
 
 # Configuration
 HOME_DIR=$HOME
-OPEN_VERSION=4.9.0
+OPENCV_VERSION=4.9.0
 
 PYTHON_EXECUTABLE=$(which python3)
 PYTHON_VERSION=$($PYTHON_EXECUTABLE -c 'import platform; print(platform.python_version())')

--- a/opencv4_install.sh
+++ b/opencv4_install.sh
@@ -1,20 +1,23 @@
 #!/bin/sh
+# The script takes the path to the virtual environment directory as the argument
 if [ "$#" -ne 1 ] || ! [ -d "$1" ]; then
   echo "Usage: $0 VIRTUALENV_PATH" >&2
   exit 1
 fi
 
-# The script takes the path to the virtual environment directory as the argument
-
 # Configuration
 HOME_DIR=$HOME
-VERSION=4.1.2
+OPEN_VERSION=4.9.0
+
+PYTHON_EXECUTABLE=$(which python3)
+PYTHON_VERSION=$($PYTHON_EXECUTABLE -c 'import platform; print(platform.python_version())')
+PYTHON_INCLUDE_DIR=$(python3 -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())")
 
 # Installation
 sudo apt-get update
 sudo apt-get upgrade -y
 sudo apt-get install -y build-essential cmake pkg-config
-sudo apt-get install -y libjpeg-dev libtiff5-dev libjasper-dev libpng12-dev
+sudo apt-get install -y libjpeg-dev libtiff5-dev libpng-dev
 sudo apt-get install -y libavcodec-dev libavformat-dev libswscale-dev libv4l-dev
 sudo apt-get install -y libxvidcore-dev libx264-dev
 sudo apt-get install -y gstreamer1.0-tools
@@ -23,24 +26,23 @@ sudo apt-get install -y libgtk-3-dev
 sudo apt-get install -y libatlas-base-dev gfortran
 
 cd ${HOME_DIR}
-wget -O opencv.zip https://github.com/Itseez/opencv/archive/${VERSION}.zip
+wget -O opencv.zip https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip
 unzip -o opencv.zip
-wget -O opencv_contrib.zip https://github.com/Itseez/opencv_contrib/archive/${VERSION}.zip
+wget -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip
 unzip -o opencv_contrib.zip
 
-cd ${HOME_DIR}/opencv-${VERSION}/
+cd ${HOME_DIR}/opencv-${OPENCV_VERSION}/
 mkdir build
 cd build
 cmake -D CMAKE_BUILD_TYPE=DEBUG \
     -D CMAKE_INSTALL_PREFIX=${1} \
     -D INSTALL_C_EXAMPLES=OFF \
-    -D OPENCV_EXTRA_MODULES_PATH=${HOME_DIR}/opencv_contrib-${VERSION}/modules \
-    -D PYTHON_DEFAULT_EXECUTABLE=$HOME_DIR/vRMS/bin/python3.7 \
-    -D PYTHON_INCLUDE_DIR=/usr/include/python3.7 \
+    -D OPENCV_EXTRA_MODULES_PATH=${HOME_DIR}/opencv_contrib-${OPENCV_VERSION}/modules \
+    -D PYTHON_DEFAULT_EXECUTABLE=${PYTHON_EXECUTABLE} \
+    -D PYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} \
     -D WITH_opencv_python3=ON \
     -D HAVE_opencv_python2=OFF \
     -D ENABLE_NEON=ON \
-    -D ENABLE_VFPV3=ON \
     -D WITH_OPENMP=ON \
     -D BUILD_TIFF=ON \
     -D WITH_TBB=ON \
@@ -66,4 +68,4 @@ sudo make install
 sudo ldconfig
 
 cd ${HOME_DIR}
-rm -rf opencv-${VERSION} opencv_contrib-${VERSION} opencv.zip opencv_contrib.zip
+rm -rf opencv-${OPENCV_VERSION} opencv_contrib-${OPENCV_VERSION} opencv.zip opencv_contrib.zip


### PR DESCRIPTION
Updates to latest opencv version tested on -
RPi Buster + Bookworm RPi4 +5,
X86_64 Debian-12, Ubuntu 20.04-LTS, 22.04-LTS

Note: Only supports 64-bit platforms - VFPV3 is only 32-bit.
For Linux builds I'll script around disabling NEON on non-ARM platforms.

All above also tested for support of Luc Busquin's enhanced timestamping fork.