### PR TITLE
Config File Enhancements - Restyling, Template, and Audit Tool

### DIFF
--- a/.config
+++ b/.config
@@ -197,6 +197,9 @@ slideshow_enable: false
 ; Automatically reprocess broken capture directories (due to e.g. power cut or system crash)
 auto_reprocess: true
 
+; Prioritize capture over reprocessing - do not start reprocessing a new directory if should be capturing
+prioritize_capture_over_reprocess: false
+
 ; Flag file which indicates that the previously processed files are loaded during capture resume
 capture_resume_flag_file: .capture_resuming
 

--- a/.config
+++ b/.config
@@ -1,83 +1,110 @@
-; IMPORTANT: There always must be at least one space after the argument value and before the semicolon in front of the comment.
-; For example, "parameter: value ; comment" is correct, while "parameter: value; comment" is incorrect.
+; IMPORTANT: Unlike other RMS files, the '.config' file is never automatically
+; updated. When changes are introduced to the config file in RMS, these changes
+; will NOT be automatically reflected in the active '.config' file on 
+; individual machines. Users should manually update their '.config' file if 
+; changing any option from its default value is desired, or to simply stay 
+; up-to-date. If an option is missing from the config file, a default value 
+; will be automatically applied.
+; An up-to-date template config '.configTemplate' file, containing the current
+; options, is located in the RMS root directory.
+; Run python -m Utils.AuditConfig to compare the .config file to the template. 
 
 [System]
 
-stationID: XX0001
-latitude: 43.19301 ; WGS84 +N  (degrees )
-longitude: -81.315555 ; WGS84 +E (degrees)
-elevation: 327 ; mean sea level EGM96 geoidal datum, not WGS84 ellipsoidal (meters)
+; The assigned station ID
+stationID: US9999
+
+; WGS84 +N (degrees)
+latitude: 43.19301
+
+; WGS84 +E (degrees)
+longitude: -81.315555
+
+; Mean sea level EGM96 geoidal datum, not WGS84 ellipsoidal (meters)
+; Can be obtained from Google Earth or other apps. Raw GPS altitude should not
+; be used as the software converts from EGM96 to WGS84 internally.
+elevation: 327
 
 ; Should be set only if full CAMS compatibility is desired
-cams_code: 0 
+cams_code: 0
+
+; Weblog and PerfMonitor
+; ----------------------
 
 ; Show this camera on the GMN weblog
-weblog_enable: true
+weblog_enable: false
 
-; The description that will be shown on the weblog (e.g. location, pointing direction)
+; The description shown on the weblog (e.g. location, pointing direction)
 weblog_description: none
 
-
 ; Server will generate obfuscated coordinates for public datasets.
-; Optionally, uncomment and populate the three parameters below to use a specific public location if desired. 
-; The recommended precision is two decimal places for latitude and longitude, and ~10 m for elevation.
-; public_latitude: 0.0 ; WGS84 +N (degrees)
-; public_longitude: 0.0 ; WGS84 +E (degrees)
+; Optionally, uncomment and populate the three parameters below to use a
+; specific public location if desired. The recommended precision is two decimal
+; places for latitude and longitude, and ~10 m for elevation.
+
+; WGS84 +N (degrees)
+; public_latitude: 0.0
+
+; WGS84 +E (degrees)
+; public_longitude: 0.0
+
+; mean sea level EGM96 (meters)
 ; public_elevation: 0.0
 
-; Camera network (e.g. national networks, used for grouping on the weblog). 
+; Camera network (e.g. national networks, used for grouping on the weblog).
 ; Separate by comma for multiple networks
 network_name: none
+
 ; Camera group (e.g. a camera cluster or a location with multiple cameras)
 camera_group_name: none
 
 
-
 ; External script
-; An external script will be run after RMS finishes the processing for the night, it will be passed 
-; three arguments:
-;   captured_night_dir, archived_night_dir, config - captured_night dir is the full path to the 
-;   captured folder of the night, the second one is the archived, and config is an object holding 
-;   the values in this config file.
 ; ---------------
-; Enable running an external script at the end of every night of processing
-external_script_run: false
-; Run the external script after auto reprocess. "auto_reprocess" needs to be "true" for this to work.
-auto_reprocess_external_script_run: false
-; Full path to the external script
-external_script_path: /home/dvida/Desktop/rms_external.py
-; Name of the function in the external script which will be called
-external_function_name: rmsExternal
 
+; Enable running an external script at the end of every night. it will be passed
+; three arguments: captured_night_dir, archived_night_dir, config 
+external_script_run: false
+
+; Run the external script after auto reprocess.
+; "auto_reprocess" needs to be "true" for this to work.
+auto_reprocess_external_script_run: false
+
+; Full path to the external script
+external_script_path: none
+
+; Name of the function in the external script to be called
+external_function_name: rmsExternal
 
 ; Daily reboot
 ; ---------------
-; Reboot the computer daily after the processing and upload is done
+
+; Reboot the computer daily after processing and upload
 reboot_after_processing: true
-; Name of the lock file which the external script should create to prevent rebooting until the 
-;   script is done. The external script should remove this file if the reboot is to run after the 
-;   script finishes. This file should be created in the config.data_dir directory (i.e. ~/RMS_data).
+
+; Lock file name for preventing rebooting until the script is done.
+; The external script should remove this file if the reboot is to run after the
+; script finishes. This file should be created in the config.data_dir directory
+; (i.e. ~/RMS_data).
 reboot_lock_file: .reboot_lock
+
 
 
 [Capture]
 
-device: rtsp://192.168.42.10:554/user=admin&password=&channel=1&stream=0.sdp ; device id
+; device URL
+device: rtsp://192.168.42.10:554/user=admin&password=&channel=1&stream=0.sdp
 
 ; Transport Layer Protocol: 'tcp' or 'udp'. Defaults to tcp. UDP typically
 ; provides more stable connectivity, but TCP has a longer track record.
 protocol: tcp
 
 ; Media Backend: options are gst, cv2, or v4l2.
-;
-; The preferred option is 'gst', which corresponds to GStreamer Standalone. This method bypass OpenCV,
-; and provides the highest timestamps accuracy.
-; For the OpenCV method, choose 'cv2', this will revert to the OpenCV method which has proven to be
-; stable but has poor timestamping performance. 
-; To force OpenCV to use v4l2, choose 'v4l2', this will attempt to use v4l2 hardware acceleration
-; with OpenCV (also has poor timestamping performance compared to gst.) 
-; If gst, or v4l2 fails, the code reverts to cv2.
-; If media_backend is not set, the code will first attempt to use GStreamer Direct, them OpenCV 
+; 'gst':    (default - preferred) GStreamer Standalone. Bypass OpenCV, and
+;           provides the highest timestamps accuracy.
+; 'cv2':    OpenCV method. Reliable but has poor timestamping performance. 
+; 'v4l2':   OpenCV with v4l2, uses v4l2 hardware acceleration with OpenCV.
+; If gst, or v4l2 return an error, the code reverts to cv2.
 media_backend: gst
 
 ; Gstreamer color space to use. Only applicable if media_backend is gst.
@@ -88,135 +115,147 @@ gst_colorspace: BGR
 ; Examples: decodebin, avdec_h264, nvh264dec
 gst_decoder: avdec_h264
 
-# Location of the raw videos to be saved to disk (None means no saving)
+# Location of the raw videos to be saved to disk (None means no saving).
 raw_video_dir: None
 
-# Save the raw video to the night directory (if True, the raw_video_dir is ignored)
+# Save the raw video to the night directory.
+# If True, the raw_video_dir is ignored.
 raw_video_dir_night: False
 
-# Duration of the raw video segment (seconds). If -1, the segment duration will be 256/FPS seconds
+# Duration of the raw video segment (seconds).
+# If -1, the segment duration will be 256/FPS seconds
 raw_video_duration: 30
 
 uyvy_pixelformat: false
 
+; The capture device resolution
 width: 1280
 height: 720
-fps: 25.0 ; frames per second
 
-; Camera Latency Settings for GStreamer Timestamps:
-;
-; The following two parameters correct for camera latency when in GStreamer Standalone mode.
-; The settings are ignore when using other media_backend methods.
+; Frames per second (FPS) are precisely calculated and reported at the end of
+; each capture session when in GStreamer standalone mode. This information can
+; be found in each session's log by searching for 'Last Calculated FPS'. Please
+; update the value here with the log's reported value. The calculate FPS
+; often differs from the nominal FPS, usually by less than 0.1%.
+; Example: fps: 24.98122
+fps: 25.0
+
+; Camera Latency Settings for GStreamer Timestamps
+; ------------------------------------------------
+; The following two parameters correct for camera latency when in GStreamer
+; Standalone mode. The settings are ignored when using other media_backend
+; methods.
 ; The settings should be experimentally establishes for the specific setup.
-;
-; For example:
-;
-; RPi4, IMX291, 720p @ 25 FPS, VBR
-;     camera_buffer = 1
-;     camera_latency = 0.05
-;
+; For example:  RPi4, IMX291, 720p @ 25 FPS, VBR
+;               camera_buffer: 1
+;               camera_latency: 0.05
 ; If timestamps are late, increase latency. If early, decrease latency.
 ; Formula is:
 ; corrected_timestamp = timestamp - camera_buffer / fps - total_latency
