### PR TITLE
Further Improve Pipeline State Management with Enhanced Retry Logic

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -692,7 +692,7 @@ class BufferedCapture(Process):
                             time.sleep(5)
                             break
 
-                        time.sleep(5)
+                        time.sleep(1)
 
                     if not ping_success:
                         log.error("Can't ping the camera IP!")

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -169,7 +169,9 @@ class BufferedCapture(Process):
 
                 if GST_IMPORTED:
 
-                    state = self.device.get_state(Gst.CLOCK_TIME_NONE).state
+                    # Use a 10-second timeout to avoid indefinite blocking while checking if the device is in the PLAYING state
+                    state = self.device.get_state(Gst.SECOND * 10).state
+
                     if state == Gst.State.PLAYING:
                         return True
                     else:

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -512,7 +512,7 @@ class BufferedCapture(Process):
 
 
     def createGstreamDevice(self, video_format, gst_decoder='decodebin', 
-                            video_file_dir=None, segment_duration_sec=30, max_retries=5, retry_interval=5):
+                            video_file_dir=None, segment_duration_sec=30, max_retries=5, retry_interval=1):
         """
         Creates a GStreamer pipeline for capturing video from an RTSP source and 
         initializes playback with specific configurations.


### PR DESCRIPTION
This PR introduces additional improvements to the GStreamer pipeline state management process, particularly focusing on enhancing the robustness of transitioning the pipeline to the `PLAYING` state. These changes aim to reduce the risk of **indefinite blocking** that were still occasionally occurring, especially in scenarios where stations have unreliable network connections leading to frequent disconnects. The updates also optimize timeouts during reconnects to minimize the loss of observation time.

### **Key Changes**:

1. **Incremental Timeout for State Transitions**:
   - Implemented an increasing timeout strategy for the `get_state()` function when transitioning the pipeline to the `PLAYING` state. The timeout now grows with each retry attempt, starting at 5 seconds and increasing by 5 seconds for each subsequent attempt. This allows the pipeline more time to stabilize on retries.
   - Introduced a `state_transition_timeout` variable to clearly indicate the purpose of this timeout.

2. **Pipeline Reset and Cleanup**:
   - Added logic to set the pipeline to `NULL` and then wait for a specified interval (`retry_interval`) to ensure the pipeline is fully cleaned up before attempting to create a new one.
   - Set `self.pipeline` to `None` after the cleanup to avoid retaining references to a potentially stale or invalid pipeline object.

3. **Improved Logging**:
   - Enhanced the logging around pipeline state transitions to provide more detailed information about each attempt, including the attempt number, the current state of the pipeline, and the outcome of the state transition.

4. **Refined Retry Logic**:
   - Structured the retry logic to handle intermittent failures more gracefully, ensuring proper cleanup between attempts and providing more time for the pipeline to reach a stable state before retrying.
   - Reduced the timeout from 10 to 5 seconds after a successful ping.
   - Reduced the wait time between pings from 5 to 1 second.

### **Why These Changes Were Made**:
- **Prevent Indefinite Blocking**: The previous implementation still risked hanging indefinitely if the pipeline failed to transition to the `PLAYING` state in some edge cases. The new timeout strategy mitigates this risk by progressively increasing the wait time, giving the system more time to recover on subsequent attempts.
- **Ensure Resource Release**: Properly resetting and cleaning up the pipeline between retries helps prevent resource conflicts and ensures that each retry starts with a clean slate.
- **Clarity and Maintainability**: Improved logging and code structure make it easier to diagnose issues during pipeline setup and enhance the maintainability of the codebase.
- **Minimize Lost Observational Time**: By optimizing timeouts and reducing wait times during reconnects, these changes aim to minimize lost observational time due to network-related issues.