### PR TITLE
Add support for microseconds in FS filenames and FF headers

### DIFF
--- a/RMS/Compression.py
+++ b/RMS/Compression.py
@@ -106,7 +106,7 @@ class Compressor(multiprocessing.Process):
 
 
     def saveFF(self, arr, startTime, N):
-        """ Write metadata and data array to FF file.
+        """ Write metadata and data array to FF file and return filenames for FF and FS files
         
         Arguments:
             arr: [3D ndarray] 3D numpy array in format: (N, y, x) where N is [0, 4)
@@ -117,7 +117,7 @@ class Compressor(multiprocessing.Process):
         # Generate the name for the file
         date_string = time.strftime("%Y%m%d_%H%M%S", time.gmtime(startTime))
 
-        # Calculate miliseconds
+        # Calculate microseconds and milliseconds
         micros = int((startTime - floor(startTime))*1000000)
         millis = int((startTime - floor(startTime))*1000)
         
@@ -137,6 +137,7 @@ class Compressor(multiprocessing.Process):
         ff.first = N + 256
         ff.camno = self.config.stationID
         ff.fps = self.config.fps
+        ff.starttime = date_string + "_" + str(micros).zfill(6)
         
         # Write the FF file
         FFfile.write(ff, self.data_dir, filename_millis, fmt=self.config.ff_format)
@@ -312,7 +313,7 @@ class Compressor(multiprocessing.Process):
                 self.saveLiveJPG(compressed, startTime)
 
 
-            # Save the extracted intensitites per every field
+            # Save the extracted intensities per every field
             FieldIntensities.saveFieldIntensitiesBin(field_intensities, self.data_dir, filename_micros)
 
             # Run the extractor

--- a/RMS/Formats/FFfile.py
+++ b/RMS/Formats/FFfile.py
@@ -228,18 +228,19 @@ def selectFFFrames(img_input, ff, frame_min, frame_max):
 
 
 def filenameToDatetime(file_name):
-    """ Converts FF bin file name to a datetime object.
+    """ Converts FS and FF bin file name to a datetime object.
 
     Arguments:
-        file_name: [str] Name of a FF file.
+        file_name: [str] Name of a FF or FS file.
 
     Return:
-        [datetime object] Date and time of the first frame in the FF file.
+        [datetime object] Date and time of the first frame in the FS or FF file.
 
     """
 
     # e.g.  FF499_20170626_020520_353_0005120.bin
     # or FF_CA0001_20170626_020520_353_0005120.fits
+    # or FS_US9999_20240318_011731_867370_1054720_fieldsum.bin
 
     file_name = file_name.split('_')
 
@@ -258,10 +259,15 @@ def filenameToDatetime(file_name):
     minute = int(time[2:4])
     seconds = int(time[4:6])
 
-    ms = int(file_name[i + 3])
+    # Determine if the time fraction is in milliseconds or microseconds
+    time_fraction_str = file_name[i + 3]
+    if len(time_fraction_str) == 3:  # Milliseconds, need to convert to microseconds
+        microseconds = int(time_fraction_str) * 1000
+    else:  # Assuming microseconds directly
+        microseconds = int(time_fraction_str)
 
 
-    return datetime.datetime(year, month, day, hour, minute, seconds, ms*1000)
+    return datetime.datetime(year, month, day, hour, minute, seconds, microseconds)
 
 
 


### PR DESCRIPTION
This PR is related to PR #257. Because PR #257 improves frame timestamping and makes microseconds significant, this PR preserves the microseconds information instead of rounding to milliseconds. Due to compatibility concerns with downstream processes, the FF filename structure remains unchanged, still displaying only milliseconds. To retain microseconds, a new **EXPSTART** header field is added to store the datetime string with microseconds:
```
SIMPLE  =                    T / conforms to FITS standard                      
BITPIX  =                    8 / array data type                                
NAXIS   =                    0 / number of array dimensions                     
EXTEND  =                    T                                                  
NROWS   =                 1080                                                  
NCOLS   =                 1920                                                  
NBITS   =                    8                                                  
NFRAMES =                  256                                                  
FIRST   =               704768                                                  
CAMNO   = 'US9999  '                                                            
FPS     =            24.981216                                                  
EXPSTART= '20240319_095911_310820'                                             
END                                                                             
```

FS files cannot store microseconds in their header. However, since there doesn't seem to be compatibility issues downstream, microseconds are included in the filename:
`FS_US9999_20240318_011711_371924_1054208_fieldsum.bin`