-;
-; camera_buffer corresponds to the number of frames in the camera's internal buffer.
-; Uncomment to change the default values.
-;
-; camera_buffer = 1 ; frames (integer)
-; camera_latency = 0.05 ; delay in seconds
+; camera_buffer corresponds to the number of frames in the camera's internal
+; buffer. If these parameters are not present then RMS will use the default. 
 
+; frames (integer). Default is 1
+camera_buffer: 1
+
+; delay in seconds. Default is 0.05 s (50 ms)
+camera_latency: 0.05
+
+; Log dropped frames. Only reliable for analog cameras
 report_dropped_frames: false
 
-; Region of interest, left limit. -1 to disable
-roi_left: -1 
-; Region of interest, right limit. -1 to disable
-roi_right: -1 
-; Region of interest, upper limit. -1 to disable
-roi_up: -1 
-; Region of interest, lower limit. -1 to disable
-roi_down: -1 
+; Region of interest. -1 to disable
+roi_left: -1
+roi_right: -1
+roi_up: -1
+roi_down: -1
 
 ; Bit depth of the camera (e.g. an 8-bit camera)
-bit_depth: 8 
+bit_depth: 8
+
 ; Gamma of the camera. Usually 0.45 or 1.0
 gamma: 1.0
 
 ; Format of files, either 'bin' (CAMS format), or 'fits' (new RMS format)
 ff_format: fits
 
-; Approx. horizontal Field-of-view in degrees
+; Approximate Field-of-view in degrees
 fov_w: 87
-; Approx. vertical Field-of-view in degrees
 fov_h: 45
 
-; Deinterlacing -2 = global shutter, -1 = rolling shutter, 0 = even first, 1 = odd first
-deinterlace_order: -1 
+; Deinterlacing:    -2 = global shutter
+;                   -1 = rolling shutter
+;                    0 = even first
+;                    1 = odd first
+deinterlace_order: -1
 
-; A mask which is applied on every image so that nothing is detected in the masked (blacked out) region
-; (DO NOT PUT A FULL PATH HERE, DO NOT CHANGE THE NAME OF THE MASK FILE - processing scripts upstream 
-; expect it to be called "mask.bmp")
-; The operational mask file is always assumed to be in the same directory as the config file
-mask: mask.bmp 
+; A mask applied to images to prevent detection in the masked area
+; Must be located in the same directory as the config file
+; DO NOT CHANGE
+mask: mask.bmp
 
-; Directory where all data will be stored
-data_dir: ~/RMS_data 
-; Directory for raw captured files
-captured_dir: CapturedFiles 
-; Directory for archived files
-archived_dir: ArchivedFiles 
+; Path to the directory where all data will be stored
+data_dir: ~/RMS_data
 
-; Extra available space in GB to leave on the SD card every night after the predicted size of all 
-;     FF files have been taken into account
-extra_space_gb: 5
+; Name of directory within data_dir for raw captured files
+captured_dir: CapturedFiles
 
-; Directory for log files
+; Name of directory within data_dir for archived files
+archived_dir: ArchivedFiles
+
+; Name of directory within data_dir for log files
 log_dir: logs
 
-; number of days of logs to keep. Default is 30. If this parameter is not present then RMS will use the default. 
-logdays_to_keep: 30
+; Extra GB space left on the SD card nightly, accounting for the predicted
+; size of all FF files.
+extra_space_gb: 5
 
-; By default the system will keep 20 ArchivedFiles folders and compressed versions of the folders. 
-; You can adjust these limits using the below parameters. A value of zero means do nothing ie keep everything forever.
-; If these parameters are not present then RMS will use the default. 
+; By default the system will keep 20 ArchivedFiles folders and compressed
+; versions of the folders. You can adjust these limits using the below
+; parameters. A value of zero means do nothing ie keep everything forever.
 
-; number of ArchivedFiles folders to keep. Default is 20. 
+; number of ArchivedFiles folders to keep. Default is 20
 arch_dirs_to_keep: 20
 
-; number of bz2 compressed archive folders to keep. Default 20. 
+; number of days of logs to keep. Default is 30
+logdays_to_keep: 30
+
+; number of bz2 compressed archive folders to keep. Default 20
 bz2_files_to_keep: 20
 
-; Enable/disable showing maxpixel on the screen during capture
+
+; Toggle showing maxpixel on the screen during capture
 live_maxpixel_enable: false
 
-; Enable/disable saving a live.jpg file in the data directory with the latest image
+; Toggle saving a single jpg with the latest maxpixel image in the data dir
 live_jpg: false
 
-; Enable/disable showing a slideshow of last night's meteor detections on the screen during the day
+; Toggle daytime slideshow of last night's meteor detections
 slideshow_enable: false
 
-; Automatically reprocess broken capture directories (due to e.g. power cut or system crash)
+; Auto-reprocess broken capture directories after power cuts or crashes
 auto_reprocess: true
 
-; Prioritize capture over reprocessing - do not start reprocessing a new directory if should be capturing
+; Prioritize capture over reprocessing.
+; Do not start reprocessing a new directory if should be capturing
 prioritize_capture_over_reprocess: false
 
-; Flag file which indicates that the previously processed files are loaded during capture resume
+; Flag file to load processed files on capture resume
 capture_resume_flag_file: .capture_resuming
 
-; Wait an additional time (in seconds) after the capture is supposed to start. Used for multi-camera systems
-;   for a staggered capture start
+; Additional wait time (seconds) for staggered start in multi-camera setups
 capture_wait_seconds: 0
 
-; Randomize the wait time between 0 and capture_wait_seconds. Used for multi-camera systems
+; Randomize wait time (0 to capture_wait_seconds) for multi-camera systems.
 capture_wait_randomize: false
 
-; Run detection and the rest of postprocessing at the end of the night, instead of parallel to capture
+; Process detection and postprocessing at night's end, not during capture.
 postprocess_at_end: false
 
-; Wait an additional time (in seconds) to start the detection thread. If postprocess_at_end is set to false,
-;   the delay will occur after the beginning of capture, and if it's set to true, the delay will occur after
-;   the capture ends
+; Add extra seconds before starting detection: after capture begins if
+; postprocess_at_end is false, or after capture ends if true.
 postprocess_delay: 0
+
 
 
 [Build]
@@ -227,43 +266,56 @@ linux_pc_weave: -O3
 win_pc_weave: -Wall
 
 
+
 [Upload]
 
-; Flag for enabling/disabling upload to server
-upload_enabled: true 
+; Flag for enabling/disabling upload to meteor server
+upload_enabled: true
+
 ; Delay upload for the given number of minutes
 upload_delay: 0
+
 ; Server address
-hostname: gmn.uwo.ca 
+hostname: gmn.uwo.ca
+
 ; Standard SSH port
-host_port: 22 
-; Path to the SSH private key.
-rsa_private_key: ~/.ssh/id_rsa 
+host_port: 22
+
+; Path to the SSH private key
+rsa_private_key: ~/.ssh/id_rsa
+
 ; Directory on the server where the detected files will be uploaded to
-remote_dir: files 
-; Name of the file where the upload queue will be stored.
-upload_queue_file: FILES_TO_UPLOAD.inf 
+remote_dir: files
+
+; Name of the file where the upload queue will be stored
+upload_queue_file: FILES_TO_UPLOAD.inf
 
 ; Upload mode
 ; -----------
-; By default, RMS will upload text files with meteor and star detections, secondary data products 
-;     such as calibration plots, all FF image files, and all FR files with raw fireball frames.
-;     This typically results in an archive of 100-500 MB in size. Some stations have limited 
-;     data or bad internet connections, so a reduced data set can be uploaded to the server.
+; By default, RMS will upload text files with meteor and star detections,
+; secondary data products such as calibration plots, all FF image files, and all
+; FR files with raw fireball frames. This typically results in an archive of
+; 100-500 MB in size. Some stations have limited data or bad internet
+; connections, so a reduced data set can be uploaded to the server.
 ; Options:
-;     1 - Normal mode. Everything is uploaded, including FF files with detections.
-;     2 - Skip FFs. Everything except two FF files will be uploaded. One with the most matched stars
-;         and another random one with a meteor detection.
-;     3 - Skip FFs and FRs. Same as option 2, but FR files will also be skipped.
-;     4 - Skip FRs, but upload everything else.
+; 1 - Normal mode. Everything is uploaded, including FF files with detections.
+; 2 - Skip FFs. Everything except two FF files will be uploaded. One with the
+;     most matched stars and another random one with a meteor detection.
+; 3 - Skip FFs and FRs. Same as option 2, but FR files will also be skipped.
+; 4 - Skip FRs, but upload everything else.
 upload_mode: 1
 
+; Event Monitor
+; -------------
 ; Upload events on demand
 event_monitor_enabled: true
-; Webpage to retrieve watchlist from
+
+; Webpage for watchlist
 event_monitor_webpage: https://globalmeteornetwork.org/events/event_watchlist.txt
