### PR TITLE
Map FileNotFoundError to IOError if in Python 2

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -30,6 +30,9 @@ except:
     # Python 2
     from ConfigParser import NoOptionError, RawConfigParser
 
+# Map FileNotFoundError to IOError in Python 2 as it does not exist
+if sys.version_info[0] < 3:
+    FileNotFoundError = IOError
 
 # Used to determine detection parameters which will change in ML filtering is available
 try:

--- a/RMS/Formats/FTPdetectinfo.py
+++ b/RMS/Formats/FTPdetectinfo.py
@@ -18,9 +18,13 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 import os
-
+import sys
 import git
 import numpy as np
+
+# Map FileNotFoundError to IOError in Python 2 as it does not exist
+if sys.version_info[0] < 3:
+    FileNotFoundError = IOError
 
 
 def validDefaultFTPdetectinfo(file_name):

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -28,6 +28,9 @@ from matplotlib import scale as mscale
 from matplotlib import transforms as mtransforms
 from matplotlib.ticker import FixedLocator
 
+# Map FileNotFoundError to IOError in Python 2 as it does not exist
+if sys.version_info[0] < 3:
+    FileNotFoundError = IOError
 
 # Get the logger from the main module
 log = logging.getLogger("logger")

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -25,6 +25,9 @@ except:
 
 from RMS.Misc import mkdirP
 
+# Map FileNotFoundError to IOError in Python 2 as it does not exist
+if sys.version_info[0] < 3:
+    FileNotFoundError = IOError
 
 # Get the logger from the main module
 log = logging.getLogger("logger")

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -160,7 +160,7 @@ def createRemoteDirectory(sftp, path):
                 sftp.stat(path)
                 print("Directory '{}' already exists.".format(path))
 
-            except IOError:
+            except FileNotFoundError:
 
                 sftp.mkdir(path)
                 print("Directory '{}' created.".format(path))

--- a/Utils/AuditConfig.py
+++ b/Utils/AuditConfig.py
@@ -82,7 +82,7 @@ def validatePath(path, file_name):
     
     abs_path = os.path.abspath(path)
     if not os.path.exists(abs_path):
-        raise IOError("{} not found. Tried to find it at absolute path: '{}'".format(file_name, abs_path))
+        raise FileNotFoundError("{} not found. Tried to find it at absolute path: '{}'".format(file_name, abs_path))
     
     return abs_path   
 
@@ -110,7 +110,7 @@ def compareConfigs(config_path, template_path, configreader_path, dev_report=Fal
         validatePath(config_path, ".config file")
         config_file_options = parseConfigFile(config_path)
         found_config = True
-    except (ValueError, IOError) as e:
+    except (ValueError, FileNotFoundError) as e:
         dev_report = True
         print("Error loading .config file: {}".format(e))
 
@@ -118,7 +118,7 @@ def compareConfigs(config_path, template_path, configreader_path, dev_report=Fal
         validatePath(template_path, ".configTemplate")
         template_file_options = parseConfigFile(template_path)
         found_template = True
-    except (ValueError, IOError) as e:
+    except (ValueError, FileNotFoundError) as e:
         dev_report = True
         print("Error loading .configTemplate file: {}".format(e))
 
@@ -126,7 +126,7 @@ def compareConfigs(config_path, template_path, configreader_path, dev_report=Fal
         validatePath(configreader_path, "ConfigReader.py")
         configreader_file_options = extractConfigOptions(configreader_path)
         found_configreader = True
-    except (ValueError, IOError) as e:
+    except (ValueError, FileNotFoundError) as e:
         dev_report = True
         print("Error loading ConfigReader.py file: {}".format(e))
 
@@ -264,6 +264,6 @@ if __name__ == "__main__":
         print(compareConfigs(cml_args.config_path, cml_args.template, cml_args.configreader,
                              dev_report=cml_args.dev))
         
-    except (ValueError, IOError) as e:
+    except (ValueError, FileNotFoundError) as e:
         print("Error: {}".format(str(e)))
         exit(1)

--- a/Utils/AuditConfig.py
+++ b/Utils/AuditConfig.py
@@ -2,6 +2,11 @@ import re
 import configparser
 import argparse
 import os
+import sys
+
+# Map FileNotFoundError to IOError in Python 2 as it does not exist
+if sys.version_info[0] < 3:
+    FileNotFoundError = IOError
 
 
 OMIT_FROM_CONFIG = {'lat',

--- a/Utils/FluxBatch.py
+++ b/Utils/FluxBatch.py
@@ -4,6 +4,7 @@ from __future__ import print_function, division, absolute_import
 
 import datetime
 import os
+import sys
 import shlex
 import sys
 import collections
@@ -28,6 +29,10 @@ from Utils.Flux import calculatePopulationIndex, calculateMassIndex, computeFlux
 from RMS.Routines.SolarLongitude import unwrapSol
 from RMS.Misc import formatScientific, roundToSignificantDigits, SegmentedScale, mkdirP
 from RMS.QueuedPool import QueuedPool
+
+# Map FileNotFoundError to IOError in Python 2 as it does not exist
+if sys.version_info[0] < 3:
+    FileNotFoundError = IOError
 
 # Now that the Scale class has been defined, it must be registered so
 # that ``matplotlib`` can find it.

--- a/Utils/PlotTimeIntervals.py
+++ b/Utils/PlotTimeIntervals.py
@@ -9,6 +9,7 @@ If fps is not provided, the default value of 25 is used.
 from __future__ import print_function, division, absolute_import
 
 import os
+import sys
 import argparse
 import tarfile
 import math
@@ -19,6 +20,10 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
 import RMS.ConfigReader as cr
+
+# Map FileNotFoundError to IOError in Python 2 as it does not exist
+if sys.version_info[0] < 3:
+    FileNotFoundError = IOError
 
 
 def plotFFTimeIntervals(dir_path, fps=25.0, ff_block_size=256, ma_window_size=50):

--- a/Utils/TimestampRMSVideos.py
+++ b/Utils/TimestampRMSVideos.py
@@ -12,7 +12,9 @@ import numpy as np
 
 from RMS.Formats.FFfile import filenameToDatetime
 
-
+# Map FileNotFoundError to IOError in Python 2 as it does not exist
+if sys.version_info[0] < 3:
+    FileNotFoundError = IOError
 
 
 class FrameTime:


### PR DESCRIPTION
Addresses issue #344 by mapping FileNotFoundError to IOError if in Python 2.

The PR also reverse some premature changes where FileNotFoundError were changed to IOError.