### PR TITLE
Update requirements.txt as tflite-runtime 2.14.0 now support python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,7 @@ python-dvr>=0.0.1 ; python_version >='3.6'
 pyqtgraph @ git+https://github.com/pyqtgraph/pyqtgraph@develop#egg=pyqtgraph ; python_version=='2.7'
 pyqtgraph>=0.12,<0.13 ; python_version >='3.6'
 pyyaml; python_version>='3.6'
-tflite-runtime; python_version>='3.6' and python_version<'3.10'
-# workaround till tensorflow-lite supports python 3.10 on Debian/Ubuntu
-tflite-runtime @ https://github.com/hjonnala/snippets/raw/main/wheels/python3.10/tflite_runtime-2.5.0.post1-cp310-cp310-linux_x86_64.whl ; python_version=='3.10'
+tflite-runtime; python_version>='3.6'
 PyGObject; python_version >= '3.6'
 astrometry; python_version >= "3.8"
 astrometry==3.0.0; python_version < "3.8"


### PR DESCRIPTION
https://pypi.org/project/tflite-runtime/
