### PR TITLE
Add GStreamer Pipeline TCP or UDP Protocol Config Switch

### DIFF
--- a/.config
+++ b/.config
@@ -52,6 +52,10 @@ reboot_lock_file: .reboot_lock
 
 device: rtsp://192.168.42.10:554/user=admin&password=&channel=1&stream=0.sdp ; device id
 
+; Transport Layer Protocol: 'tcp' or 'udp'. Defaults to tcp. UDP typically
+; provides more stable connectivity.
+protocol: tcp
+
 ; Media Backend: options are gst, cv2, or v4l2.
 ;
 ; The preferred option is 'gst', which corresponds to GStreamer Standalone. This method bypass OpenCV,

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -391,13 +391,19 @@ class BufferedCapture(Process):
 
             # GStreamer
             if GST_IMPORTED and (self.config.media_backend == 'gst') and (not self.media_backend_override):
+
+                # Pull a sample from the appsink
                 sample = self.device.emit("pull-sample")
                 if not sample:
                     log.info("GStreamer pipeline did not emit a sample.")
-
                     return False, None, None
 
+                # Try to get the buffer from the sample
                 buffer = sample.get_buffer()
+                if not buffer:
+                    log.error("Failed to get buffer from sample.")
+                    return False, None, None
+
                 gst_timestamp_ns = buffer.pts  # GStreamer timestamp in nanoseconds
 
                 # Sanity check for pts value
@@ -419,13 +425,13 @@ class BufferedCapture(Process):
                 timestamp = self.start_timestamp + (smoothed_pts/1e9)
 
                 buffer.unmap(map_info)
-        
+
             # OpenCV
             else:
                 ret, frame = self.device.read()
                 if ret:
                     timestamp = time.time()
-                
+
         return ret, frame, timestamp
 
 
@@ -445,8 +451,8 @@ class BufferedCapture(Process):
 
             rtsp_url = match.group(0)
 
-            # Add '/' if it's missing
-            if not rtsp_url.endswith('/'):
+            # Add '/' if it's missing from '.sdp' URL
+            if rtsp_url.endswith('.sdp'):
                 rtsp_url += '/'
 
             return rtsp_url
@@ -481,7 +487,7 @@ class BufferedCapture(Process):
         return gray_frame
 
 
-    def createGstreamDevice(self, video_format):
+    def createGstreamDevice(self, video_format, max_retries=5, retry_interval=1):
         """
         Creates a GStreamer pipeline for capturing video from an RTSP source and 
         initializes playback with specific configurations.
@@ -491,6 +497,9 @@ class BufferedCapture(Process):
         Arguments:
             video_format: [str] The desired video format for the conversion, 
                 e.g., 'BGR', 'GRAY8', etc.
+            max_retries: [int] The maximum number of retry attempts
+            retry_interval: [float] The number of seconds to wait between retries
+
 
         Returns:
             Gst.Element: The appsink element of the created GStreamer pipeline, 
@@ -512,24 +521,53 @@ class BufferedCapture(Process):
 
         pipeline_str = ("{} ! queue leaky=downstream max-size-buffers=100 max-size-bytes=0 max-size-time=0 ! "
                         "{} ! queue max-size-buffers=100 max-size-bytes=0 max-size-time=0 ! "
-                        "appsink max-buffers=100 drop=true sync=0 name=appsink").format(device_str, conversion)
+                        "appsink max-buffers=100 drop=true sync=0 name=appsink"
+                        ).format(device_str, conversion)
 
         log.debug("GStreamer pipeline string: {}".format(pipeline_str))
 
-        self.pipeline = Gst.parse_launch(pipeline_str)
+        # Set the pipeline to PLAYING state with retries
+        for attempt in range(max_retries):
+            
+            # Parse and create the pipeline
+            self.pipeline = Gst.parse_launch(pipeline_str)
 
-        self.pipeline.set_state(Gst.State.PLAYING)
+            # Set the pipeline to PLAYING state
+            self.pipeline.set_state(Gst.State.PLAYING)
 
+            # Capture time
+            start_time = time.time()
 
-        # Calculate camera latency from config parameters
-        total_latency = self.config.camera_buffer/self.config.fps + self.config.camera_latency
+            # Wait for the state change to complete
+            state_change_return, current_state, pending_state = self.pipeline.get_state(Gst.CLOCK_TIME_NONE)
 
-        self.start_timestamp = time.time() - total_latency
- 
-        start_time_str = datetime.datetime.fromtimestamp(self.start_timestamp).strftime('%Y-%m-%d %H:%M:%S.%f')
-        log.info("Start time is {}".format(start_time_str))
+            # Check if the state change was successful
+            if state_change_return != Gst.StateChangeReturn.FAILURE and current_state == Gst.State.PLAYING:
+                log.info("Pipeline is in PLAYING state.")
 
-        return self.pipeline.get_by_name("appsink")
+                # Calculate camera latency from config parameters
+                total_latency = self.config.camera_buffer/self.config.fps + self.config.camera_latency
+
+                # Calculate stream start time
+                self.start_timestamp = start_time - total_latency
+
+                # Log start time
+                start_time_str = (datetime.datetime.fromtimestamp(self.start_timestamp)
+                                  .strftime('%Y-%m-%d %H:%M:%S.%f'))
+
+                log.info("Start time is {}".format(start_time_str))
+
+                return self.pipeline.get_by_name("appsink")
+
+            # Log the failure and retry if attempts are left
+            log.error("Attempt {}: Pipeline did not transition to PLAYING state, current state is {}. \
+                      Retrying in {} seconds."
+                      .format(attempt + 1, current_state, retry_interval))
+
+            time.sleep(retry_interval)
+
+        log.error("Failed to set pipeline to PLAYING state after {} attempts.".format(max_retries))
+        return False
 
 
     def initVideoDevice(self):
@@ -562,7 +600,7 @@ class BufferedCapture(Process):
                 if ip:
                     ip = ip[0]
 
-                    # Try pinging 5 times
+                    # Try pinging 500 times
                     ping_success = False
 
                     for i in range(500):
@@ -571,7 +609,10 @@ class BufferedCapture(Process):
                         ping_success = ping(ip)
 
                         if ping_success:
-                            log.info("Camera IP ping successful!")
+                            log.info("Camera IP ping successful! Waiting  10 seconds. ")
+
+                            # Wait for camera to finish booting up
+                            time.sleep(10)
                             break
 
                         time.sleep(5)
@@ -617,7 +658,7 @@ class BufferedCapture(Process):
                     Gst.init(None)
 
                     # Create and start a GStreamer pipeline
-                    self.device = self.createGstreamDevice('BGR')
+                    self.device = self.createGstreamDevice('BGR', max_retries=5, retry_interval=1)
                     self.pts_buffer = []  # Reset pts buffer
 
                     # Attempt to get a sample and determine the frame shape

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -498,19 +498,22 @@ class BufferedCapture(Process):
         """
 
         device_url = self.extractRtspUrl(self.config.deviceID)
