### PR TITLE
Only add trailing slash to URL ending with '.sdp'

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -445,8 +445,8 @@ class BufferedCapture(Process):
 
             rtsp_url = match.group(0)
 
-            # Add '/' if it's missing
-            if not rtsp_url.endswith('/'):
+            # Add '/' if it's missing from '.sdp' URL
+            if rtsp_url.endswith('.sdp'):
                 rtsp_url += '/'
 
             return rtsp_url


### PR DESCRIPTION
This PR addresses issue #299 by only adding a trailing slash to URLs ending with '.sdp' instead of always adding a trailing slash if one is missing.