+
 ; Where to put the detected events
 event_monitor_remote_dir: files/event_monitor
+
 ; Remote server will be as given in hostname
 
 ; Event monitor check interval (minutes)
@@ -279,144 +331,206 @@ event_monitor_check_interval_fast: 3
 [FireballDetection]
 
 ; Flag for enabling/disabling fireball detection
-enable_fireball_detection: true 
+enable_fireball_detection: true
+
 ; Subsample to 16x16 squares (default 16)
-subsampling_size: 16 
+subsampling_size: 16
+
 ; Weight for stddev in thresholding for fireball extraction
 k1: 7.0
+
 ; Absolute offset in thresholding for fireball extraction
 j1: 10
-; Maximum time in seconds for which line finding algorithm can run (seconds)
+
+; Max runtime (seconds) for the line finding algorithm.
 max_time: 6
-; Average frame level at which the image will not be processed, as it will be deemed too white
-white_avg_level: 220 
-; Absolute minimum brightness in order to consider a pixel (0-255)
-minimal_level: 40 
+
+; Threshold average frame level beyond which images are considered too white to
+; process
+white_avg_level: 220
+
+ ; Absolute minimum brightness in order to consider a pixel (0-255)
+minimal_level: 40
+
 ; How many pixels in a square to consider it as an event point (DEFAULT 8)
-minimum_pixels: 8 
+minimum_pixels: 8
+
 ; Absolute number of points per frame required for flare detection
-max_points_per_frame: 30 
+max_points_per_frame: 30
+
 ; Multiplied with median number of points, used for flare detection
-max_per_frame_factor: 10 
+max_per_frame_factor: 10
+
 ; If there is more event points than this threshold, randomize them
 max_points: 500
-; Minimum number of frames covered by event points (not just one line, but all points)
-min_frames: 6 
+
+; Minimum number of frames covered by event points (not just one line, but all
+; points)
+min_frames: 6
+
 ; Minimum number of event points in a line
-min_points: 8 
-; Percentage of frames to extrapolate before a detected start of a meteor trail
+min_points: 8
+
+; Percent of frames to extrapolate before a meteor trail's detected start
 extend_before: 0.15
-; Percentage of frames to extrapolate after a detected end of a meteor trail 
-extend_after: 0.15 
+
+; Percent of frames to extrapolate after a meteor trail's detected end
+extend_after: 0.15
+
 ; Absolute minimum size for extracted frame crop
 min_window_size: 100
+
 ; Absolute maximum size for extracted frame crop
-max_window_size: 400 
+max_window_size: 400
+
 ; Threshold for dynamically determining window size
 threshold_for_size: 0.9
-; Maximum distance between the line and the point to be takes as a part of the same line 
-distance_threshold: 70 
+
+; Max distance for a point to be considered part of the same line
+distance_threshold: 70
+
 ; Maximum allowed gap between points
-gap_threshold: 150 
-; Minimum range of frames that a line should cover (eliminates flash detections)
-line_minimum_frame_range: 6 
-; Constant that determines the influence of average point distance on the line quality
-line_distance_const: 4 
-; Ratio of how many points must be close to the line before considering searching for another line
-point_ratio_threshold: 0.7 
+gap_threshold: 150
+
+; Minimum frame range a line must span to exclude flash detections
+line_minimum_frame_range: 6
+
+; Constant affecting average point distance's impact on line quality.
+line_distance_const: 4
+
+; Ratio of points near a line needed before seeking another line.
+point_ratio_threshold: 0.7
+
 ; Maximum number of lines which are allowed to be found on the image
-max_lines: 5 
+max_lines: 5
+
 
 
 [MeteorDetection]
 
 ; Minimum number of stars required in order to run the detection
-ff_min_stars: 20
+ff_min_stars: 20 
 
 ; Binning (only supported for videos, images, and vid files, but no FF files!)
 ; -------
-; Bin images before detection (has to be a factor of 2, e.g. 2, 4, 8, etc.). The X, Y coordinates in 
-; detections will be rescaled to the original size. 1 = do not bin.
+; Bin images before detection (has to be a factor of 2, e.g. 2, 4, 8, etc.).
+; The X, Y coordinates in detections will be rescaled to the original size.
+; 1 = do not bin.
 detection_binning_factor: 1 
-; The image can be binned by either averaging ('avg') or summing ('sum') pixel intensities in the bin window.
-; Note that the output image data type is uint16, so be careful of integer overflows when using "sum" method!
+
+; The image can be binned by either averaging ('avg') or summing ('sum') pixel
+; intensities in the bin window. Note that the output image data type is uint16,
+; so be careful of integer overflows when using "sum" method!
 detection_binning_method: avg
 
 ; Thresholding and KHT parameters
 ; -------------------------------
+
 ; Weight for stddev in thresholding for faint meteor detection
 k1: 3.5
+
 ; Absolute levels above average in thresholding for faint meteor detection 
-j1: 12 
-; Maximum ratio of white to all pixels on a thresholded image (used to avoid searching on very messed up 
-; images)
+j1: 12
+
+; Maximum ratio of white to all pixels on a thresholded image
+; (used to avoid searching on very messed up images)
 max_white_ratio: 0.05
-; Size of the time window which will be slided over the time axis 
-time_window_size: 64 
-; Subdivision size of the time axis (256 will be divided into 256/time_slide parts)
-time_slide: 32 
+
+; Size of the time window which will be slided over the time axis
+time_window_size: 64
+
+; Subdivision size of the time axis
+; (256 will be divided into 256/time_slide parts)
+time_slide: 32
+
 ; Maximum number of lines to be found on the time segment with KHT
-max_lines_det: 30 
-; Minimum Frechet distance between KHT lines in Cartesian space to merge them (used for merging similar 
-; lines after KHT)
+max_lines_det: 30
+
+; Minimum Frechet distance to merge KHT lines in Cartesian space
+; (used for merging similar lines after KHT)
 line_min_dist: 50
-; Width of the stripe around the line which will be used for centroiding and photometry
-stripe_width: 28 
+
+; Stripe width around the line for centroiding and photometry
+stripe_width: 28
 
 ; Directory where binaries are built
 kht_build_dir: build
+
 ; Name of the KHT binary
 kht_binary_name: kht_module
+
 ; Extension of the KHT binary
 kht_binary_extension: so
 
 ; 3D matched filter parameters
 ; ----------------------------
-; Maximum number of points during 3D line search in faint meteor detection (used to minimize runtime)
-max_points_det: 500 
-; Maximum distance between the line and the point to be taken as a part of the same line, rescaled to 720x576 (if > 20, it will be divided by subsampling_size^2 to preserve compatibility with older config files)
+
+; Maximum number of points during 3D line search in faint meteor detection
+; (used to minimize runtime)
+max_points_det: 500
+
+; Maximum distance between the line and the point to be taken as a part of the
+; same line, rescaled to 720x576 (if > 20, it will be divided by
+; subsampling_size^2 to preserve compatibility with older config files)
 distance_threshold_det: 5
-; Maximum allowed gap between points in pixels, rescaled to 720x576 (if > 100, it will be divided by subsampling_size^2 to preserve compatibility with older config files)
+
+; Maximum allowed gap between points in pixels, rescaled to 720x576 (if > 100,
+; it will be divided by subsampling_size^2 to preserve ;compatibility with older
+; config files)
 gap_threshold_det: 50
+
 ; Minimum number of pixels in a strip
-min_pixels_det: 10 
+min_pixels_det: 10
+
 ; Minimum number of frames per one detection
-line_minimum_frame_range_det: 4 
-; Constant that determines the influence of average point distance on the line quality
-line_distance_const_det: 4 
+line_minimum_frame_range_det: 4
+
+; Constant that determines the influence of average point distance on the line
+; quality
+line_distance_const_det: 4
+
 ; Maximum time in seconds for which line finding algorithm can run
 max_time_det: 7
 
 ; Postprocessing parameters
 ; -------------------------
+
 ; Angle similarity between 2 lines in a stripe to be merged
-vect_angle_thresh: 20 
-; How many frames to check during centroiding before and after the initially determined frame range
-frame_extension: 10 
+vect_angle_thresh: 20
+
+ ; How many frames to check during centroiding before and after the initially
+ ; determined frame range
+frame_extension: 10
 
 ; Centroiding
 ; ------------
-; Maximum deviation of a centroid point from a LSQ fitted line (if above max, it will be rejected)
-centroids_max_deviation: 2 
-; Maximum distance in pixels between centroids (used for filtering spurious centroids)
-centroids_max_distance: 30 
 
-; Angular velocity filter
-ang_vel_min: 2.0 ; deg/s
-ang_vel_max: 51.0 ; deg/s
+; Maximum deviation of a centroid point from a LSQ fitted line
+; (if above max, it will be rejected)
+centroids_max_deviation: 2
+
+; Maximum distance in pixels between centroids
+; (used for filtering spurious centroids)
+centroids_max_distance: 30
+
+; Angular velocity filter (deg/s)
+ang_vel_min: 2.0
+ang_vel_max: 51.0
 
 ; Filtering by intensity
