### PR TITLE
Change GStreamer Pipeline to UDP Protocol

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -541,7 +541,7 @@ class BufferedCapture(Process):
 
         # Define the source up to the point where we want to branch off
         source_to_tee = (
-            "rtspsrc buffer-mode=1 protocols=tcp tcp-timeout=5000000 retry=5 "
+            "rtspsrc buffer-mode=1 protocols=udp retry=5 "
             "location=\"{}\" ! "
             "rtph264depay ! tee name=t"
             ).format(device_url)


### PR DESCRIPTION
Recently, a station was having an issue whereby the RTSP server (the IP camera) was terminating the RTSP stream at regular intervals. It was solved by switching protocol from TCP to UDP.

TCP is connection-oriented, maintaining a continuous connection that requires acknowledgment for data transmission. UDP is connectionless, simply sending packets without establishing or maintaining a connection. If there are intermittent network issues or brief interruptions, TCP might interpret these as a broken connection and terminate the stream. UDP, being connectionless, would simply continue sending packets without caring about the connection state.

If network congestion occurs, TCP might reduce its transmission rate significantly or pause transmission, potentially leading to timeouts and stream termination. UDP would continue to send at a constant rate, which might result in some packet loss but would maintain the stream.

TCP retransmits lost packets to ensure reliable delivery. UDP does not retransmit lost packets. In poor network conditions, TCP might spend time retransmitting lost packets, potentially leading to buffer overflows or timeouts on the server side, causing it to terminate the stream. UDP would simply continue sending new packets, maintaining the flow of the stream even if some packets are lost.

In TCP, if a packet is lost, subsequent packets must wait for the lost packet to be retransmitted before they can be delivered to the application. UDP does not have this issue. This could cause significant delays in TCP transmission during packet loss, potentially leading to timeouts or the server interpreting the delay as a dead connection.

So UDP might lead to more reliable stream and more consistent timestamping at the expense of getting corrupted frames.

It would be nice if this PR could be tested on the most troublesome stations to see if it helps. 

My understanding is that cv2 defaults to TCP... so it might even improve connection reliability of gst over cv2.

Also, UDP would be a must for stations running multiple clients on one server (multiple machines streaming from one camera)

One minor issue when running UDP is that GStreamer might issue a warning message about memory size:
```
warning: Could not create a buffer of requested 524288 bytes (Operation not permitted). Need net.admin privilege?
0:00:00.107728875 32187     0x24a0d6a0 WARN                  udpsrc gstudpsrc.c:1647:gst_udpsrc_open:<udpsrc0> have udp buffer of 212992 bytes while 524288 were requested
```
The stream will proceed fine despite the warning, but increasing the system’s maximum UDP buffer size by modifying the /etc/sysctl.conf file solves the issue. Adding the following lines to /etc/sysctl.conf :
```
net.core.rmem_max=524288
net.core.wmem_max=524288
```

After making these changes, apply them by running:
```
sudo sysctl -p
```