### PR TITLE
Add configurable Transport Protocol: UDP or TCP

### DIFF
--- a/.config
+++ b/.config
@@ -64,6 +64,10 @@ reboot_lock_file: .reboot_lock
 
 device: rtsp://192.168.42.10:554/user=admin&password=&channel=1&stream=0.sdp ; device id
 
+; Transport Layer Protocol: 'tcp' or 'udp'. Defaults to tcp. UDP typically
+; provides more stable connectivity, but TCP has a longer track record.
+protocol: tcp
+
 ; Media Backend: options are gst, cv2, or v4l2.
 ;
 ; The preferred option is 'gst', which corresponds to GStreamer Standalone. This method bypass OpenCV,

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -568,7 +568,7 @@ class BufferedCapture(Process):
             video_location = os.path.join(video_file_dir, "video_%05d.mkv")
             storage_branch = (
                 "t. ! queue ! h264parse ! "
-                "splitmuxsink location={:s} max-size-time={:s} muxer-factory=matroskamux"
+                "splitmuxsink location={:s} max-size-time={:d} muxer-factory=matroskamux"
                 ).format(video_location, int(segment_duration_sec*1e9))
 
         # Otherwise, skip saving the raw stream to disk
@@ -614,13 +614,13 @@ class BufferedCapture(Process):
                 return self.pipeline.get_by_name("appsink")
 
             # Log the failure and retry if attempts are left
-            log.error("Attempt {:s}: Pipeline did not transition to PLAYING state, current state is {:s}. \
-                      Retrying in {:s} seconds."
+            log.error("Attempt {}: Pipeline did not transition to PLAYING state, current state is {}. \
+                      Retrying in {} seconds."
                       .format(attempt + 1, current_state, retry_interval))
 
             time.sleep(retry_interval)
 
-        log.error("Failed to set pipeline to PLAYING state after {:d} attempts.".format(max_retries))
+        log.error("Failed to set pipeline to PLAYING state after {} attempts.".format(max_retries))
         return False
 
 

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -508,14 +508,21 @@ class BufferedCapture(Process):
 
         device_url = self.extractRtspUrl(self.config.deviceID)
 
-        device_str = ("rtspsrc  buffer-mode=1 protocols=tcp tcp-timeout=5000000 retry=5 "
-                      "location=\"{}\" ! "
-                      "rtph264depay ! h264parse ! avdec_h264").format(device_url)
+        if self.config.protocol == 'udp':
+            rtspsrc_params = ("rtspsrc buffer-mode=1 protocols=udp retry=5")
+
+        else:  # Default to TCP
+            rtspsrc_params = ("rtspsrc buffer-mode=1 protocols=tcp tcp-timeout=5000000 retry=5")
+
+        device_str = ("{} location=\"{}\" ! rtph264depay ! h264parse ! avdec_h264"
+                      ).format(rtspsrc_params, device_url)
 
         conversion = "videoconvert ! video/x-raw,format={}".format(video_format)
+
         pipeline_str = ("{} ! queue leaky=downstream max-size-buffers=100 max-size-bytes=0 max-size-time=0 ! "
                         "{} ! queue max-size-buffers=100 max-size-bytes=0 max-size-time=0 ! "
-                        "appsink max-buffers=100 drop=true sync=0 name=appsink").format(device_str, conversion)
+                        "appsink max-buffers=100 drop=true sync=0 name=appsink"
+                        ).format(device_str, conversion)
 
         log.debug("GStreamer pipeline string: {}".format(pipeline_str))
 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -265,6 +265,9 @@ class Config:
         ##### Capture
         self.deviceID = 0
 
+        # Transport Layer Protocol: tcp or udp
+        self.protocol = "tcp"
+
         # Media backend to use for capture. Options are gst, cv2, or v4l2
         self.media_backend = "gst"
         self.uyvy_pixelformat = False
@@ -946,6 +949,9 @@ def parseCapture(config, parser):
         # If it fails, it's probably a RTSP stream
         pass
 
+    if parser.has_option(section, "protocol"):
+        config.protocol = parser.get(section, "protocol")
+    
     if parser.has_option(section, "media_backend"):
         config.media_backend = parser.get(section, "media_backend")
 


### PR DESCRIPTION
Added a configuration parameter `protocol` to `.config` that can be set to 'udp' or 'tcp'. It defaults to TCP: If not set to 'udp' the code uses TCP. I hope this will solve some disconnect issues, especially on Multicam setups.

One minor issue when running UDP is that GStreamer might issue a warning message about memory size:
```
warning: Could not create a buffer of requested 524288 bytes (Operation not permitted). Need net.admin privilege?
0:00:00.107728875 32187     0x24a0d6a0 WARN                  udpsrc gstudpsrc.c:1647:gst_udpsrc_open:<udpsrc0> have udp buffer of 212992 bytes while 524288 were requested
```
The stream will proceed fine despite the warning, but increasing the system’s maximum UDP buffer size by modifying the /etc/sysctl.conf file solves the issue. Adding the following lines to /etc/sysctl.conf :
```
net.core.rmem_max=524288
net.core.wmem_max=524288
```

After making these changes, apply them by running:
```
sudo sysctl -p
```