-; By default the peak of the meteor should be at least 16x brighter than the background. This is the 
-; multiplier that scales this number (1.0 = 16x). Disabled if the ML filter is turned on.
+; By default the peak of the meteor should be at least 16x brighter than the
+; background. This is the  multiplier that scales this number (1.0 = 16x).
+; Disabled if the ML filter is turned on.
 min_patch_intensity_multiplier: 0.0
 
-; Detection filtering by machine learning. This was only optimized on moderate field of view images and
-; IMX291 and IMX307 data. Disable by setting to -1. The recommended threshold is 0.85. This will disable 
+; Detection filtering by machine learning. This was only optimized on moderate
+; field of view images and IMX291 and IMX307 data. Disable by setting to -1.
+; The recommended threshold is 0.85. This will disable
 ; the min_patch_intensity_multiplier filtering method.
 ml_filter: 0.85
 
-
-; Number of CPU cores to use for the detection. If set to <=0, (all cores + num_cores) will be used
+; Number of CPU cores to use for the detection.
+; If set to <=0, (all cores + num_cores) will be used
 num_cores: -1
 
 
@@ -424,88 +538,129 @@ num_cores: -1
 
 ; Extract stars
 ; -------------
+
 ; Maximum mean intensity of an image before it is discarded as too bright
-max_global_intensity: 140 
-; Apply a mask on the detections by removing all that are too close to the given image border (in pixels)
-border: 15 
+max_global_intensity: 140
+
+; Apply a mask on the detections by removing all that are too close to the
+; given image border (in pixels)
+border: 15
+
 ; Size of the neighbourhood for the maximum search (in pixels)
 neighborhood_size: 10
+
 ; A threshold for cutting the detections which are too faint (0-255)
 intensity_threshold: 18
-; An upper limit on number of stars before the PSF fitting (more than that would take too long to process)
+
+; An upper limit on number of stars before the PSF fitting
+; (more than that would take too long to process)
 max_stars: 400
+
 
 ; PSF fit and filtering
 ; ---------------------
-; Radius (in pixels) of image segment around the detected star on which to perform the fit
-segment_radius: 4 
-; Minimum ratio of 2D Gaussian sigma X and sigma Y to be taken as a stars (hot pixels are narrow, while 
-; stars are round)
-roundness_threshold: 0.5 
+
+; Radius (in pixels) of image segment around the detected star on which to
+; perform the fit
+segment_radius: 4
+
+; Minimum ratio of 2D Gaussian sigma X and sigma Y to be taken as a stars
+; (hot pixels are narrow, while stars are round)
+roundness_threshold: 0.5
+
 ; Maximum ratio between 2 sigma of the star and the image segment area
-max_feature_ratio: 0.8 
+max_feature_ratio: 0.8
+
 
 
 [Calibration]
 
 ; True - use flat for calibration, false - do not use flat
-use_flat: false 
+use_flat: false
+
 ; Name of the flat field file
-flat_file: flat.bmp 
+flat_file: flat.bmp
+
 ; Minimum number of FF images for making a flat
-flat_min_imgs: 30 
+flat_min_imgs: 30
+
 
 ; Star catalog
 ; ------------
+
 ; Name of the folder where the star catalog are kept
-star_catalog_path: Catalogs 
+star_catalog_path: Catalogs
+
 ; Catalog file name (GAIA DR2 by default)
-star_catalog_file: gaia_dr2_mag_11.5.npy 
-; Ratio of B, V, R, I bands - use this only for the STARS9TH_VBVRI.txt catalog
-;star_catalog_band_ratios: 0.1,0.32,0.23,0.35 
+star_catalog_file: gaia_dr2_mag_11.5.npy
+
+; Ratio of B, V, R, I bands. use this only for the STARS9TH_VBVRI.txt catalog
+;star_catalog_band_ratios: 0.1,0.32,0.23,0.35
+
 
 ; Platepar
 ; --------
-; The default name of the PlatePar file (DO NOT CHANGE THIS)
-; The operational platepar file is always assumed to be in the same directory as the config file
+
+; The default name of the PlatePar file (DO NOT PUT A FULL PATH HERE, just the
+; name). The operational platepar file is always assumed to be in the same
+; directory as the config file
 platepar_name: platepar_cmn2010.cal 
-; Name of the JSON file with recalibrated platepars for constant intervals of FF files
+
+; Name of the JSON file with recalibrated platepars for constant intervals of FF
+; files
 platepars_flux_recalibrated_name: platepars_flux_recalibrated.json
+
 ; Name of the JSON file with recalibrated platepars for every FF file
 platepars_recalibrated_name: platepars_all_recalibrated.json
+
 ; Name of the new platepar file on the server
-platepar_remote_name: platepar_latest.cal 
+platepar_remote_name: platepar_latest.cal
+
 ; Name of the directory on the server which contains platepars
 remote_platepar_dir: platepars
 
+
 ; Auto recalibration
-; -----------
-; The limiting magnitude of the used stars, used for filtering out catalog stars which are fainter then 
-; the system can detect
+; ------------------
+
+; The limiting magnitude of the used stars, used for filtering out catalog
+; stars which are fainter then the system can detect
 catalog_mag_limit: 5.2
+
 ; How many calstars FF files to evaluate 
-calstars_files_N: 400 
-; Minimum number of stars to use across the whole night for CheckFit
-calstars_min_stars: 1000 
+calstars_files_N: 400
+
+; Minimum number of stars to use
+calstars_min_stars: 1000
+
 ; A minimum number of stars on the image for accepting the image
 min_matched_stars: 20
+
 ; Maximum number of stars to use for the fit on individual images
 recalibration_max_stars: 200
-; If the average distance (pixels) between catalog and image stars is below this threshold, astrometry 
-; recalibration will not run but the existing calibration will be used
-dist_check_threshold: 0.33 
-; If the averge distance (pixels) is below this number, only a quick recalibration procedure will run
+
+; If the average distance (pixels) between catalog and image stars is below
+; this threshold, astrometry recalibration will not run but the existing
+; calibration will be used
+dist_check_threshold: 0.33
+
+; If the averge distance (pixels) is below this number, only a quick
+; recalibration procedure will run
 dist_check_quick_threshold: 0.4
+
 
 
 [Thumbnails]
 
 ; Thumbnail binning
-thumb_bin:      4
+thumb_bin: 4
+
 ; How many images will be stacked per each thumbnail
-thumb_stack:    5
+thumb_stack: 5
+
 ; Number of thumbnails in each row
 thumb_n_width: 10
+
 
 
 [Stack]
@@ -514,14 +669,16 @@ thumb_n_width: 10
 stack_mask: false
 
 
+
 [Timelapse]
 
-; Automatically generate a timelapse using all FF files at the end of the night
+; Automatically generate a timelapse using all FF files
 timelapse_generate_captured: true
 
 
-[Colors]
-; colour palette to use for various charts -can be any matplotlib colour scheme
-; other options are gist_ncar, rainbow, gist_rainbow, inferno 
 
+[Colors]
+
+; color palette to use for various charts -can be any matplotlib color scheme
+; other options are gist_ncar, rainbow, gist_rainbow, inferno 
 shower_color_map: gist_ncar