-        # device_str = ("rtspsrc  buffer-mode=1 latency=1000 default-rtsp-version=17 protocols=tcp tcp-timeout=5000000 retry=5 "
-        #               "location=\"{}\" ! rtpjitterbuffer latency=1000 mode=1 ! "
-        #               "rtph264depay ! h264parse ! avdec_h264").format(device_url)
 
-        device_str = ("rtspsrc  buffer-mode=1 protocols=tcp tcp-timeout=5000000 retry=5 "
-                      "location=\"{}\" ! "
-                      "rtph264depay ! h264parse ! avdec_h264").format(device_url)
+        if self.config.protocol == 'udp':
+            rtspsrc_params = ("rtspsrc buffer-mode=1 protocols=udp retry=5")
+
+        else:  # Default to TCP
+            rtspsrc_params = ("rtspsrc buffer-mode=1 protocols=tcp tcp-timeout=5000000 retry=5")
+
+        device_str = ("{} location=\"{}\" ! rtph264depay ! h264parse ! avdec_h264"
+                      ).format(rtspsrc_params, device_url)
 
         conversion = "videoconvert ! video/x-raw,format={}".format(video_format)
+
         pipeline_str = ("{} ! queue leaky=downstream max-size-buffers=100 max-size-bytes=0 max-size-time=0 ! "
                         "{} ! queue max-size-buffers=100 max-size-bytes=0 max-size-time=0 ! "
-                        "appsink max-buffers=100 drop=true sync=0 name=appsink").format(device_str, conversion)
-
+                        "appsink max-buffers=100 drop=true sync=0 name=appsink"
+                        ).format(device_str, conversion)
 
         log.debug("GStreamer pipeline string: {}".format(pipeline_str))
         

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -516,7 +516,7 @@ class BufferedCapture(Process):
                         ).format(device_str, conversion)
 
         log.debug("GStreamer pipeline string: {}".format(pipeline_str))
-        
+
         self.pipeline = Gst.parse_launch(pipeline_str)
 
         self.pipeline.set_state(Gst.State.PLAYING)

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -512,8 +512,7 @@ class BufferedCapture(Process):
 
         pipeline_str = ("{} ! queue leaky=downstream max-size-buffers=100 max-size-bytes=0 max-size-time=0 ! "
                         "{} ! queue max-size-buffers=100 max-size-bytes=0 max-size-time=0 ! "
-                        "appsink max-buffers=100 drop=true sync=0 name=appsink"
-                        ).format(device_str, conversion)
+                        "appsink max-buffers=100 drop=true sync=0 name=appsink").format(device_str, conversion)
 
         log.debug("GStreamer pipeline string: {}".format(pipeline_str))
 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -260,6 +260,9 @@ class Config:
         ##### Capture
         self.deviceID = 0
 
+        # Transport Layer Protocol: tcp or udp
+        self.protocol = "tcp"
+
         # Media backend to use for capture. Options are gst, cv2, or v4l2
         self.media_backend = "gst"
         self.uyvy_pixelformat = False
@@ -930,6 +933,9 @@ def parseCapture(config, parser):
 
         # If it fails, it's probably a RTSP stream
         pass
+
+    if parser.has_option(section, "protocol"):
+        config.protocol = parser.get(section, "protocol")
 
     if parser.has_option(section, "media_backend"):
         config.media_backend = parser.get(section, "media_backend")


### PR DESCRIPTION
I made the PR relative to Master and added a new config parameter `protocol`. The default is tcp. Setting `protocol: udp` in `.config` switches the GStreamer pipeline to UDP.

UDP should provide more reliable connections, especially on Multicam Linux machines.

One minor issue when running UDP is that GStreamer might issue a warning message about memory size:
```
warning: Could not create a buffer of requested 524288 bytes (Operation not permitted). Need net.admin privilege?
0:00:00.107728875 32187     0x24a0d6a0 WARN                  udpsrc gstudpsrc.c:1647:gst_udpsrc_open:<udpsrc0> have udp buffer of 212992 bytes while 524288 were requested
```

The stream will proceed fine despite the warning, but increasing the system’s maximum UDP buffer size by modifying the `/etc/sysctl.conf` file solves the issue. Adding the following lines to `/etc/sysctl.conf `:
```
net.core.rmem_max=524288
net.core.wmem_max=524288
```
After making these changes, apply them by running:
```
sudo sysctl -p
```