### PR TITLE
Prevent getDirectoryList from returning files

### DIFF
--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -1473,10 +1473,10 @@ class EventMonitor(multiprocessing.Process):
         if os.path.exists(os.path.join(os.path.expanduser(self.config.data_dir), self.config.captured_dir)):
             for night_directory in os.listdir(
                     os.path.join(os.path.expanduser(self.config.data_dir), self.config.captured_dir)):
-                #Skip over any directory which does not start with the stationID and warn
+                # Skip over any directory which does not start with the stationID and warn
                 if night_directory[0:len(self.config.stationID)] != self.config.stationID:
                     continue
-                #Do not add any files, only add directories
+                # Do not add any files, only add directories
                 if not os.path.isdir(os.path.join(os.path.expanduser(self.config.data_dir), self.config.captured_dir,night_directory)):
                     print("Skipping {}".format(night_directory))
                     continue
@@ -2123,7 +2123,7 @@ class EventMonitor(multiprocessing.Process):
         # Delay to allow capture to check existing folders - keep the logs tidy
 
 
-        #time.sleep(60)
+        time.sleep(60)
         last_check_start_time = datetime.datetime.utcnow()
         while not self.exit.is_set():
             check_start_time = datetime.datetime.utcnow()

--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -1478,7 +1478,6 @@ class EventMonitor(multiprocessing.Process):
                     continue
                 # Do not add any files, only add directories
                 if not os.path.isdir(os.path.join(os.path.expanduser(self.config.data_dir), self.config.captured_dir,night_directory)):
-                    log.warning("Skipping {:s} - there should not be files in {:s}".format(night_directory,self.config.captured_dir))
                     continue
                 directory_POSIX_time = convertGMNTimeToPOSIX(night_directory[7:22])
                 # if the POSIX time representation is before the event, and within 16 hours add to the list of directories

--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -1476,8 +1476,12 @@ class EventMonitor(multiprocessing.Process):
                 #Skip over any directory which does not start with the stationID and warn
                 if night_directory[0:len(self.config.stationID)] != self.config.stationID:
                     continue
+                #Do not add any files, only add directories
+                if not os.path.isdir(os.path.join(os.path.expanduser(self.config.data_dir), self.config.captured_dir,night_directory)):
+                    print("Skipping {}".format(night_directory))
+                    continue
                 directory_POSIX_time = convertGMNTimeToPOSIX(night_directory[7:22])
-
+                print("Adding {}".format(night_directory))
                 # if the POSIX time representation is before the event, and within 16 hours add to the list of directories
                 # most unlikely that a single event could be split across two directories, unless there was large time uncertainty
                 if directory_POSIX_time < event_time and (event_time - directory_POSIX_time).total_seconds() < 16 * 3600:
@@ -2119,7 +2123,7 @@ class EventMonitor(multiprocessing.Process):
         # Delay to allow capture to check existing folders - keep the logs tidy
 
 
-        time.sleep(60)
+        #time.sleep(60)
         last_check_start_time = datetime.datetime.utcnow()
         while not self.exit.is_set():
             check_start_time = datetime.datetime.utcnow()

--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -1478,10 +1478,9 @@ class EventMonitor(multiprocessing.Process):
                     continue
                 # Do not add any files, only add directories
                 if not os.path.isdir(os.path.join(os.path.expanduser(self.config.data_dir), self.config.captured_dir,night_directory)):
-                    print("Skipping {}".format(night_directory))
+                    log.warning("Skipping {:s} - there should not be files in {:s}".format(night_directory,self.config.captured_dir))
                     continue
                 directory_POSIX_time = convertGMNTimeToPOSIX(night_directory[7:22])
-                print("Adding {}".format(night_directory))
                 # if the POSIX time representation is before the event, and within 16 hours add to the list of directories
                 # most unlikely that a single event could be split across two directories, unless there was large time uncertainty
                 if directory_POSIX_time < event_time and (event_time - directory_POSIX_time).total_seconds() < 16 * 3600:


### PR DESCRIPTION
When CapturedFiles directory contains files, which are named in a similar way to an observation directory, and an event is created which references a time which matches the naming of the files, files get returned from getDirectoryList, rather than just directories, as described in issue #304  

This pull request removes any files, so that only directories are returned. 