--- a/.configTemplate
+++ b/.configTemplate
@@ -1,0 +1,684 @@
+; IMPORTANT: Unlike other RMS files, the '.config' file is never automatically
+; updated. When changes are introduced to the config file in RMS, these changes
+; will NOT be automatically reflected in the active '.config' file on 
+; individual machines. Users should manually update their '.config' file if 
+; changing any option from its default value is desired, or to simply stay 
+; up-to-date. If an option is missing from the config file, a default value 
+; will be automatically applied.
+; An up-to-date template config '.configTemplate' file, containing the current
+; options, is located in the RMS root directory.
+; Run python -m Utils.AuditConfig to compare the .config file to the template. 
+
+[System]
+
+; The assigned station ID
+stationID: US9999
+
+; WGS84 +N (degrees)
+latitude: 43.19301
+
+; WGS84 +E (degrees)
+longitude: -81.315555
+
+; Mean sea level EGM96 geoidal datum, not WGS84 ellipsoidal (meters)
+; Can be obtained from Google Earth or other apps. Raw GPS altitude should not
+; be used as the software converts from EGM96 to WGS84 internally.
+elevation: 327
+
+; Should be set only if full CAMS compatibility is desired
+cams_code: 0
+
+; Weblog and PerfMonitor
+; ----------------------
+
+; Show this camera on the GMN weblog
+weblog_enable: false
+
+; The description shown on the weblog (e.g. location, pointing direction)
+weblog_description: none
+
+; Server will generate obfuscated coordinates for public datasets.
+; Optionally, uncomment and populate the three parameters below to use a
+; specific public location if desired. The recommended precision is two decimal
+; places for latitude and longitude, and ~10 m for elevation.
+
+; WGS84 +N (degrees)
+; public_latitude: 0.0
+
+; WGS84 +E (degrees)
+; public_longitude: 0.0
+
+; mean sea level EGM96 (meters)
+; public_elevation: 0.0
+
+; Camera network (e.g. national networks, used for grouping on the weblog).
+; Separate by comma for multiple networks
+network_name: none
+
+; Camera group (e.g. a camera cluster or a location with multiple cameras)
+camera_group_name: none
+
+
+; External script
+; ---------------
+
+; Enable running an external script at the end of every night. it will be passed
+; three arguments: captured_night_dir, archived_night_dir, config 
+external_script_run: false
+
+; Run the external script after auto reprocess.
+; "auto_reprocess" needs to be "true" for this to work.
+auto_reprocess_external_script_run: false
+
+; Full path to the external script
+external_script_path: none
+
+; Name of the function in the external script to be called
+external_function_name: rmsExternal
+
+; Daily reboot
+; ---------------
+
+; Reboot the computer daily after processing and upload
+reboot_after_processing: true
+
+; Lock file name for preventing rebooting until the script is done.
+; The external script should remove this file if the reboot is to run after the
+; script finishes. This file should be created in the config.data_dir directory
+; (i.e. ~/RMS_data).
+reboot_lock_file: .reboot_lock
+
+
+
+[Capture]
+
+; device URL
+device: rtsp://192.168.42.10:554/user=admin&password=&channel=1&stream=0.sdp
+
+; Transport Layer Protocol: 'tcp' or 'udp'. Defaults to tcp. UDP typically
+; provides more stable connectivity, but TCP has a longer track record.
+protocol: tcp
+
+; Media Backend: options are gst, cv2, or v4l2.
+; 'gst':    (default - preferred) GStreamer Standalone. Bypass OpenCV, and
+;           provides the highest timestamps accuracy.
+; 'cv2':    OpenCV method. Reliable but has poor timestamping performance. 
+; 'v4l2':   OpenCV with v4l2, uses v4l2 hardware acceleration with OpenCV.
+; If gst, or v4l2 return an error, the code reverts to cv2.
+media_backend: gst
+
+; Gstreamer color space to use. Only applicable if media_backend is gst.
+; Examples: BGR, GRAY8
+gst_colorspace: BGR
+
+; Gstreamer decoder element to use. Only applicable if media_backend is gst.
+; Examples: decodebin, avdec_h264, nvh264dec
+gst_decoder: avdec_h264
+
+# Location of the raw videos to be saved to disk (None means no saving).
+raw_video_dir: None
+
+# Save the raw video to the night directory.
+# If True, the raw_video_dir is ignored.
+raw_video_dir_night: False
+
+# Duration of the raw video segment (seconds).
+# If -1, the segment duration will be 256/FPS seconds
+raw_video_duration: 30
+
+uyvy_pixelformat: false
+
+; The capture device resolution
+width: 1280
+height: 720
+
+; Frames per second (FPS) are precisely calculated and reported at the end of
+; each capture session when in GStreamer standalone mode. This information can
+; be found in each session's log by searching for 'Last Calculated FPS'. Please
+; update the value here with the log's reported value. The calculate FPS
+; often differs from the nominal FPS, usually by less than 0.1%.
+; Example: fps: 24.98122
+fps: 25.0
+
+; Camera Latency Settings for GStreamer Timestamps
+; ------------------------------------------------
+; The following two parameters correct for camera latency when in GStreamer
+; Standalone mode. The settings are ignored when using other media_backend
+; methods.
+; The settings should be experimentally establishes for the specific setup.
+; For example:  RPi4, IMX291, 720p @ 25 FPS, VBR
+;               camera_buffer: 1
+;               camera_latency: 0.05
+; If timestamps are late, increase latency. If early, decrease latency.
+; Formula is:
+; corrected_timestamp = timestamp - camera_buffer / fps - total_latency
+; camera_buffer corresponds to the number of frames in the camera's internal
+; buffer. If these parameters are not present then RMS will use the default. 
+
+; frames (integer). Default is 1
+camera_buffer: 1
+
+; delay in seconds. Default is 0.05 s (50 ms)
+camera_latency: 0.05
+
+; Log dropped frames. Only reliable for analog cameras
+report_dropped_frames: false
+
+; Region of interest. -1 to disable
+roi_left: -1
+roi_right: -1
+roi_up: -1
+roi_down: -1
+
+; Bit depth of the camera (e.g. an 8-bit camera)
+bit_depth: 8
+
+; Gamma of the camera. Usually 0.45 or 1.0
+gamma: 1.0
+
+; Format of files, either 'bin' (CAMS format), or 'fits' (new RMS format)
+ff_format: fits
+
+; Approximate Field-of-view in degrees
+fov_w: 87
+fov_h: 45
+
+; Deinterlacing:    -2 = global shutter
+;                   -1 = rolling shutter
+;                    0 = even first
+;                    1 = odd first
+deinterlace_order: -1
+
+; A mask applied to images to prevent detection in the masked area
+; Must be located in the same directory as the config file
+; DO NOT CHANGE
+mask: mask.bmp
+
+; Path to the directory where all data will be stored
+data_dir: ~/RMS_data
+
+; Name of directory within data_dir for raw captured files
+captured_dir: CapturedFiles
+
+; Name of directory within data_dir for archived files
+archived_dir: ArchivedFiles
+
+; Name of directory within data_dir for log files
+log_dir: logs
+
+; Extra GB space left on the SD card nightly, accounting for the predicted
+; size of all FF files.
+extra_space_gb: 5
+
+; By default the system will keep 20 ArchivedFiles folders and compressed
+; versions of the folders. You can adjust these limits using the below
+; parameters. A value of zero means do nothing ie keep everything forever.
+
+; number of ArchivedFiles folders to keep. Default is 20
+arch_dirs_to_keep: 20
+
+; number of days of logs to keep. Default is 30
+logdays_to_keep: 30
+
+; number of bz2 compressed archive folders to keep. Default 20
+bz2_files_to_keep: 20
+
+
+; Toggle showing maxpixel on the screen during capture
+live_maxpixel_enable: false
+
+; Toggle saving a single jpg with the latest maxpixel image in the data dir
+live_jpg: false
+
+; Toggle daytime slideshow of last night's meteor detections
+slideshow_enable: false
+
+; Auto-reprocess broken capture directories after power cuts or crashes
+auto_reprocess: true
+
+; Prioritize capture over reprocessing.
+; Do not start reprocessing a new directory if should be capturing
+prioritize_capture_over_reprocess: false
+
+; Flag file to load processed files on capture resume
+capture_resume_flag_file: .capture_resuming
+
+; Additional wait time (seconds) for staggered start in multi-camera setups
+capture_wait_seconds: 0
+
+; Randomize wait time (0 to capture_wait_seconds) for multi-camera systems.
+capture_wait_randomize: false
+
+; Process detection and postprocessing at night's end, not during capture.
+postprocess_at_end: false
+
+; Add extra seconds before starting detection: after capture begins if
+; postprocess_at_end is false, or after capture ends if true.
+postprocess_delay: 0
+
+
+
+[Build]
+
+; Compiler arguments for cython
+rpi_weave: -O3 -mfpu=neon -funsafe-loop-optimizations -ftree-loop-if-convert-stores
+linux_pc_weave: -O3
+win_pc_weave: -Wall
+
+
+
+[Upload]
+
+; Flag for enabling/disabling upload to meteor server
+upload_enabled: true
+
+; Delay upload for the given number of minutes
+upload_delay: 0
+
+; Server address
+hostname: gmn.uwo.ca
+
+; Standard SSH port
+host_port: 22
+
+; Path to the SSH private key
+rsa_private_key: ~/.ssh/id_rsa
+
+; Directory on the server where the detected files will be uploaded to
+remote_dir: files
+
+; Name of the file where the upload queue will be stored
+upload_queue_file: FILES_TO_UPLOAD.inf
+
+; Upload mode
+; -----------
+; By default, RMS will upload text files with meteor and star detections,
+; secondary data products such as calibration plots, all FF image files, and all
+; FR files with raw fireball frames. This typically results in an archive of
+; 100-500 MB in size. Some stations have limited data or bad internet
+; connections, so a reduced data set can be uploaded to the server.
+; Options:
+; 1 - Normal mode. Everything is uploaded, including FF files with detections.
+; 2 - Skip FFs. Everything except two FF files will be uploaded. One with the
+;     most matched stars and another random one with a meteor detection.
+; 3 - Skip FFs and FRs. Same as option 2, but FR files will also be skipped.
+; 4 - Skip FRs, but upload everything else.
+upload_mode: 1
+
+; Event Monitor
+; -------------
+; Upload events on demand
+event_monitor_enabled: true
+
+; Webpage for watchlist
+event_monitor_webpage: https://globalmeteornetwork.org/events/event_watchlist.txt
+
+; Where to put the detected events
+event_monitor_remote_dir: files/event_monitor
+
+; Remote server will be as given in hostname
+
+; Event monitor check interval (minutes)
+event_monitor_check_interval: 30
+event_monitor_check_interval_fast: 3
+
+
+
+[Compression]
+
+
+
+[FireballDetection]
+
+; Flag for enabling/disabling fireball detection
+enable_fireball_detection: true
+
+; Subsample to 16x16 squares (default 16)
+subsampling_size: 16
+
+; Weight for stddev in thresholding for fireball extraction
+k1: 7.0
+
+; Absolute offset in thresholding for fireball extraction
+j1: 10
+
+; Max runtime (seconds) for the line finding algorithm.
+max_time: 6
+
+; Threshold average frame level beyond which images are considered too white to
+; process
+white_avg_level: 220
+
+ ; Absolute minimum brightness in order to consider a pixel (0-255)
+minimal_level: 40
+
+; How many pixels in a square to consider it as an event point (DEFAULT 8)
+minimum_pixels: 8
+
+; Absolute number of points per frame required for flare detection
+max_points_per_frame: 30
+
+; Multiplied with median number of points, used for flare detection
+max_per_frame_factor: 10
+
+; If there is more event points than this threshold, randomize them
+max_points: 500
+
+; Minimum number of frames covered by event points (not just one line, but all
+; points)
+min_frames: 6
+
+; Minimum number of event points in a line
+min_points: 8
+
+; Percent of frames to extrapolate before a meteor trail's detected start
+extend_before: 0.15
+
+; Percent of frames to extrapolate after a meteor trail's detected end
+extend_after: 0.15
+
+; Absolute minimum size for extracted frame crop
+min_window_size: 100
+
+; Absolute maximum size for extracted frame crop
+max_window_size: 400
+
+; Threshold for dynamically determining window size
+threshold_for_size: 0.9
+
+; Max distance for a point to be considered part of the same line
+distance_threshold: 70
+
+; Maximum allowed gap between points
+gap_threshold: 150
+
+; Minimum frame range a line must span to exclude flash detections
+line_minimum_frame_range: 6
+
+; Constant affecting average point distance's impact on line quality.
+line_distance_const: 4
+
+; Ratio of points near a line needed before seeking another line.
+point_ratio_threshold: 0.7
+
+; Maximum number of lines which are allowed to be found on the image
+max_lines: 5
+
+
+
+[MeteorDetection]
+
+; Minimum number of stars required in order to run the detection
+ff_min_stars: 20 
+
+; Binning (only supported for videos, images, and vid files, but no FF files!)
+; -------
+; Bin images before detection (has to be a factor of 2, e.g. 2, 4, 8, etc.).
+; The X, Y coordinates in detections will be rescaled to the original size.
+; 1 = do not bin.
+detection_binning_factor: 1 
+
+; The image can be binned by either averaging ('avg') or summing ('sum') pixel
+; intensities in the bin window. Note that the output image data type is uint16,
+; so be careful of integer overflows when using "sum" method!
+detection_binning_method: avg
+
+; Thresholding and KHT parameters
+; -------------------------------
+
+; Weight for stddev in thresholding for faint meteor detection
+k1: 3.5
+
+; Absolute levels above average in thresholding for faint meteor detection 
+j1: 12
+
+; Maximum ratio of white to all pixels on a thresholded image
+; (used to avoid searching on very messed up images)
+max_white_ratio: 0.05
+
+; Size of the time window which will be slided over the time axis
+time_window_size: 64
+
+; Subdivision size of the time axis
+; (256 will be divided into 256/time_slide parts)
+time_slide: 32
+
+; Maximum number of lines to be found on the time segment with KHT
+max_lines_det: 30
+
+; Minimum Frechet distance to merge KHT lines in Cartesian space
+; (used for merging similar lines after KHT)
+line_min_dist: 50
+
+; Stripe width around the line for centroiding and photometry
+stripe_width: 28
+
+; Directory where binaries are built
+kht_build_dir: build
+
+; Name of the KHT binary
+kht_binary_name: kht_module
+
+; Extension of the KHT binary
+kht_binary_extension: so
+
+; 3D matched filter parameters
+; ----------------------------
+
+; Maximum number of points during 3D line search in faint meteor detection
+; (used to minimize runtime)
+max_points_det: 500
+
+; Maximum distance between the line and the point to be taken as a part of the
+; same line, rescaled to 720x576 (if > 20, it will be divided by
+; subsampling_size^2 to preserve compatibility with older config files)
+distance_threshold_det: 5
+
+; Maximum allowed gap between points in pixels, rescaled to 720x576 (if > 100,
+; it will be divided by subsampling_size^2 to preserve ;compatibility with older
+; config files)
+gap_threshold_det: 50
+
+; Minimum number of pixels in a strip
+min_pixels_det: 10
+
+; Minimum number of frames per one detection
+line_minimum_frame_range_det: 4
+
+; Constant that determines the influence of average point distance on the line
+; quality
+line_distance_const_det: 4
+
+; Maximum time in seconds for which line finding algorithm can run
+max_time_det: 7
+
+; Postprocessing parameters
+; -------------------------
+
+; Angle similarity between 2 lines in a stripe to be merged
+vect_angle_thresh: 20
+
+ ; How many frames to check during centroiding before and after the initially
+ ; determined frame range
+frame_extension: 10
+
+; Centroiding
+; ------------
+
+; Maximum deviation of a centroid point from a LSQ fitted line
+; (if above max, it will be rejected)
+centroids_max_deviation: 2
+
+; Maximum distance in pixels between centroids
+; (used for filtering spurious centroids)
+centroids_max_distance: 30
+
+; Angular velocity filter (deg/s)
+ang_vel_min: 2.0
+ang_vel_max: 51.0
+
+; Filtering by intensity
+; By default the peak of the meteor should be at least 16x brighter than the
+; background. This is the  multiplier that scales this number (1.0 = 16x).
+; Disabled if the ML filter is turned on.
+min_patch_intensity_multiplier: 0.0
+
+; Detection filtering by machine learning. This was only optimized on moderate
+; field of view images and IMX291 and IMX307 data. Disable by setting to -1.
+; The recommended threshold is 0.85. This will disable
+; the min_patch_intensity_multiplier filtering method.
+ml_filter: 0.85
+
+; Number of CPU cores to use for the detection.
+; If set to <=0, (all cores + num_cores) will be used
+num_cores: -1
+
+
+[StarExtraction]
+
+; Extract stars
+; -------------
+
+; Maximum mean intensity of an image before it is discarded as too bright
+max_global_intensity: 140
+
+; Apply a mask on the detections by removing all that are too close to the
+; given image border (in pixels)
+border: 15
+
+; Size of the neighbourhood for the maximum search (in pixels)
+neighborhood_size: 10
+
+; A threshold for cutting the detections which are too faint (0-255)
+intensity_threshold: 18
+
+; An upper limit on number of stars before the PSF fitting
+; (more than that would take too long to process)
+max_stars: 400
+
+
+; PSF fit and filtering
+; ---------------------
+
+; Radius (in pixels) of image segment around the detected star on which to
+; perform the fit
+segment_radius: 4
+
+; Minimum ratio of 2D Gaussian sigma X and sigma Y to be taken as a stars
+; (hot pixels are narrow, while stars are round)
+roundness_threshold: 0.5
+
+; Maximum ratio between 2 sigma of the star and the image segment area
+max_feature_ratio: 0.8
+
+
+
+[Calibration]
+
+; True - use flat for calibration, false - do not use flat
+use_flat: false
+
+; Name of the flat field file
+flat_file: flat.bmp
+
+; Minimum number of FF images for making a flat
+flat_min_imgs: 30
+
+
+; Star catalog
+; ------------
+
+; Name of the folder where the star catalog are kept
+star_catalog_path: Catalogs
+
+; Catalog file name (GAIA DR2 by default)
+star_catalog_file: gaia_dr2_mag_11.5.npy
+
+; Ratio of B, V, R, I bands. use this only for the STARS9TH_VBVRI.txt catalog
+;star_catalog_band_ratios: 0.1,0.32,0.23,0.35
+
+
+; Platepar
+; --------
+
+; The default name of the PlatePar file (DO NOT PUT A FULL PATH HERE, just the
+; name). The operational platepar file is always assumed to be in the same
+; directory as the config file
+platepar_name: platepar_cmn2010.cal 
+
+; Name of the JSON file with recalibrated platepars for constant intervals of FF
+; files
+platepars_flux_recalibrated_name: platepars_flux_recalibrated.json
+
+; Name of the JSON file with recalibrated platepars for every FF file
+platepars_recalibrated_name: platepars_all_recalibrated.json
+
+; Name of the new platepar file on the server
+platepar_remote_name: platepar_latest.cal
+
+; Name of the directory on the server which contains platepars
+remote_platepar_dir: platepars
+
+
+; Auto recalibration
+; ------------------
+
+; The limiting magnitude of the used stars, used for filtering out catalog
+; stars which are fainter then the system can detect
+catalog_mag_limit: 5.2
+
+; How many calstars FF files to evaluate 
+calstars_files_N: 400
+
+; Minimum number of stars to use
+calstars_min_stars: 1000
+
+; A minimum number of stars on the image for accepting the image
+min_matched_stars: 20
+
+; Maximum number of stars to use for the fit on individual images
+recalibration_max_stars: 200
+
+; If the average distance (pixels) between catalog and image stars is below
+; this threshold, astrometry recalibration will not run but the existing
+; calibration will be used
+dist_check_threshold: 0.33
+
+; If the averge distance (pixels) is below this number, only a quick
+; recalibration procedure will run
+dist_check_quick_threshold: 0.4
+
+
+
+[Thumbnails]
+
+; Thumbnail binning
+thumb_bin: 4
+
+; How many images will be stacked per each thumbnail
+thumb_stack: 5
+
+; Number of thumbnails in each row
+thumb_n_width: 10
+
+
+
+[Stack]
+
+; Whether to apply the mask to stack or not
+stack_mask: false
+
+
+
+[Timelapse]
+
+; Automatically generate a timelapse using all FF files
+timelapse_generate_captured: true
+
+
+
+[Colors]
+
+; color palette to use for various charts -can be any matplotlib color scheme
+; other options are gist_ncar, rainbow, gist_rainbow, inferno 
+shower_color_map: gist_ncar

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -353,6 +353,8 @@ class Config:
 
         # Automatically reprocess broken capture directories
         self.auto_reprocess = True
