### PR TITLE
Ensure all shared buffers are properly freed

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -17,6 +17,8 @@
 from __future__ import print_function, division, absolute_import
 
 import os
+import sys
+import traceback
 # Set GStreamer debug level. Use '2' for warnings in production environments.
 os.environ['GST_DEBUG'] = '3'
 
@@ -132,6 +134,15 @@ class BufferedCapture(Process):
         if self.is_alive():
             log.info('Terminating capture...')
             self.terminate()
+        
+        # Free shared memory after the compressor is done
+        try:
+            log.debug('Freeing frame buffers in BufferedCapture...')
+            del self.array1
+            del self.array2
+        except Exception as e:
+            log.debug('Freeing frame buffers failed with error:' + repr(e))
+            log.debug(repr(traceback.format_exception(*sys.exc_info())))
 
         return self.dropped_frames.value
 

--- a/RMS/Compression.py
+++ b/RMS/Compression.py
@@ -16,6 +16,8 @@
 
 
 import os
+import sys
+import traceback
 import time
 import logging
 import multiprocessing
@@ -197,11 +199,19 @@ class Compressor(multiprocessing.Process):
                 log.debug('Waited more than 60 seconds for compression to end, killing it...')
                 break
 
-
         log.debug('Compression joined!')
 
         self.terminate()
         self.join()
+
+        # Free shared memory after the compressor is done
+        try:
+            log.debug('Freeing frame buffers in Compressor...')
+            del self.array1
+            del self.array2
+        except Exception as e:
+            log.debug('Freeing frame buffers failed with error:' + repr(e))
+            log.debug(repr(traceback.format_exception(*sys.exc_info())))
 
         # Return the detector and live viewer objects because they were updated in this namespace
         return self.detector

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -400,7 +400,7 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
 
     # Free shared memory after the compressor is done
     try:
-        log.debug('Freeing frame buffers...')
+        log.debug('Freeing frame buffers in StartCapture...')
         del sharedArrayBase
         del sharedArray
         del sharedArrayBase2


### PR DESCRIPTION
In a multicam setup, a ‘Bus Error (Core Dumped)’ can occur during the reinitialization of frame buffers in subsequent nightly runs. This issue arises because the frame buffers, which are utilized by `StartCapture`, `Compressor`, and `BufferedCapture`, are only being freed in `StartCapture` upon exit. This PR addresses the problem by ensuring that the frame buffers are properly freed in all three classes upon their respective exits.