### PR TITLE
Fix for kht_binary_search

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -125,7 +125,7 @@ def findBinaryPath(config, dir_path, binary_name, binary_extension):
             binary_dir_version = binary_dir.split('-')[-1]
 
 
-            # the binary directory may or may not contain a dot in the directory name
+            # the binary directory may or may not contain a dot in the version
             # e.g lib.linux-x86_64-3.7 vs lib.linux-x86_64-cpython-311
             if '.' in binary_dir_version:
                 py_version = "{:d}.{:d}".format(sys.version_info.major, sys.version_info.minor)

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -114,7 +114,10 @@ def findBinaryPath(config, dir_path, binary_name, binary_extension):
     else:
         # If there are more candidates, find the right one for the running version of python, platform, and
         #   bits
-        py_version = "{:d}.{:d}".format(sys.version_info.major, sys.version_info.minor)
+        if sys.version_info.minor <= 9:
+            py_version = "{:d}.{:d}".format(sys.version_info.major, sys.version_info.minor)
+        else:
+            py_version = "{:d}{:d}".format(sys.version_info.major, sys.version_info.minor)
 
         # Find the compiled module for the correct python version
         for file_path in file_candidates:

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -114,19 +114,26 @@ def findBinaryPath(config, dir_path, binary_name, binary_extension):
     else:
         # If there are more candidates, find the right one for the running version of python, platform, and
         #   bits
-        if sys.version_info.minor <= 9:
-            py_version = "{:d}.{:d}".format(sys.version_info.major, sys.version_info.minor)
-        else:
-            py_version = "{:d}{:d}".format(sys.version_info.major, sys.version_info.minor)
+
 
         # Find the compiled module for the correct python version
         for file_path in file_candidates:
             
             # Extract the name of the dir where the binary is located
             binary_dir = os.path.split(os.path.split(file_path)[0])[1]
+            # take the final section as the version
+            binary_dir_version = binary_dir.split('-')[-1]
+
+
+            # the binary directory may or may not contain a dot in the directory name
+            # e.g lib.linux-x86_64-3.7 vs lib.linux-x86_64-cpython-311
+            if '.' in binary_dir_version:
+                py_version = "{:d}.{:d}".format(sys.version_info.major, sys.version_info.minor)
+            else:
+                py_version = "{:d}{:d}".format(sys.version_info.major, sys.version_info.minor)
 
             # If the directory ends with the correct python version, take that binary
-            if binary_dir.endswith('-' + py_version):
+            if binary_dir_version == py_version:
                 return file_path
 
 


### PR DESCRIPTION
Issue #319 notes that detector can fail with the following error

```
2024/07/31 18:45:27-INFO-QueuedPool-line:204 - Traceback (most recent call last):
  File "/home/au0004/source/RMS/RMS/QueuedPool.py", line 356, in _workerFunc
    result = func(*all_args, **self.func_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/au0004/source/RMS/RMS/DetectStarsAndMeteors.py", line 98, in detectStarsAndMeteors
    meteor_list = detectMeteors(img_handle, config, flat_struct=flat_struct, dark=dark, mask=mask)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/au0004/source/RMS/RMS/Detection.py", line 1107, in detectMeteors
    line_list = getLines(img_handle, config.k1_det, config.j1_det, config.time_slide, config.time_window_size,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/au0004/source/RMS/RMS/Detection.py", line 413, in getLines
    kht.kht_wrapper.argtypes = [npct.ndpointer(dtype=np.double, ndim=2),
    ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/ctypes/__init__.py", line 389, in __getattr__
    func = self.__getitem__(name)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/ctypes/__init__.py", line 394, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: python: undefined symbol: kht_wrapper
```

This is because the binary is not correctly detected when python minor version is greater than 9. This PR addresses this issue. 

Adding the full binary name in .config is a good workaround. 