+
+        # Prioritize capture over reprocessing - do not start reprocessing a new directory if should be capturing
         self.prioritize_capture_over_reprocess = False
 
         # Flag file which indicates that the previously processed files are loaded during capture resume
@@ -818,10 +820,6 @@ def parseSystem(config, parser):
     if parser.has_option(section, "auto_reprocess_external_script_run"):
         config.auto_reprocess_external_script_run = parser.getboolean(section, \
             "auto_reprocess_external_script_run")
-
-    if parser.has_option(section, "prioritize_capture_over_reprocess"):
-        config.prioritize_capture_over_reprocess = parser.getboolean(section, \
-            "prioritize_capture_over_reprocess")
 
     if parser.has_option(section, "external_script_path"):
         config.external_script_path = parser.get(section, "external_script_path")

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -436,11 +436,14 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
         # Make the name of the audit file
         audit_file_name = night_data_dir_name.replace("_detected", "") + "_config_audit_report.txt"
 
-        # Construct the full path for the audit file
+        # Construct the full path for files
         audit_file_path = os.path.join(night_data_dir, audit_file_name)
+        config_file_path = os.path.join(night_data_dir, ".config")
 
         with open(audit_file_path, 'w') as f:
-            f.write(compareConfigs(night_data_dir, './.configTemplate', './RMS/ConfigReader.py'))
+            f.write(compareConfigs(config_file_path,
+                                   os.path.join(config.rms_root_dir, ".configTemplate"),
+                                   os.path.join(config.rms_root_dir, "RMS/ConfigReader.py")))
 
         extra_files.append(audit_file_path)
 

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -37,6 +37,8 @@ from Utils.RMS2UFO import FTPdetectinfo2UFOOrbitInput
 from Utils.ShowerAssociation import showerAssociation
 from Utils.PlotTimeIntervals import plotFFTimeIntervals
 from Utils.TimestampRMSVideos import timestampRMSVideos
