### PR TITLE
Fix GStreamer hanging after multiple attempts

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -520,6 +520,7 @@ class BufferedCapture(Process):
         log.debug("GStreamer pipeline string: {}".format(pipeline_str))
 
         # Set the pipeline to PLAYING state with retries
+        attempt = 0
         for attempt in range(max_retries):
             
             # Parse and create the pipeline


### PR DESCRIPTION
Occasionally, GStreamer would hang after 5 attempts during a night run. The retry loop doesn't reset/initialize the attempt counter and would hang on subsequent reconnect attempt after a disconnect. This PR initialize the attempt counter.