### PR TITLE
Replace datetime.datetime.utcnow() by datetime.datetime.now(datetime UTC)

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -45,6 +45,7 @@ from RMS.Formats.FFfile import filenameToDatetime
 from RMS.Formats.FTPdetectinfo import (findFTPdetectinfoFile,
                                        readFTPdetectinfo, writeFTPdetectinfo)
 from RMS.Math import angularSeparation, cartesianToPolar, polarToCartesian
+from RMS.Misc import rms_datetime
 
 pyximport.install(setup_args={'include_dirs':[np.get_include()]})
 from RMS.Astrometry.CyFunctions import (cyraDecToXY, cyTrueRaDec2ApparentAltAz,
@@ -833,7 +834,7 @@ def applyAstrometryFTPdetectinfo(dir_path, ftp_detectinfo_file, platepar_file, U
 
 
     # Calibration string to be written to the FTPdetectinfo file
-    calib_str = 'Calibrated with RMS on: ' + str(datetime.datetime.utcnow()) + ' UTC'
+    calib_str = 'Calibrated with RMS on: ' + str(rms_datetime.utcnow()) + ' UTC'
 
     # If no meteors were detected, set dummpy parameters
     if len(meteor_list) == 0:

--- a/RMS/Astrometry/ApplyRecalibrate.py
+++ b/RMS/Astrometry/ApplyRecalibrate.py
@@ -34,6 +34,7 @@ from RMS.Formats import CALSTARS, FFfile, FTPdetectinfo, Platepar, StarCatalog
 from RMS.Formats.FTPdetectinfo import findFTPdetectinfoFile
 from RMS.Math import angularSeparation
 from RMS.Logger import initLogging
+from RMS.Misc import rms_datetime
 
 # Neighbourhood size around individual FFs with detections which will be takes for recalibration
 #   A size of e.g. 3 means that an FF before, the FF with the detection, an an FF after will be taken
@@ -930,7 +931,7 @@ def recalibrateIndividualFFsAndApplyAstrometry(
         meteor_output_list.append([ff_name, meteor_No, rho, phi, meteor_picks])
 
     # Calibration string to be written to the FTPdetectinfo file
-    calib_str = 'Recalibrated with RMS on: ' + str(datetime.datetime.utcnow()) + ' UTC'
+    calib_str = 'Recalibrated with RMS on: ' + str(rms_datetime.utcnow()) + ' UTC'
 
     # If no meteors were detected, set dummpy parameters
     if len(meteor_list) == 0:
@@ -942,7 +943,7 @@ def recalibrateIndividualFFsAndApplyAstrometry(
         shutil.copy(
             ftpdetectinfo_path,
             ftpdetectinfo_path.strip('.txt')
-            + '_backup_{:s}.txt'.format(datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f')),
+            + '_backup_{:s}.txt'.format(rms_datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f')),
         )
     except:
         log.info('ERROR! The FTPdetectinfo file could not be backed up: {:s}'.format(ftpdetectinfo_path))

--- a/RMS/CaptureDuration.py
+++ b/RMS/CaptureDuration.py
@@ -4,6 +4,7 @@ import datetime
 
 import ephem
 
+from RMS.Misc import rms_datetime
 
 def captureDuration(lat, lon, elevation, current_time=None, max_hours=23):
     """ Calcualtes the start time and the duration of capturing, for the given geographical coordinates. 
@@ -38,7 +39,7 @@ def captureDuration(lat, lon, elevation, current_time=None, max_hours=23):
 
     # If the current time is not given, use the current time
     if current_time is None:
-        current_time = datetime.datetime.utcnow()
+        current_time = rms_datetime.utcnow()
 
     # Set the current time
     o.date = current_time

--- a/RMS/DetectStarsAndMeteors.py
+++ b/RMS/DetectStarsAndMeteors.py
@@ -35,6 +35,7 @@ from RMS.ExtractStars import extractStars
 from RMS.Detection import detectMeteors
 from RMS.DetectionTools import loadImageCalibration
 from RMS.QueuedPool import QueuedPool
+from RMS.Misc import rms_datetime
 
 
 # Get the logger from the main module
@@ -285,7 +286,7 @@ def detectStarsAndMeteorsDirectory(dir_path, config):
 
 if __name__ == "__main__":
 
-    time_start = datetime.datetime.utcnow()
+    time_start = rms_datetime.utcnow()
 
 
     ### COMMAND LINE ARGUMENTS
@@ -324,4 +325,4 @@ if __name__ == "__main__":
     # Delete backup files
     detector.deleteBackupFiles()
 
-    log.info('Total time taken: {}'.format(datetime.datetime.utcnow() - time_start))
+    log.info('Total time taken: {}'.format(rms_datetime.utcnow() - time_start))

--- a/RMS/DownloadMask.py
+++ b/RMS/DownloadMask.py
@@ -29,7 +29,7 @@ import paramiko
 
 from RMS.UploadManager import _agentAuth, existsRemoteDirectory, createRemoteDirectory
 
-
+from RMS.Misc import rms_datetime
 
 
 # Get the logger from the main module
@@ -158,7 +158,7 @@ def downloadNewMask(config, port=22):
 
     # Construct a new name with the time of the download included
     dl_mask_name = remote_mask_path + 'mask_dl_' \
-        + datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + '.bmp'
+        + rms_datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + '.bmp'
 
     sftp.posix_rename(remote_mask, dl_mask_name)
 

--- a/RMS/DownloadPlatepar.py
+++ b/RMS/DownloadPlatepar.py
@@ -11,6 +11,7 @@ import paramiko
 
 
 from RMS.UploadManager import _agentAuth
+from RMS.Misc import rms_datetime
 
 
 # Get the logger from the main module
@@ -82,7 +83,7 @@ def downloadNewPlatepar(config, port=22):
 
     # Construct a new name with the time of the download included
     dl_pp_name = remote_platepar_path + 'platepar_dl_' \
-        + datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + '.cal'
+        + rms_datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + '.cal'
 
     sftp.posix_rename(remote_platepar, dl_pp_name)
 

--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -33,6 +33,7 @@ import uuid
 import random
 import string
 
+from RMS.Misc import rms_datetime
 
 if sys.version_info[0] < 3:
 
@@ -1168,7 +1169,7 @@ class EventMonitor(multiprocessing.Process):
         sql_statement += "UPDATE event_monitor                 \n"
         sql_statement += "SET                                  \n"
         sql_statement += "processedstatus = 1,                 \n"
-        sql_statement += "timecompleted   = CURRENT_TIMESTAMP  \n".format(datetime.datetime.utcnow())
+        sql_statement += "timecompleted   = CURRENT_TIMESTAMP  \n".format(rms_datetime.utcnow())
         sql_statement += "                                     \n"
         sql_statement += "WHERE                                \n"
         sql_statement += "uuid = '{}'                          \n".format(event.uuid)
@@ -1854,9 +1855,9 @@ class EventMonitor(multiprocessing.Process):
             # if the end of the event is before the next scheduled execution of event monitor loop,
             # then set the loop to execute after the event ends
             if convertGMNTimeToPOSIX(observed_event.dt) + \
-                    datetime.timedelta(seconds=int(observed_event.time_tolerance)) > datetime.datetime.utcnow():
+                    datetime.timedelta(seconds=int(observed_event.time_tolerance)) > rms_datetime.utcnow():
                 time_until_event_end_seconds = (convertGMNTimeToPOSIX(observed_event.dt) -
-                                                    datetime.datetime.utcnow() +
+                                                    rms_datetime.utcnow() +
                                                     datetime.timedelta(seconds=int(observed_event.time_tolerance))).total_seconds()
                 future_events += 1
                 log.info("The end of event at {} is in the future by {:.1f} minutes"
@@ -1877,7 +1878,7 @@ class EventMonitor(multiprocessing.Process):
 
 
             log.info("Checks on trajectories for event at {}".format(observed_event.dt))
-            check_time_start = datetime.datetime.utcnow()
+            check_time_start = rms_datetime.utcnow()
             # Iterate through the work
             # Events can be specified in different ways, make sure converted to LatLon
             observed_event.latLonAzElToLatLonLatLon()
@@ -1966,7 +1967,7 @@ class EventMonitor(multiprocessing.Process):
                 if min_dist < event.close_radius * 1000 and not test_mode:
                     # this is just for info
                     log.info("Event at {} was {:.0f}km away, inside {:.0f}km so is uploaded with no further checks.".format(event.dt, min_dist / 1000, event.close_radius))
-                    check_time_end = datetime.datetime.utcnow()
+                    check_time_end = rms_datetime.utcnow()
                     check_time_seconds = (check_time_end- check_time_start).total_seconds()
                     log.info("Check of trajectories time elapsed {:.2f} seconds".format(check_time_seconds))
                     count, event.start_distance, event.start_angle, event.end_distance, event.end_angle, event.fovra, event.fovdec = self.trajectoryThroughFOV(
@@ -1988,7 +1989,7 @@ class EventMonitor(multiprocessing.Process):
                     count, event.start_distance, event.start_angle, event.end_distance, event.end_angle, event.fovra, event.fovdec = self.trajectoryThroughFOV(event)
                     if count != 0:
                         log.info("Event at {} had {} points out of 100 in the trajectory in the FOV. Uploading.".format(event.dt, count))
-                        check_time_end = datetime.datetime.utcnow()
+                        check_time_end = rms_datetime.utcnow()
                         check_time_seconds = (check_time_end - check_time_start).total_seconds()
                         log.info("Check of trajectories took {:2f} seconds".format(check_time_seconds))
                         if self.doUpload(observed_event, ev_con, file_list, test_mode=test_mode):
@@ -2019,12 +2020,12 @@ class EventMonitor(multiprocessing.Process):
             # End of the processing loop for this event
             if self.eventProcessed(observed_event.uuid):
                 log.info("Reached end of checks - {} is processed".format(observed_event.dt))
-                check_time_end = datetime.datetime.utcnow()
+                check_time_end = rms_datetime.utcnow()
                 check_time_seconds = (check_time_end - check_time_start).total_seconds()
                 log.info("Check of trajectories time elapsed {:.2f} seconds".format(check_time_seconds))
 
             else:
-                check_time_end = datetime.datetime.utcnow()
+                check_time_end = rms_datetime.utcnow()
                 check_time_seconds = (check_time_end - check_time_start).total_seconds()
                 log.info("Reached end of checks - {} is processed, nothing to upload".format(observed_event.dt))
                 log.info("Check of trajectories time elapsed {:.2f} seconds".format(check_time_seconds))
@@ -2037,7 +2038,7 @@ class EventMonitor(multiprocessing.Process):
             log.info("{} event was processed, EventMonitor work completed"
                      .format(len(unprocessed) - future_events))
 
-        next_run = (datetime.datetime.utcnow() + datetime.timedelta(minutes=self.check_interval)).replace(microsecond = 0)
+        next_run = (rms_datetime.utcnow() + datetime.timedelta(minutes=self.check_interval)).replace(microsecond = 0)
         if future_events == 1:
             log.info("{} future event is scheduled, running again at {}"
                      .format(future_events, next_run))
@@ -2122,10 +2123,10 @@ class EventMonitor(multiprocessing.Process):
 
 
         time.sleep(60)
-        last_check_start_time = datetime.datetime.utcnow()
+        last_check_start_time = rms_datetime.utcnow()
         while not self.exit.is_set():
-            check_start_time = datetime.datetime.utcnow()
-            next_check_start_time = (datetime.datetime.utcnow() + datetime.timedelta(minutes=self.check_interval))
+            check_start_time = rms_datetime.utcnow()
+            next_check_start_time = (rms_datetime.utcnow() + datetime.timedelta(minutes=self.check_interval))
             next_check_start_time_str = next_check_start_time.replace(microsecond=0).strftime('%H:%M:%S')
             self.checkDBExists()
             self.getEventsAndCheck(last_check_start_time,next_check_start_time)
@@ -2135,10 +2136,10 @@ class EventMonitor(multiprocessing.Process):
 
             if not isinstance(start_time, bool):
 
-                time_left_before_start = (start_time - datetime.datetime.utcnow())
+                time_left_before_start = (start_time - rms_datetime.utcnow())
                 time_left_before_start = time_left_before_start - datetime.timedelta(microseconds=time_left_before_start.microseconds)
                 time_left_before_start_minutes = int(time_left_before_start.total_seconds() / 60)
-                next_check_start_time = (datetime.datetime.utcnow() + datetime.timedelta(minutes=self.check_interval))
+                next_check_start_time = (rms_datetime.utcnow() + datetime.timedelta(minutes=self.check_interval))
                 next_check_start_time_str = next_check_start_time.replace(microsecond=0).strftime('%H:%M:%S')
                 log.info('Next EventMonitor run : {} UTC; {:3.1f} minutes from now'.format(next_check_start_time_str, int(self.check_interval)))
                 if time_left_before_start_minutes < 120:
@@ -2146,7 +2147,7 @@ class EventMonitor(multiprocessing.Process):
                 else:
                     log.info('Next Capture start    : {} UTC'.format(str(start_time.strftime('%H:%M:%S'))))
             else:
-                next_check_start_time = (datetime.datetime.utcnow() + datetime.timedelta(minutes=self.check_interval))
+                next_check_start_time = (rms_datetime.utcnow() + datetime.timedelta(minutes=self.check_interval))
                 next_check_start_time_str = next_check_start_time.replace(microsecond=0).strftime('%H:%M:%S')
                 log.info('Next EventMonitor run : {} UTC {:3.1f} minutes from now'.format(next_check_start_time_str, self.check_interval))
             # Wait for the next check

--- a/RMS/Formats/FTPdetectinfo.py
+++ b/RMS/Formats/FTPdetectinfo.py
@@ -21,6 +21,7 @@ import os
 
 import git
 import numpy as np
+from RMS.Misc import rms_datetime
 
 
 def validDefaultFTPdetectinfo(file_name):
@@ -80,7 +81,7 @@ def writeFTPdetectinfo(meteor_list, ff_directory, file_name, cal_directory, cam_
         ftpdetect_file.write("Meteor Count = " + str(total_meteors).zfill(6) + "\n")
         ftpdetect_file.write("-----------------------------------------------------\n")
         ftpdetect_file.write("Processed with RMS 1.0 " + commit_time + " " + str(sha) + " on " \
-            + str(datetime.datetime.utcnow()) + " UTC\n")
+            + str(rms_datetime.utcnow()) + " UTC\n")
         ftpdetect_file.write("-----------------------------------------------------\n")
         ftpdetect_file.write("FF  folder = " + ff_directory + "\n")
         ftpdetect_file.write("CAL folder = " + cal_directory + "\n")

--- a/RMS/Logger.py
+++ b/RMS/Logger.py
@@ -22,7 +22,7 @@ import logging
 import logging.handlers
 import datetime
 
-from RMS.Misc import mkdirP
+from RMS.Misc import mkdirP, rms_datetime
 
 
 def initLogging(config, log_file_prefix="", safedir=None):
@@ -50,7 +50,7 @@ def initLogging(config, log_file_prefix="", safedir=None):
             log_path = safedir
 
     # Generate a file name for the log file
-    log_file_name = log_file_prefix + "log_" + str(config.stationID) + "_" + datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + ".log"
+    log_file_name = log_file_prefix + "log_" + str(config.stationID) + "_" + rms_datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + ".log"
         
     # Init logging
     log = logging.getLogger('logger')

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -13,6 +13,7 @@ import string
 import inspect
 import datetime
 
+
 # tkinter import that works on both Python 2 and 3
 if sys.version_info[0] < 3:
     import Tkinter as tkinter
@@ -403,7 +404,7 @@ def checkListEquality(t1, t2):
 
         else:
 
-            # If the elements are someting else, compare them directly
+            # If the elements are something else, compare them directly
             if e1 != e2:
                 return False
 
@@ -599,13 +600,18 @@ def sanitise(unsanitised, lower = False, space_substitution = "", log_changes = 
     return sanitised
 
 
-class rms_datetime():
+class RmsDateTime:
     """ Class to hold utcnow() wrapper function definition.
-        Select the best approach to retrieve current UCT time according to Python version
+        Select the best approach to retrieve current UTC time according to Python version.
     """
     if sys.version_info[0] < 3:
-        utcnow = datetime.datetime.utcnow
+        @staticmethod
+        def utcnow():
+            # Python 2: Use the existing utcnow, which is not timezone-aware.
+            return datetime.datetime.utcnow()
     else:
         @staticmethod
-        def utcnow(): return datetime.datetime.now(datetime.UTC)
-
+        def utcnow():
+            # Python 3: Get timezone-aware UTC time and then make it naive.
+            return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -11,7 +11,7 @@ import subprocess
 import random
 import string
 import inspect
-
+import datetime
 
 # tkinter import that works on both Python 2 and 3
 if sys.version_info[0] < 3:
@@ -597,4 +597,15 @@ def sanitise(unsanitised, lower = False, space_substitution = "", log_changes = 
         log.info("String {} was sanitised to {}".format(unsanitised, sanitised))
 
     return sanitised
+
+
+class rms_datetime():
+    """ Class to hold utcnow() wrapper function definition.
+        Select the best approach to retrieve current UCT time according to Python version
+    """
+    if sys.version_info[0] < 3:
+        utcnow = datetime.datetime.utcnow
+    else:
+        @staticmethod
+        def utcnow(): return datetime.datetime.now(datetime.UTC)
 

--- a/RMS/Routines/SolarLongitude.py
+++ b/RMS/Routines/SolarLongitude.py
@@ -7,6 +7,7 @@ import datetime
 import numpy as np
 import scipy.optimize
 from RMS.Astrometry.Conversions import date2JD, datetime2JD, jd2Date
+from RMS.Misc import rms_datetime
 
 @np.vectorize
 def jd2SolLonSteyaert(jd):
@@ -201,9 +202,9 @@ if __name__ == "__main__":
 
     # ### ###
 
-    print("Current UTC time is: {}".format(datetime.datetime.utcnow()))
-    print("Current Julian date is: {:.12f}".format(datetime2JD(datetime.datetime.utcnow())))
-    print("Current solar longitude: {:.6f} deg".format(np.degrees(jd2SolLonSteyaert(datetime2JD(datetime.datetime.utcnow())))))
+    print("Current UTC time is: {}".format(rms_datetime.utcnow()))
+    print("Current Julian date is: {:.12f}".format(datetime2JD(rms_datetime.utcnow())))
+    print("Current solar longitude: {:.6f} deg".format(np.degrees(jd2SolLonSteyaert(datetime2JD(rms_datetime.utcnow())))))
 
 
     # Test inverse function

--- a/RMS/Routines/SolarLongitude.py
+++ b/RMS/Routines/SolarLongitude.py
@@ -201,10 +201,10 @@ if __name__ == "__main__":
     #         print('JD inverse Steyaert: {:.12f} +/- {:.6f} s'.format(jd_steyaert, 24*60*60*abs(jd - jd_steyaert)))
 
     # ### ###
-
-    print("Current UTC time is: {}".format(rms_datetime.utcnow()))
-    print("Current Julian date is: {:.12f}".format(datetime2JD(rms_datetime.utcnow())))
-    print("Current solar longitude: {:.6f} deg".format(np.degrees(jd2SolLonSteyaert(datetime2JD(rms_datetime.utcnow())))))
+    current_time = rms_datetime.utcnow()
+    print("Current UTC time is: {}".format(current_time))
+    print("Current Julian date is: {:.12f}".format(datetime2JD(current_time)))
+    print("Current solar longitude: {:.6f} deg".format(np.degrees(jd2SolLonSteyaert(datetime2JD(current_time)))))
 
 
     # Test inverse function

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -51,6 +51,7 @@ from RMS.RunExternalScript import runExternalScript
 from RMS.UploadManager import UploadManager
 from RMS.EventMonitor import EventMonitor
 from RMS.DownloadMask import downloadNewMask
+from RMS.Misc import rms_datetime
 
 # Flag indicating that capturing should be stopped
 STOP_CAPTURE = False
@@ -97,7 +98,7 @@ def wait(duration, compressor, buffered_capture, video_file):
     log.info('Press Ctrl+C to stop capturing...')
 
     # Get the time of capture start
-    time_start = datetime.datetime.utcnow()
+    time_start = rms_datetime.utcnow()
 
 
     while True:
@@ -115,7 +116,7 @@ def wait(duration, compressor, buffered_capture, video_file):
         # If some wait time was given, check if it passed
         if duration is not None:
 
-            time_elapsed = (datetime.datetime.utcnow() - time_start).total_seconds()
+            time_elapsed = (rms_datetime.utcnow() - time_start).total_seconds()
 
             # If the total time is elapsed, break the wait
             if time_elapsed >= duration:
@@ -203,7 +204,7 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         # Create a directory for captured files based on the current time
         if video_file is None:
             night_data_dir_name = str(config.stationID) + '_' \
-                + datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S_%f')
+                + rms_datetime.utcnow().strftime('%Y%m%d_%H%M%S_%f')
 
         # If a video file is given, take the folder name from the video file
         else:
@@ -551,9 +552,9 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
 
                 # Wait for the upload delay to pass
                 sleep_time = None
-                while (datetime.datetime.utcnow() - upload_manager.next_runtime).total_seconds() < 0:
+                while (rms_datetime.utcnow() - upload_manager.next_runtime).total_seconds() < 0:
                     
-                    wait_time = (datetime.datetime.utcnow() - upload_manager.next_runtime).total_seconds()
+                    wait_time = (rms_datetime.utcnow() - upload_manager.next_runtime).total_seconds()
                     log.info("Waiting for upload delay to pass: {:.1f} seconds...".format(abs(wait_time)))
 
                     # Sleep for a short interval between 1 and 30 seconds
@@ -958,7 +959,7 @@ if __name__ == "__main__":
                     if start_time:
                         break
 
-                time_now = datetime.datetime.utcnow()
+                time_now = rms_datetime.utcnow()
                 waiting_time = start_time - time_now
                 if waiting_time.total_seconds() <= 0:
                     break
@@ -1067,7 +1068,7 @@ if __name__ == "__main__":
             if not isinstance(start_time, bool):
 
                 # Calculate how many seconds to wait until capture starts, and with for that time
-                time_now = datetime.datetime.utcnow()
+                time_now = rms_datetime.utcnow()
                 waiting_time = start_time - time_now
 
                 log.info('Waiting {:s} to start recording for {:.3f} hrs'.format(str(waiting_time), \

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -23,7 +23,7 @@ except:
 
 
 
-from RMS.Misc import mkdirP
+from RMS.Misc import mkdirP, rms_datetime
 
 
 # Get the logger from the main module
@@ -515,7 +515,7 @@ class UploadManager(multiprocessing.Process):
 
         # Set the next run time using a delay
         with self.next_runtime_lock:
-            self.next_runtime = datetime.datetime.utcnow() + datetime.timedelta(seconds=delay)
+            self.next_runtime = rms_datetime.utcnow() + datetime.timedelta(seconds=delay)
 
             log.info("Upload delayed for {:.1f} min until {:s}".format(delay/60, str(self.next_runtime)))
 
@@ -533,7 +533,7 @@ class UploadManager(multiprocessing.Process):
 
                 # Check if the upload should be run (if 15 minutes are up)
                 if self.last_runtime is not None:
-                    if (datetime.datetime.utcnow() - self.last_runtime).total_seconds() < 15*60:
+                    if (rms_datetime.utcnow() - self.last_runtime).total_seconds() < 15*60:
                         time.sleep(1)
                         continue
 
@@ -541,12 +541,12 @@ class UploadManager(multiprocessing.Process):
 
                 # Check if the upload delay is up
                 if self.next_runtime is not None:
-                    if (datetime.datetime.utcnow() - self.next_runtime).total_seconds() < 0:
+                    if (rms_datetime.utcnow() - self.next_runtime).total_seconds() < 0:
                         time.sleep(1)
                         continue
 
             with self.last_runtime_lock:
-                self.last_runtime = datetime.datetime.utcnow()
+                self.last_runtime = rms_datetime.utcnow()
 
             # Run the upload procedure
             self.uploadData()

--- a/Utils/FluxAuto.py
+++ b/Utils/FluxAuto.py
@@ -19,7 +19,7 @@ from RMS.Math import isAngleBetween
 from RMS.Routines.SolarLongitude import jd2SolLonSteyaert
 from Utils.FluxBatch import fluxBatch, plotBatchFlux, FluxBatchBinningParams, saveBatchFluxCSV, \
     reportCameraTally
-from RMS.Misc import mkdirP, walkDirsToDepth
+from RMS.Misc import mkdirP, walkDirsToDepth, rms_datetime
 from Utils.FluxFitActivityCurve import computeCurrentPeakZHR, loadFluxActivity, plotYearlyZHR
 
 
@@ -1004,7 +1004,7 @@ if __name__ == "__main__":
     while True:
 
         # Clock for measuring script time
-        t1 = datetime.datetime.utcnow()
+        t1 = rms_datetime.utcnow()
 
 
         if cml_args.time is not None:
@@ -1012,7 +1012,7 @@ if __name__ == "__main__":
 
         # If no manual time was given, use current time.
         else:
-            ref_dt = datetime.datetime.utcnow()
+            ref_dt = rms_datetime.utcnow()
 
 
         print("Computing flux using reference time:", ref_dt)
@@ -1042,7 +1042,7 @@ if __name__ == "__main__":
 
             # Otherwise wait to run
             wait_time = (datetime.timedelta(hours=cml_args.auto) \
-                - (datetime.datetime.utcnow() - t1)).total_seconds()
+                - (rms_datetime.utcnow() - t1)).total_seconds()
 
             # Run immediately if the wait time has elapsed
             if wait_time < 0:

--- a/Utils/FluxFitActivityCurve.py
+++ b/Utils/FluxFitActivityCurve.py
@@ -1093,7 +1093,7 @@ def computeCurrentPeakZHR(shower_models, dt=None, time_window=24, sporadic_zhr=2
 
     # If no datetime is given, use the current time
     if dt is None:
-        dt = datetime.datetime.utcnow()
+        dt = rms_datetime.utcnow()
 
     # Convert the time window from hours to degrees of the solar longitude
     time_window_deg = (time_window/24)*360/365.25
@@ -1193,7 +1193,7 @@ def plotYearlyZHR(config, plot_path, sporadic_zhr=25, dt_ref=None, plot_current_
 
     # If the reference datetime is not provided, use the current time
     if dt_ref is None:
-        dt_ref = datetime.datetime.utcnow()
+        dt_ref = rms_datetime.utcnow()
 
 
     # If the date is before the vernal equinox, use the previous year for the plot

--- a/Utils/GenerateMP4s.py
+++ b/Utils/GenerateMP4s.py
@@ -30,7 +30,7 @@ from RMS.Misc import mkdirP
 
 
 def generateMP4s(dir_path, ftpfile_name, shower_code=None, min_mag=None, config=None):
-    t1 = datetime.datetime.utcnow()
+    t1 = rms_datetime.utcnow()
 
     # Load the font for labeling
     try:
@@ -190,7 +190,7 @@ def generateMP4s(dir_path, ftpfile_name, shower_code=None, min_mag=None, config=
 
             print("Deleted temporary directory : " + dir_tmp_path)
 
-    print("Total time:", datetime.datetime.utcnow() - t1)
+    print("Total time:", rms_datetime.utcnow() - t1)
 
 
 if __name__ == "__main__":

--- a/Utils/GenerateTimelapse.py
+++ b/Utils/GenerateTimelapse.py
@@ -55,7 +55,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
         crf = 29
 
 
-    t1 = datetime.datetime.utcnow()
+    t1 = rms_datetime.utcnow()
 
     # Load the font for labeling
     try:
@@ -121,7 +121,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
         # Print elapsed time
         if c % 30 == 0:
             print("{:>5d}/{:>5d}, Elapsed: {:s}".format(c + 1, len(ff_list), \
-                str(datetime.datetime.utcnow() - t1)), end="\r")
+                str(rms_datetime.utcnow() - t1)), end="\r")
             sys.stdout.flush()
 
 
@@ -176,7 +176,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
         shutil.rmtree(dir_tmp_path)
         print("Deleted temporary directory : " + dir_tmp_path)
 		
-    print("Total time:", datetime.datetime.utcnow() - t1)
+    print("Total time:", rms_datetime.utcnow() - t1)
 
 
 if __name__ == "__main__":

--- a/Utils/SaturationCorrection.py
+++ b/Utils/SaturationCorrection.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
 
 
     # Calibration string to be written to the FTPdetectinfo file
-    calib_str = "RMS - Saturation corrected on {:s} UTC".format(str(datetime.datetime.utcnow()))
+    calib_str = "RMS - Saturation corrected on {:s} UTC".format(str(rms_datetime.utcnow()))
 
     # Write a corrected FTPdetectinfo file
     corrected_ftpdetectinfo_name = ftpdetectinfo_name.strip('.txt') + '_saturation_corrected.txt'

--- a/iStream/iStream.py
+++ b/iStream/iStream.py
@@ -7,7 +7,7 @@ import datetime
 import logging
 from RMS.CaptureDuration import captureDuration
 from RMS.Logger import initLogging
-from RMS.Misc import isRaspberryPi
+from RMS.Misc import isRaspberryPi, rms_datetime
 
 
 def rmsExternal(captured_night_dir, archived_night_dir, config):
@@ -34,7 +34,7 @@ def rmsExternal(captured_night_dir, archived_night_dir, config):
     # Compute the capture duration from now
     start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation)
 
-    timenow = datetime.datetime.utcnow()
+    timenow = rms_datetime.utcnow()
     remaining_seconds = 0
 
     # Compute how long to wait before capture


### PR DESCRIPTION


.utcnow() is being deprecated:
   "DeprecationWarning: datetime.datetime.utcnow() is deprecated and
   scheduled for removal in a future version. Use timezone-aware
   objects to represent datetimes in UTC"

Output differences:
```python
>>> str(datetime.datetime.utcnow()) + ' UTC'
'2024-07-25 13:12:15.773880 UTC'

>>> str(datetime.datetime.now(datetime.UTC)) + ' UTC'
'2024-07-25 13:12:23.862181+00:00 UTC'
```