+from Utils.AuditConfig import compareConfigs
+
 
 # Get the logger from the main module
 log = logging.getLogger("logger")
@@ -426,6 +428,24 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
     except Exception as e:
         log.debug('Plotting timestamp interval failed with message:\n' + repr(e))
+        log.debug(repr(traceback.format_exception(*sys.exc_info())))
+
+    # Generate a config audit report
+    log.info('Generate config audit report')
+    try:
+        # Make the name of the audit file
+        audit_file_name = night_data_dir_name.replace("_detected", "") + "_config_audit_report.txt"
+
+        # Construct the full path for the audit file
+        audit_file_path = os.path.join(night_data_dir, audit_file_name)
+
+        with open(audit_file_path, 'w') as f:
+            f.write(compareConfigs(night_data_dir, './.configTemplate', './RMS/ConfigReader.py'))
+
+        extra_files.append(audit_file_path)
+
+    except Exception as e:
+        log.debug('Generating config audit failed with message:\n' + repr(e))
         log.debug(repr(traceback.format_exception(*sys.exc_info())))
 
 

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -249,7 +249,9 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
 
     # Audit config file
     try:
-        log.info(compareConfigs(night_data_dir, './configTemplate', './RMS/ConfigReader.py'))
+        log.info(compareConfigs(config.config_file_name,
+                                os.path.join(config.rms_root_dir, ".configTemplate"),
+                                os.path.join(config.rms_root_dir, "RMS/ConfigReader.py")))
     except Exception as e:
         log.debug('Could not generate config audit report:' + repr(e))
 

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -51,6 +51,7 @@ from RMS.RunExternalScript import runExternalScript
 from RMS.UploadManager import UploadManager
 from RMS.EventMonitor import EventMonitor
 from RMS.DownloadMask import downloadNewMask
+from Utils.AuditConfig import compareConfigs
 
 # Flag indicating that capturing should be stopped
 STOP_CAPTURE = False
@@ -245,6 +246,12 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
             shutil.copy2(config.config_file_name, os.path.join(night_data_dir, ".config"))
         except:
             log.error("Cannot copy the config file to the capture directory!")
+
+    # Audit config file
+    try:
+        log.info(compareConfigs(night_data_dir, './configTemplate', './RMS/ConfigReader.py'))
+    except Exception as e:
+        log.debug('Could not generate config audit report:' + repr(e))
 
     # Check for and get an updated mask
     if config.mask_download_permissive:

--- a/Utils/AuditConfig.py
+++ b/Utils/AuditConfig.py
@@ -69,6 +69,18 @@ def checkCommentedOptions(config_path, options):
     return commented_out_options
 
 
+def validatePath(path, file_name):
+    """Validate if the given path includes a filename and exists."""
+    if not os.path.basename(path):
+        raise ValueError(f"'{path}' does not include a filename.")
+    
+    abs_path = os.path.abspath(path)
+    if not os.path.exists(abs_path):
+        raise FileNotFoundError(f"{file_name} not found. Tried to find it at absolute path: '{abs_path}'")
+    
+    return abs_path   
+
+
 def compareConfigs(config_path, template_path, configreader_path, dev_report=False):
     """Audit .config, and optionally .configTemplate, by comparing options between '.config',
     '.configTemplate', and 'ConfigReader.py'
@@ -82,6 +94,17 @@ def compareConfigs(config_path, template_path, configreader_path, dev_report=Fal
     Returns:
         str: A formatted string containing the comparison results
     """
+    
+    # Validate input paths
+    validatePath(config_path, ".config file")
+    validatePath(template_path, ".configTemplate")
+    validatePath(configreader_path, "ConfigReader.py")
+    
+    # print(f"Using the following files:")
+    # print(f"  Config file: {config_path}")
+    # print(f"  Template file: {template_path}")
+    # print(f"  ConfigReader file: {configreader_path}")
+    # print()
 
     # Gather options from all three files
     config_file_options = parseConfigFile(config_path)
