### PR TITLE
Fix v4l2 support in ShowLiveStream

### DIFF
--- a/Utils/ShowLiveStream.py
+++ b/Utils/ShowLiveStream.py
@@ -12,7 +12,7 @@ from RMS.Routines.Image import applyBrightnessAndContrast
 
 def get_device(config):
     """ Get the video device """
-    if config.force_v4l2:
+    if config.media_backend == 'v4l2':
         vcap = cv2.VideoCapture(config.deviceID, cv2.CAP_V4L2)
         vcap.set(cv2.CAP_PROP_CONVERT_RGB, 0)
     else:


### PR DESCRIPTION
This PR incorporates media_backend config setting support for v4l2. ShowLiveStream will continue to use OpenCV, even if media_backend is set to gst, for the sake of simplicity.