### PR TITLE
Fix Rolling Shutter Correction sometimes using image width instead of…

### DIFF
--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -5575,7 +5575,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 img_h = self.config.height
 
             else:
-                img_h = self.img.data.shape[0]
+                img_h = self.img.data.shape[1]
 
             # Compute the corrected frame time
             frame_no = RollingShutterCorrection.correctRollingShutterTemporal(frame, pick['y_centroid'], img_h)


### PR DESCRIPTION
Thank you Jamie Shepherd for noticing this bug. Jamie noticed that if RMS is in auto-detect mode, then the correct divisor of 720 is applied, as it is fetched from the .config file as self.config.height. In manual use of SkyFit2, it fetches up the width of  1280 instead the height of 720.

There might be a similar inversion in FFTalign line 45:
```
def addPoint(img, xc, yc, radius):
    """ Add a point to the image. """

    img_w = img.shape[1]
    img_h = img.shape[0]
```
Shouldn't the 1 and 0 be swapped?