@@ -108,6 +131,7 @@ def compareConfigs(config_path, template_path, configreader_path, dev_report=Fal
 
     # Generate report
     output = []
+    output.append("")
     output.append("=" * 80)
     output.append("CONFIG COMPARISON RESULTS".center(80))
     output.append("=" * 80 + "\n")
@@ -199,12 +223,10 @@ if __name__ == "__main__":
 
     #########################
 
-    config_path = cml_args.config_path
-    configTemplate_path = cml_args.template
-    configreader_path = cml_args.configreader
-
-    checkFileExists(config_path, ".config file")
-    checkFileExists(configTemplate_path, ".configTemplate")
-    checkFileExists(configreader_path, "ConfigReader.py")
-
-    print(compareConfigs(config_path, configTemplate_path, configreader_path, dev_report=cml_args.dev))
+    try:
+        print(compareConfigs(cml_args.config_path, cml_args.template, cml_args.configreader,
+                             dev_report=cml_args.dev))
+        
+    except (ValueError, FileNotFoundError) as e:
+        print(f"Error: {str(e)}")
+        exit(1)

--- a/Utils/AuditConfig.py
+++ b/Utils/AuditConfig.py
@@ -134,8 +134,8 @@ if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser(description="Compare either .configTemplate or ConfigReader.py "
                                          "options with .config file options.")
 
-    arg_parser.add_argument("config_path", default="./.config", help="Path to the .config file")
-
+    arg_parser.add_argument("config_path", nargs='?', default="./.config", help="Path to the .config file")
+    
     arg_parser.add_argument('-r', '--cr', action="store_true", \
         help="""Use ConfigReader options as reference. """)
 
@@ -154,11 +154,11 @@ if __name__ == "__main__":
     configreader_path = cml_args.configreader
     configTemplate_path = cml_args.template
 
-    if not os.path.exists(configreader_path) and cml_args.cr:
+    if not os.path.exists(configreader_path):
         print(f"Error: ConfigReader.py not found at {configreader_path}")
         exit(1)
 
-    if not os.path.exists(configTemplate_path) and not cml_args.cr:
+    if not os.path.exists(configTemplate_path):
         print(f"Error: .configTemplate not found at {configTemplate_path}")
         exit(1)
 

--- a/Utils/AuditConfig.py
+++ b/Utils/AuditConfig.py
@@ -1,0 +1,172 @@
+import re
+import configparser
+import argparse
+import os
+
+
+def extractConfigOptions(file_path):
+    """Extract configuration options from ConfigReader.py
+    
+    Arguments:
+        file_path: [str] Path to the ConfigReader.py file
+    
+    """
+
+    options = set()
+
+    # Ignore DFNS specific options
+    excluded_words = {'lat', 'lon', 'location', 'altitude'}
+
+    with open(file_path, 'r') as file:
+        content = file.read()
+        # Look for patterns like parser.has_option(section, "option_name")
+        matches = re.findall(r'parser\.has_option\([^,]+,\s*["\'](\w+)["\']', content)
+        options.update(match.lower() for match in matches if match.lower() not in excluded_words)
+    return options
+
+
+def parseConfigFile(config_path):
+    """Parse the .config file, excluding specific words
+    
+    Arguments:
+        config_path: [str] Path to the .config file
+
+    """
+
+    config = configparser.ConfigParser()
+    config.read(config_path)
+    options = set()
+
+    # Ignore stationID which is a special case
+    excluded_words = {'stationid'}
+
+    for section in config.sections():
+        for option in config.options(section):
+            if option.lower() not in excluded_words:
+                options.add(option.lower())
+
+    return options
+
+def check_commented_options(config_path, options):
+    commented_out_options = set()
+    
+    if not os.path.exists(config_path):
+        print(f"Config file {config_path} does not exist.")
+        return commented_out_options
+
+    with open(config_path, 'r') as file:
+        lines = file.readlines()
+        
+    for option in options:
+        commented_option_1 = f";{option}:"
+        commented_option_2 = f"; {option}:"
+        for line in lines:
+            if commented_option_1 in line or commented_option_2 in line:
+                commented_out_options.add(option.lower())
+                break
+    
+    return commented_out_options
+
+
+def compareConfigs(reference_path, config_path, template=True):
+    """Compare ConfigReader.py options with .config file options
+
+    Arguments:
+        reference_path: [str] Path to the ConfigReader.py or the .configTemplate file
+        config_path: [str] Path to the .config file
+
+    """
+    
+    config_file_options = parseConfigFile(config_path)
+
+    if template:
+        reference_file_options = parseConfigFile(reference_path)
+
+    else:
+        reference_file_options = extractConfigOptions(reference_path)
+
+    missing_in_config = reference_file_options - config_file_options
+    extra_in_config = config_file_options - reference_file_options
+
+    commented_options = check_commented_options(config_path, missing_in_config)
+    missing_in_config -= commented_options
+
+    print("\n" + "="*80)
+    print("CONFIG COMPARISON RESULTS".center(80))
+    print("="*80 + "\n")
+
+    if missing_in_config:
+        print("OPTIONS NOT IN .CONFIG FILE (default values will be used):".center(80))
+        print("-"*80)
+        for option in sorted(missing_in_config):
+            print(f"  • {option}")
+        print()
+
+    if commented_options:
+        print("OPTIONS COMMENTED OUT IN .CONFIG FILE (default values will be used):".center(80))
+        print("-"*80)
+        for option in sorted(commented_options):
+            print(f"  • {option}")
+        print()
+
+    if extra_in_config:
+        print("OPTIONS IN .CONFIG FILE NOT IMPLEMENTED IN CONFIGREADER (will be ignored):".center(80))
+        print("-"*80)
+        for option in sorted(extra_in_config):
+            print(f"  • {option}")
+        print()
+
+    if not missing_in_config and not extra_in_config:
+        print("All options match between ConfigReader.py and .config file.".center(80))
+        print()
+
+    print("="*80)
+    print(f"Total options in reference: {len(reference_file_options)}".center(80))
+    print(f"Total options in .config file: {len(config_file_options)}".center(80))
+    print(f"Common options: {len(reference_file_options.intersection(config_file_options))}".center(80))
+    print("="*80 + "\n")
+
+
+if __name__ == "__main__":
+    ### COMMAND LINE ARGUMENTS
+
+    # Init the command line arguments parser
+    arg_parser = argparse.ArgumentParser(description="Compare either .configTemplate or ConfigReader.py "
+                                         "options with .config file options.")
+
+    arg_parser.add_argument("config_path", default="./.config", help="Path to the .config file")
+
+    arg_parser.add_argument('-r', '--cr', action="store_true", \
+        help="""Use ConfigReader options as reference. """)
+
+    arg_parser.add_argument("--template", default="./.configTemplate",
+                        help="Path to .configTemplate (default: ./.configTemplate)")
+
+    arg_parser.add_argument("--configreader", default="./RMS/ConfigReader.py",
+                        help="Path to ConfigReader.py (default: ./RMS/ConfigReader.py)")
+    
+    # Parse the command line arguments
+    cml_args = arg_parser.parse_args()
+
+    #########################
+
+    config_path = cml_args.config_path
+    configreader_path = cml_args.configreader
+    configTemplate_path = cml_args.template
+
+    if not os.path.exists(configreader_path) and cml_args.cr:
+        print(f"Error: ConfigReader.py not found at {configreader_path}")
+        exit(1)
+
+    if not os.path.exists(configTemplate_path) and not cml_args.cr:
+        print(f"Error: .configTemplate not found at {configTemplate_path}")
+        exit(1)
+
+    if not os.path.exists(config_path):
+        print(f"Error: .config file not found at {config_path}")
+        exit(1)
+
+    if cml_args.cr:
+        compareConfigs(configreader_path, config_path,template=False)
+    else:
+        compareConfigs(configTemplate_path, config_path,template=True)


### PR DESCRIPTION
I'm proposing the following changes to `.config`:

Restyling:
- Move inline comments to a separate line (per Denis request).
- 80-character line limit (per Denis request).
- Various cleanups

`.config` is the only RMS source file that does not automatically update on production machines. Individual operators are responsible for any change to their `.config` files. However, operators may not be aware that new options have been introduced, or old options removed. Therefore, the '.config' file tends to be out-of-date with the rest of the code base on many installations.

I'm proposing the following to try to make things easier for operators:

- Add a template config file, `.configTemplate`,  in the RMS root directory. Yes, operators could just look at the GitHub version, but I think having it in the RMS root folder would be more convenient and more likely to be noticed.
- Add an explanatory note at the beginning of `.config`
- Add an audit tool to quickly highlight the difference between a `.config` file and the template
- Generate an automatic report at the start of capture where it is more likely to be noticed
- Generate a text file in archive where it can be referenced.

To make things easier for developers, the tool can also compare the template config to options supported  in `ConfigReader.py`. The tool highlights obsolete options and options not present in the template.

I've also removed duplicate entries in ConfigReader.

Here's an example of the report generated to the user. There might be reasons not to include certain options in the report - this can be done with an omit list.

```
================================================================================
                           CONFIG COMPARISON RESULTS                            
================================================================================

             OPTIONS MISSING IN .CONFIG FILE (PRESENT IN TEMPLATE)              
             ****** CONSIDER MANUALLY UPDATING .CONFIG FILE ******              
                          Default values will be used:                          
--------------------------------------------------------------------------------
 • camera_buffer
 • camera_latency

                     OPTIONS COMMENTED OUT IN .CONFIG FILE                      
                          Default values will be used:                          
--------------------------------------------------------------------------------
 • public_elevation
 • public_latitude
 • public_longitude
 • star_catalog_band_ratios

================================================================================
                         Total options in template: 157                         
                       Total options in .config file: 155                       
                              Common options: 155                               
================================================================================

```

Here's an example with `--dev` flag:
```

================================================================================
                           CONFIG COMPARISON RESULTS                            
================================================================================

             OPTIONS MISSING IN .CONFIG FILE (PRESENT IN TEMPLATE)              
             ****** CONSIDER MANUALLY UPDATING .CONFIG FILE ******              
                          Default values will be used:                          
--------------------------------------------------------------------------------
 • camera_buffer
 • camera_latency

            OPTIONS MISSING IN TEMPLATE FILE BUT IMPLEMENTED IN RMS:            
--------------------------------------------------------------------------------
 • brightness
 • contrast
 • dark_file
 • event_monitor_db_name
 • force_v4l2
 • mask_download_permissive
 • mask_remote_name
 • min_lines
 • platepar_template_dir
 • remote_mask_dir
 • use_dark

                     OPTIONS COMMENTED OUT IN .CONFIG FILE                      
                          Default values will be used:                          
--------------------------------------------------------------------------------
 • public_elevation
 • public_latitude
 • public_longitude
 • star_catalog_band_ratios

                    OPTIONS COMMENTED OUT IN TEMPLATE FILE:                     
--------------------------------------------------------------------------------
 • public_elevation
 • public_latitude
 • public_longitude
 • star_catalog_band_ratios

================================================================================
                         Total options in template: 157                         
                       Total options in .config file: 155                       
                              Common options: 155                               
================================================================================

```

Usage example:
`python -m Utils.AuditConfig`
`python -m Utils.AuditConfig --dev`