### PR TITLE
UpdateConfig, a utility to bring an existing .config file in line with current template

### DIFF
--- a/Utils/AuditConfig.py
+++ b/Utils/AuditConfig.py
@@ -1,8 +1,16 @@
 import re
-import configparser
 import argparse
 import os
+import sys
 
+
+try:
+    # Python 3
+    import configparser
+
+except:
+    # Python 2
+    import ConfigParser as configparser
 
 OMIT_FROM_CONFIG = {'lat',
                     'lon',
@@ -174,21 +182,21 @@ def compareConfigs(config_path, template_path, configreader_path, dev_report=Fal
         output.append("Default values will be used:".center(80))
         output.append("-" * 80)
         for option in sorted(missing_in_config_wrt_template):
-            output.append(" • {}".format(option))
+            output.append(" - {}".format(option))
         output.append("")
 
     if missing_in_template_wrt_cr and dev_report and found_template and found_configreader:
         output.append("OPTIONS NOT IN TEMPLATE FILE BUT IMPLEMENTED IN RMS:".center(80))
         output.append("-" * 80)
         for option in sorted(missing_in_template_wrt_cr):
-            output.append(" • {}".format(option))
+            output.append(" - {}".format(option))
         output.append("")
 
     if missing_in_config_wrt_cr and dev_report and found_config and found_configreader:
         output.append("OPTIONS NOT IN CONFIG FILE BUT IMPLEMENTED IN RMS:".center(80))
         output.append("-" * 80)
         for option in sorted(missing_in_config_wrt_cr):
-            output.append(" • {}".format(option))
+            output.append(" - {}".format(option))
         output.append("")
 
     if commented_options_in_config and found_config:
@@ -196,28 +204,28 @@ def compareConfigs(config_path, template_path, configreader_path, dev_report=Fal
         output.append("Default values will be used:".center(80))
         output.append("-" * 80)
         for option in sorted(commented_options_in_config):
-            output.append(" • {}".format(option))
+            output.append(" - {}".format(option))
         output.append("")
 
     if commented_options_in_template and dev_report and found_template:
         output.append("OPTIONS COMMENTED OUT IN TEMPLATE FILE:".center(80))
         output.append("-" * 80)
         for option in sorted(commented_options_in_template):
-            output.append(" • {}".format(option))
+            output.append(" - {}".format(option))
         output.append("")
 
     if extra_in_config and found_config and found_configreader:
         output.append("OPTIONS IN .CONFIG FILE NOT IMPLEMENTED IN RMS (will be ignored):".center(80))
         output.append("-" * 80)
         for option in sorted(extra_in_config):
-            output.append(" • {}".format(option))
+            output.append(" - {}".format(option))
         output.append("")
 
     if extra_in_template and dev_report and found_template and found_configreader:
         output.append("OPTIONS IN TEMPLATE FILE NOT IMPLEMENTED IN RMS (will be ignored):".center(80))
         output.append("-" * 80)
         for option in sorted(extra_in_template):
-            output.append(" • {}".format(option))
+            output.append(" - {}".format(option))
         output.append("")
 
     if found_config and found_template and found_configreader:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -223,8 +223,8 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     """
 
-    output_lines = "; These options added automatically by {}",format(__file__)
-    output_lines += "; On {}".format(datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f'))
+    output_lines = "; These options added automatically by {:s}",format(__file__)
+    output_lines += "; On {:s}".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
 
     for section, option, value in insert_options_list:
         if section == current_section:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -50,6 +50,7 @@ def printWarning(config_path, template):
     else:
         return
 
+
 def parseConfigFileBySection(config_path):
     """Parse the .config file, into one list and two lists of lists
 
@@ -84,6 +85,7 @@ def parseConfigFileBySection(config_path):
                 values_list.append(value)
         options_list_of_lists.append(options_list)
         values_list_of_lists.append(values_list)
+
 
     return sections_list, options_list_of_lists, values_list_of_lists
 
@@ -166,7 +168,7 @@ def sectionHeaderLine(line, section_list):
         return False
 
 
-def getOption(line, delimiter =":"):
+def getOption(line, delimiter =":", preserve_case=True):
 
     """
     Get the option, if any from a line
@@ -181,7 +183,11 @@ def getOption(line, delimiter =":"):
     """
 
     if delimiter in line:
-        return line[0:line.index(delimiter)].strip().lower()
+        line = line[0:line.index(delimiter)].strip()
+        if preserve_case:
+            return line
+        else:
+            return line.lower()
     else:
         return None
 
@@ -459,13 +465,13 @@ def compare(new_config_path, sections_list, options_list_of_lists, values_list_o
 
                 if correct_section:
 
-                    if getOption(line) == option and getValue(line) != value:
+                    if getOption(line, preserve_case=False) == option and getValue(line) != value:
                         option_value_mismatch = True
                         found_option_value = True
                         wrong_value = getValue(line)
                         break
 
-                    if getOption(line) == option and getValue(line) == value:
+                    if getOption(line, preserve_case=False) == option and getValue(line) == value:
                         found_option_value = True
 
             if option_value_mismatch and found_option_value:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -241,8 +241,8 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     if insert_made:
         comment_lines = ""
-        comment_lines += "; These options added automatically by {:s}\n".format(os.path.basename(sys.argv[0]))
-        comment_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M'))
+        comment_lines += "; These options added automatically by {:s} ".format(os.path.basename(sys.argv[0]))
+        comment_lines += "; on {:s}\n\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M'))
         output_lines = comment_lines + output_lines
         if newline_after_last:
             output_lines += "\n"

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -316,7 +316,7 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
 
     """
 
-    interactive = True
+    # interactive = True
     # Create paths for reuse later
     config_template_file_path = os.path.expanduser(config_template_file_path)
     config_file_path = os.path.expanduser(config_file_path)

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -229,15 +229,17 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     for section, option, value in insert_options_list:
         if section == current_section:
-            insert_made = True
+
             insert = "{}: {}\n".format(option, value)
             if interactive:
                 print("Working in section {}".format(section))
                 response = input("Would you like to insert {}".format(insert))
                 if response.lower() == "y":
                     output_lines += insert
+                    insert_made = True
             else:
                 output_lines += insert
+                insert_made = True
 
     if insert_made:
         comment_lines = ""

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -21,8 +21,6 @@ def parseConfigFileBySection(config_path):
 
     """
 
-    print("Reading in configuration from {:s}".format(config_path))
-
     config = configparser.ConfigParser()
     config.read(os.path.expanduser(config_path))
 
@@ -40,7 +38,7 @@ def parseConfigFileBySection(config_path):
                 value = config.get(section,option)
                 if ";" in value:
                     value = value[:value.index(";")].strip()
-                values_list.append(config.get(section,option))
+                values_list.append(value)
         options_list_of_lists.append(options_list)
         values_list_of_lists.append(values_list)
 
@@ -134,7 +132,7 @@ def getOption(line, delimiter =":"):
     else:
         return None
 
-def getValue(line, delimiter = ":"):
+def getValue(line, delimiter=":", comment=";"):
 
 
     """
@@ -151,7 +149,10 @@ def getValue(line, delimiter = ":"):
 
 
     if delimiter in line:
-        return line[line.index(delimiter) + 1:].strip()
+        value = line[line.index(delimiter) + 1:].strip()
+        if comment in value:
+            value = value[:value.index(comment)]
+        return value
     else:
         return None
 
@@ -428,7 +429,7 @@ if __name__ == "__main__":
     arg_parser.add_argument("config_file_path", nargs='?', default="./.config",
                             help="Path to the .config file")
 
-    arg_parser.add_argument("--template", default="./.configTemplate",
+    arg_parser.add_argument("-t","--template", default="./.configTemplate",
                         help="Path to .configTemplate (default: ./.configTemplate)")
 
     arg_parser.add_argument("-i", "--interactive", default=False, action="store_true",

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -223,8 +223,8 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     """
 
-    output_lines = "; These options added automatically by {:s}/n".format(__file__)
-    output_lines += "; On {:s}".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
+    output_lines = "; These options added automatically by {:s}\n".format(__file__)
+    output_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
 
     for section, option, value in insert_options_list:
         if section == current_section:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -1,4 +1,4 @@
-# RPi Meteor Station
+
 # Copyright (C) 2024
 #
 # This program is free software: you can redistribute it and/or modify
@@ -316,7 +316,7 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
 
     """
 
-
+    interactive = True
     # Create paths for reuse later
     config_template_file_path = os.path.expanduser(config_template_file_path)
     config_file_path = os.path.expanduser(config_file_path)
@@ -371,7 +371,7 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
 
         if not len(line.strip()):
             blank_line = True
-
+            output_line += ""
 
         # Detect a comment line, or a comment line that should be uncommented
         elif line.strip()[0] == ";" or line.strip()[0] == "#":
@@ -380,19 +380,22 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
             # Could this be an option that is commented out
             # Check to see if it is an option in the current section
             if ":" in comment:
+
                 if current_section in sections_list:
                     option = comment[:comment.index(":")]
-                    if option in options_list_of_lists[sections_list.index(current_section)]:
-                        uncomment_line = True
-                        # This option is required in the station configuration file.
-                        # Does it exist elsewhere uncommented - even in the wrong section
-                        # This will be overly cautious when the same option name occurs in
-                        # multiple sections.
-                        for line2 in lines_list:
-                            if option in line2:
-                                if option == line2[:len(option)]:
-                                    # It exists elsewhere uncommented, do not uncomment this line
-                                    uncomment_line = False
+
+                    if sections_list.index(current_section) < len(options_list_of_lists):
+                        if option in options_list_of_lists[sections_list.index(current_section)]:
+                            uncomment_line = True
+                            # This option is required in the station configuration file.
+                            # Does it exist elsewhere uncommented - even in the wrong section
+                            # This will be overly cautious when the same option name occurs in
+                            # multiple sections.
+                            for line2 in lines_list:
+                                if option in line2:
+                                    if option == line2[:len(option)]:
+                                        # It exists elsewhere uncommented, do not uncomment this line
+                                        uncomment_line = False
             else:
                 comment_line = True
 
@@ -411,7 +414,6 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
                 # This is the last line of this section, so insert any missing options
                 # that were passed in as parameters
                 output_line += insert(current_section, insert_options_list, interactive=interactive)
-
             # Set the current section
             current_section = getSectionHeaderFromLine(line)
         # If this was a line that should be uncommented
@@ -425,10 +427,10 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
         # If not any of these, then it must be a line with an option and value
         if not blank_line and not comment_line and not section_header_line and not uncomment_line:
             option = getOption(line)
-            if current_section in sections_list:
-                section_number = sections_list.index(current_section)
+            #if current_section in sections_list:
+            section_number = sections_list.index(current_section)
 
-            # If this section number is going to return a an option then it must have
+            # If this section number is going to return an option then it must have
             # been in the station .config file
             if section_number < len(options_list_of_lists):
                 if option.lower() in options_list_of_lists[section_number]:
@@ -440,15 +442,14 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
                     if interactive:
                         print("Option:{} from Section:{} was not found in station .config, set to {}"
                                                 .format(option, current_section, getValue(line)))
-                    output_line = line
+                    output_line = "{}\n".format(line)
             else:
                 if interactive:
-                    print("From new section {} adding new line {}".format(template_sections_list[-1],line))
-                output_line = line
+                    print("From new section {} adding new line {}".format(current_section,line))
+                output_line = "{}\n".format(line)
 
         else:
             output_line += "{}\n".format(line)
-
         output_file_handle.write(output_line)
 
     # Close the files

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -238,7 +238,7 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
             else:
                 output_lines += insert
 
-    output_lines += "\n" if newline_after_last else output_lines
+    output_lines += "\n" if newline_after_last else ""
 
     return output_lines
 

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -242,7 +242,7 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
     if insert_made:
         comment_lines = ""
         comment_lines += "; These options added automatically by {:s} ".format(os.path.basename(sys.argv[0]))
-        comment_lines += "; on {:s}\n\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M'))
+        comment_lines += "on {:s}\n\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M'))
         output_lines = comment_lines + output_lines
         if newline_after_last:
             output_lines += "\n"

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -223,8 +223,9 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     """
 
-    output_lines = "; These options added automatically by {:s}\n".format(__file__)
-    output_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
+    if len(insert_options_list):
+        output_lines = "; These options added automatically by {:s}\n".format(__file__)
+        output_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
 
     for section, option, value in insert_options_list:
         if section == current_section:
@@ -238,8 +239,9 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
             else:
                 output_lines += insert
 
-    if newline_after_last:
-        output_lines += "\n"
+    if len(insert_options_list):
+        if newline_after_last:
+            output_lines += "\n"
 
     return output_lines
 

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -236,7 +236,7 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
             else:
                 output_lines += insert
 
-    output_lines += "/n" if newline_after_last else ""
+    output_lines += "\n" if newline_after_last else ""
 
     return output_lines
 

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -223,7 +223,7 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     """
 
-    output_lines = "; These options added automatically by {:s}".format(__file__)
+    output_lines = "; These options added automatically by {:s}/n".format(__file__)
     output_lines += "; On {:s}".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
 
     for section, option, value in insert_options_list:
@@ -238,7 +238,7 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
             else:
                 output_lines += insert
 
-    output_lines += "\n" if newline_after_last else ""
+    output_lines += "\n" if newline_after_last else output_lines
 
     return output_lines
 

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -1,0 +1,444 @@
+import configparser
+import argparse
+import os
+from Utils.AuditConfig import validatePath
+import glob
+import shutil
+import tempfile
+from RMS.Misc import mkdirP
+
+def parseConfigFileBySection(config_path):
+    """Parse the .config file, into one list and two lists of lists
+
+
+    Arguments:
+        config_path: [str] Path to the .config file
+
+    Returns:
+        sections_list: A list of all the sections
+        options_list_of_lists: A list of lists of all the options
+        values_list_of_lists: A list of lists of all the values
+
+    """
+
+    print("Reading in configuration from {:s}".format(config_path))
+
+    config = configparser.ConfigParser()
+    config.read(os.path.expanduser(config_path))
+
+    sections_list = []
+    options_list_of_lists = []
+    values_list_of_lists = []
+
+    for section in config.sections():
+        sections_list.append(section)
+        options_list = []
+        values_list = []
+        for option in config.options(section):
+            if option:
+                options_list.append(option)
+                value = config.get(section,option)
+                if ";" in value:
+                    value = value[:value.index(";")].strip()
+                values_list.append(config.get(section,option))
+        options_list_of_lists.append(options_list)
+        values_list_of_lists.append(values_list)
+
+    return sections_list, options_list_of_lists, values_list_of_lists
+
+def backupConfig(config_file_path, number_to_keep=5):
+
+    """Create numbered backups of the .config file
+
+
+        Arguments:
+            config_path: [str] Path to the .config file
+
+        Returns:
+            sections_list: A list of all the sections
+            options_list_of_lists: A list of lists of all the options
+            values_list_of_lists: A list of lists of all the values
+
+        """
+
+    config_file_backups = sorted(glob.glob(config_file_path + "_*"), reverse=True)
+    for config_backup in config_file_backups:
+        name, number = config_backup.split("_")[0], config_backup.split("_")[1]
+
+        number = int(number)
+        if int(number) < number_to_keep:
+            number += 1
+            os.rename(config_backup,"{}_{}".format(name,number))
+        else:
+            os.rename(config_backup,"{}_{}".format(name,number))
+
+    config_backup = config_file_path +"_1"
+    shutil.copy(config_file_path, config_file_path +"_1")
+
+    return config_backup
+
+
+
+def sectionHeaderLine(line, section_list):
+
+    """
+    Detect if this is a section header line
+
+    Arguments:
+        line: line to be checked
+        section_list: list of all the expected sections
+
+    Returns:
+        bool
+
+    """
+
+
+    opening_square_bracket, closing_square_bracket = False, False
+    opening_square_bracket_position, closing_square_bracket_position = 0, 0
+
+    n = 0
+    for c in line:
+        if c == "[" and opening_square_bracket_position == False:
+            opening_square_bracket = True
+            opening_square_bracket_position = n
+        if c == "]" and opening_square_bracket:
+            closing_square_bracket = True
+            closing_square_bracket_position = n
+        n += 1
+    if opening_square_bracket and closing_square_bracket:
+        header = line[opening_square_bracket_position + 1:closing_square_bracket_position]
+        if header in section_list:
+            return True
+        else:
+            return False
+    else:
+        return False
+
+def getOption(line, delimiter =":"):
+
+    """
+    Get the option, if any from a line
+
+    Arguments:
+        line: line to be checked
+        delimiter: optional default :
+
+    Returns:
+        str: option name
+
+    """
+
+    if delimiter in line:
+        return line[0:line.index(delimiter)].strip().lower()
+    else:
+        return None
+
+def getValue(line, delimiter = ":"):
+
+
+    """
+    Get the value, if any from a line
+
+    Arguments:
+        line: line to be checked
+        delimiter: optional default :
+
+    Returns:
+        str: value
+
+    """
+
+
+    if delimiter in line:
+        return line[line.index(delimiter) + 1:].strip()
+    else:
+        return None
+
+
+
+def insert(current_section, insert_options_list, interactive=False):
+
+
+    """
+    Create a string containing options which can be inserted into the .config file
+
+    Arguments:
+        line: line to be checked
+        delimiter: optional default :
+
+    Returns:
+        str: value
+
+    """
+
+    output_lines = ""
+
+    for section, option, value in insert_options_list:
+        if section == current_section:
+
+            insert = "{}: {}\n".format(option, value)
+            if interactive:
+                print("Working in section {}".format(section))
+                response = input("Would you like to insert {}".format(insert))
+                if response.lower() == "y":
+                    output_lines += insert
+            else:
+                output_lines += insert
+
+    return output_lines
+
+def populateTemplateConfig(config_template_file_path, config_file_path,
+                            sections_list, options_list_of_lists, values_list_of_lists,
+                                 temporary_suffix="new", insert_options_list = [], interactive = False):
+
+
+    """
+    Reads in a .config template file, and populates it with the data collected from another .config file
+    If an option is commented out in the template, but is required in the station config file, then it
+    will be uncommented, provided it does not exist elsewhere.
+
+    Arguments:
+        config_template_file_path: path to the template file
+        config_file_path: path to the config file t be upgradedd
+        sections_list: list of the sections in the original config file
+        options_list_of_lists: list of lists of options
+        values_list_of_lists: list of lists of values
+        temporary_suffix: optional suffix to use for the temporary config file
+        insert_options_list: list of [section, option, value] to insert, used if the template is missing required
+                                options
+        interactive: optional, default False, if True, asks for confirmations
+
+    Returns:
+        str: value
+
+    """
+
+
+
+    config_template_file_path = os.path.expanduser(config_template_file_path)
+    config_file_path = os.path.expanduser(config_file_path)
+    config_template_file_name = os.path.basename(config_template_file_path)
+    config_file_name = os.path.basename(config_file_path)
+
+    temp_directory = tempfile.mkdtemp()
+    if os.path.isfile(temp_directory):
+        os.unlink(temp_directory)
+    mkdirP(temp_directory)
+
+    shutil.copy(config_file_path, os.path.join(temp_directory, config_template_file_name))
+    shutil.copy(config_template_file_path, os.path.join(temp_directory, config_template_file_name))
+    temporary_template = os.path.join(temp_directory, os.path.basename(config_template_file_path))
+    temporary_output_file = os.path.join(temp_directory, "{}_{}".format(config_file_name,temporary_suffix))
+
+    input_file_handle = open(temporary_template, "r")
+    output_file_handle = open(temporary_output_file,"w")
+
+    lines_list = []
+    for line in input_file_handle:
+        lines_list.append(line)
+
+    current_section = ""
+    for line in lines_list:
+        output_line = ""
+        blank_line, comment_line, section_header_line, uncomment_line = False, False, False, False
+        line = line.replace("\n","")
+        if not len(line):
+            blank_line = True
+        elif line.strip()[0] == ";" or line.strip()[0] == "#":
+            comment = line.strip()[1:].strip()
+            comment_line = True
+            # Could this be an option that is commented out
+            if ":" in comment:
+                if current_section in sections_list:
+                    option = comment[:comment.index(":")]
+                    if option in options_list_of_lists[sections_list.index(current_section)]:
+                        uncomment_line = True
+                        # This option is required in the station configuration file.
+                        # Does it exist elsewhere uncommented?
+                        for line2 in lines_list:
+                            if option in line2:
+                                if option == line2[:len(option)]:
+                                    # It exists elsewhere uncommented, do not uncomment this line
+                                    uncomment_line = False
+            else:
+                comment_line = True
+        elif sectionHeaderLine(line, sections_list):
+            section_header_line = True
+
+        if section_header_line:
+            if current_section != "":
+                # This is the last line of this section, so insert any missing options
+                output_line += insert(current_section, insert_options_list, interactive=interactive)
+            current_section = line.strip()[1:-1]
+
+
+        if uncomment_line:
+            option_number = options_list_of_lists[sections_list.index(current_section)].index(option)
+            value = values_list_of_lists[sections_list.index(current_section)][option_number]
+            line = "{}: {}".format(option, value)
+
+        if not blank_line and not comment_line and not section_header_line and not uncomment_line:
+            option = getOption(line)
+            section_number = sections_list.index(current_section)
+            if option.lower() in options_list_of_lists[section_number]:
+                option_number = options_list_of_lists[section_number].index(option.lower())
+                station_value = values_list_of_lists[section_number][option_number]
+                output_line = "{}: {}\n".format(option, station_value)
+            else:
+                if interactive:
+                    print("Option:{} from Section:{} was not found in station .config, set to {}"
+                                                .format(option, current_section, getValue(line)))
+                output_line = line
+
+        else:
+            output_line += "{}\n".format(line)
+
+        output_file_handle.write(output_line)
+    input_file_handle.close()
+    output_file_handle.close()
+
+    return temporary_output_file
+
+def compare(new_config_path, sections_list, options_list_of_lists, values_list_of_lists):
+
+    """
+    Compares a configuration file on disc against
+
+    """
+
+
+    fh = open(new_config_path,"r")
+    config_file_as_list, errors, missing_options = [], [], []
+
+
+    for line in fh:
+        config_file_as_list.append(line.replace("\n",""))
+
+    correct_section = False
+    for section in sections_list:
+        for option, value in zip(options_list_of_lists[sections_list.index(section)], values_list_of_lists[sections_list.index(section)]):
+            correct_section, option_value_mismatch, found_option_value = False, False, False
+            wrong_value = ""
+
+            for line in config_file_as_list:
+                if sectionHeaderLine(line, sections_list):
+                    correct_section = True if line.strip() == "[{}]".format(section) else False
+
+                if correct_section:
+
+                    if getOption(line) == option and getValue(line) != value:
+                        option_value_mismatch = True
+                        found_option_value = True
+                        wrong_value = getValue(line)
+                        break
+
+                    if getOption(line) == option and getValue(line) == value:
+                        found_option_value = True
+
+            if option_value_mismatch and found_option_value:
+                errors.append("Found {} in section {} with wrong value {} instead of {}".
+                                    format(option, section, wrong_value, value))
+
+            if not found_option_value:
+                errors.append("Did not find option {} in section {} with expected value {}".format(option, section, value))
+                missing_options.append([section,option,value])
+
+    return errors, missing_options
+
+
+def updateConfig(config_file_path, config_template_file_path, interactive=False):
+
+
+
+
+    config_file_path = os.path.expanduser(config_file_path)
+    config_template_file_path = os.path.expanduser(config_template_file_path)
+
+    if validatePath(config_file_path, ".config"):
+        # Make backup of the .config file
+        config_backup = backupConfig(config_file_path)
+        # Parse the .config file
+        sections_list, options_list_of_lists, values_list_of_lists = parseConfigFileBySection(config_file_path)
+        # Create a new config file in a temporary directory
+        new_config_path = populateTemplateConfig(config_template_file_path, config_file_path, sections_list,
+                                                                options_list_of_lists, values_list_of_lists,
+                                                                interactive=interactive)
+
+        # Check that every value that was in the station .config file has been migrated in the new .config file
+        error_list, missing_option_list = compare(new_config_path, sections_list, options_list_of_lists,
+                                                  values_list_of_lists)
+
+        if interactive:
+            abort = False
+            while len(error_list) or abort:
+                print("Unsuccessful compare - the following missing options were noted")
+                for error in error_list:
+                    print("    {:s}".format(error))
+                response = input("Would you like to insert the missing options? (y/n)")
+                if response.lower() == "y":
+                    new_config_path = populateTemplateConfig(config_template_file_path, config_file_path, sections_list,
+                                                         options_list_of_lists, values_list_of_lists,
+                                                         insert_options_list=missing_option_list,
+                                                             interactive=interactive)
+
+                    error_list, missing_option_list = compare(new_config_path, sections_list, options_list_of_lists,
+                                                      values_list_of_lists)
+                else:
+                    break
+
+
+            print("The new configuration is stored at {}".format(new_config_path))
+            print("A backup of the .config file is stored at {}".format(config_backup))
+            response = input("Copy new config file at {} over old config file at {} (y/n)"
+                                            .format(new_config_path, config_file_path))
+            if response.lower() == "y":
+                shutil.copy(new_config_path, config_file_path)
+
+            response = input("Would you like remove the temporary working directory (y/n)")
+            if response.lower() == "y":
+                files = os.listdir(os.path.dirname(new_config_path))
+                for file in files:
+                    os.unlink(os.path.join(os.path.dirname(new_config_path), file))
+                os.rmdir(os.path.dirname(new_config_path))
+                exit(0)
+            else:
+                exit(0)
+
+        else:
+            new_config_path = populateTemplateConfig(config_template_file_path, config_file_path, sections_list,
+                                                     options_list_of_lists, values_list_of_lists,
+                                                     insert_options_list=missing_option_list,
+                                                     interactive=interactive)
+
+            compare(new_config_path, sections_list, options_list_of_lists, values_list_of_lists)
+            shutil.copy(new_config_path, config_file_path)
+            files = os.listdir(os.path.dirname(new_config_path))
+            for file in files:
+                os.unlink(os.path.join(os.path.dirname(new_config_path), file))
+            os.rmdir(os.path.dirname(new_config_path))
+
+
+if __name__ == "__main__":
+    ### COMMAND LINE ARGUMENTS
+
+    # Init the command line arguments parser
+    arg_parser = argparse.ArgumentParser(description="Upgrade a .config file to match the .configTemplate format")
+
+    arg_parser.add_argument("config_file_path", nargs='?', default="./.config",
+                            help="Path to the .config file")
+
+    arg_parser.add_argument("--template", default="./.configTemplate",
+                        help="Path to .configTemplate (default: ./.configTemplate)")
+
+    arg_parser.add_argument("-i", "--interactive", default=False, action="store_true",
+                            help="Run interactively")
+
+
+
+    # Parse the command line arguments
+    cml_args = arg_parser.parse_args()
+
+    #########################
+
+    updateConfig(cml_args.config_file_path, cml_args.template, cml_args.interactive)

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -223,7 +223,7 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     """
 
-    output_lines = "; These options added automatically by {:s}",format(__file__)
+    output_lines = "; These options added automatically by {:s}".format(__file__)
     output_lines += "; On {:s}".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
 
     for section, option, value in insert_options_list:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -38,6 +38,18 @@ except:
 
 def printWarning(config_path, template):
 
+    """
+
+    Prints a warning to the user
+
+    Args:
+        config_path (): path to a config file
+        template (): path to the template file
+
+    Returns:
+
+    """
+
     print("This utility will copy all the options from the config file {} ".format(config_path))
     print("into a new file based on the template {} \n".format(template))
     print("Any options in the config file which are not in the template")
@@ -52,7 +64,10 @@ def printWarning(config_path, template):
 
 
 def parseConfigFileBySection(config_path):
-    """Parse the .config file, into one list and two lists of lists
+    """
+
+    Parse the .config file, into one list and two lists of lists
+
 
 
     Arguments:
@@ -91,7 +106,9 @@ def parseConfigFileBySection(config_path):
 
 def backupConfig(config_file_path, number_to_keep=5):
 
-    """Create numbered backups of the .config file
+    """
+
+    Create numbered backups of the .config file
 
 
         Arguments:
@@ -126,6 +143,24 @@ def backupConfig(config_file_path, number_to_keep=5):
 
 def getSectionHeaderFromLine(line):
 
+    """
+    Get the section header from a line
+
+    Qualification is an opening [
+    A word which is the the list of sections
+    Following by a closing ]
+
+    Args:
+        line (str): a string of text
+
+    Returns:
+        either
+            a string if a section header is found
+        or
+            None if no header is found
+    """
+
+
     opening_square_bracket, closing_square_bracket = False, False
     opening_square_bracket_position, closing_square_bracket_position = 0, 0
 
@@ -146,10 +181,8 @@ def getSectionHeaderFromLine(line):
 def sectionHeaderLine(line, section_list):
 
     """
-    Detect if this is a section header line
-    Qualification is an opening [
-    A word which is the the list of sections
-    Following by a closing ]
+    Detect if this is a section header line found in the section list
+
 
     Arguments:
         line: line to be checked
@@ -160,8 +193,6 @@ def sectionHeaderLine(line, section_list):
 
     """
 
-
-
     if getSectionHeaderFromLine(line) in section_list:
         return True
     else:
@@ -169,6 +200,7 @@ def sectionHeaderLine(line, section_list):
 
 
 def getOption(line, delimiter =":", preserve_case=True):
+
 
     """
     Get the option, if any from a line
@@ -233,8 +265,6 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
     """
     output_lines = ""
     insert_made = False
-
-
 
     for section, option, value in insert_options_list:
         if section == current_section:
@@ -324,7 +354,8 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
     new_sections_list = []
     for template_section in template_sections_list:
         if template_section not in sections_list:
-            print("{} is a new section in the template, not in the config".format(template_section))
+            if interactive:
+                print("{} is a new section in the template, not in the config".format(template_section))
             new_sections_list.append(template_section)
 
     # Work through the template file
@@ -397,6 +428,8 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
             if current_section in sections_list:
                 section_number = sections_list.index(current_section)
 
+            # If this section number is going to return a an option then it must have
+            # been in the station .config file
             if section_number < len(options_list_of_lists):
                 if option.lower() in options_list_of_lists[section_number]:
                     option_number = options_list_of_lists[section_number].index(option.lower())
@@ -409,7 +442,8 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
                                                 .format(option, current_section, getValue(line)))
                     output_line = line
             else:
-                print("Section {} was not found in station .config, copying this line across".format(current_section))
+                if interactive:
+                    print("From new section {} adding new line {}".format(template_sections_list[-1],line))
                 output_line = line
 
         else:
@@ -452,7 +486,8 @@ def compare(new_config_path, sections_list, options_list_of_lists, values_list_o
     correct_section = False
     for section in sections_list:
         if not sections_list.index(section) < len(options_list_of_lists):
-            print("Section {} is in the template file only, not comparing.".format(section))
+            if interactive:
+                print("Section {} is in the template file only, not comparing.".format(section))
             continue
         for option, value in zip(options_list_of_lists[sections_list.index(section)],
                                                                 values_list_of_lists[sections_list.index(section)]):

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -369,7 +369,7 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
         # If not any of these, then it must be a line with an option and value
         if not blank_line and not comment_line and not section_header_line and not uncomment_line:
             # added print call for debugging purposes
-            print(line)
+            print("[{}]  {}".format(current_section,line))
             option = getOption(line)
             section_number = sections_list.index(current_section)
             if option.lower() in options_list_of_lists[section_number]:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -368,6 +368,8 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
 
         # If not any of these, then it must be a line with an option and value
         if not blank_line and not comment_line and not section_header_line and not uncomment_line:
+            # added print call for debugging purposes
+            print(line)
             option = getOption(line)
             section_number = sections_list.index(current_section)
             if option.lower() in options_list_of_lists[section_number]:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -24,6 +24,7 @@ import glob
 import shutil
 import tempfile
 from RMS.Misc import mkdirP
+from datetime import datetime
 
 try:
     # Python 3
@@ -222,7 +223,8 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     """
 
-    output_lines = ""
+    output_lines = "; These options added automatically by {}",format(__file__)
+    output_lines += "; On {}".format(datetime.utcnow().strftime('%Y%m%d_%H%M%S.%f'))
 
     for section, option, value in insert_options_list:
         if section == current_section:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -223,13 +223,13 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
 
     """
     output_lines = ""
-    if len(insert_options_list):
-        output_lines += "; These options added automatically by {:s}\n".format(os.path.basename(sys.argv[0]))
-        output_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
+    insert_made = False
+
+
 
     for section, option, value in insert_options_list:
         if section == current_section:
-
+            insert_made = True
             insert = "{}: {}\n".format(option, value)
             if interactive:
                 print("Working in section {}".format(section))
@@ -239,7 +239,11 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
             else:
                 output_lines += insert
 
-    if len(insert_options_list):
+    if insert_made:
+        comment_lines = ""
+        comment_lines += "; These options added automatically by {:s}\n".format(os.path.basename(sys.argv[0]))
+        comment_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M'))
+        output_lines = comment_lines + output_lines
         if newline_after_last:
             output_lines += "\n"
 

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -222,9 +222,9 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
         str: value
 
     """
-
+    output_lines = ""
     if len(insert_options_list):
-        output_lines = "; These options added automatically by {:s}\n".format(__file__)
+        output_lines += "; These options added automatically by {:s}\n".format(__file__)
         output_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
 
     for section, option, value in insert_options_list:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -238,7 +238,8 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
             else:
                 output_lines += insert
 
-    output_lines += "\n" if newline_after_last else ""
+    if newline_after_last:
+        output_lines += "\n"
 
     return output_lines
 

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -224,7 +224,7 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
     """
     output_lines = ""
     if len(insert_options_list):
-        output_lines += "; These options added automatically by {:s}\n".format(__file__)
+        output_lines += "; These options added automatically by {:s}\n".format(sys.argv[0])
         output_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
 
     for section, option, value in insert_options_list:

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -1,3 +1,19 @@
+# RPi Meteor Station
+# Copyright (C) 2024
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import configparser
 import argparse
 import os

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -304,7 +304,17 @@ def populateTemplateConfig(config_template_file_path, config_file_path,
 def compare(new_config_path, sections_list, options_list_of_lists, values_list_of_lists):
 
     """
-    Compares a configuration file on disc against
+    Compares a configuration file on disc against data held in lists
+
+    Arguments:
+        new_config_path: path to the config file to be checked
+        sections_list: list of sections
+        options_list_of_lists: list of lists of options
+        values_list_of_lists: list of lists of values
+
+    Returns:
+        errors: human-readable list of errors
+        missing_options: list of lists of [section, option, value], intended to be passed to insert
 
     """
 
@@ -350,7 +360,21 @@ def compare(new_config_path, sections_list, options_list_of_lists, values_list_o
 
 def updateConfig(config_file_path, config_template_file_path, interactive=False):
 
+    """
+    Reads an existing station config, and writes out in the same format as the template file.
 
+
+    Arguments:
+        new_config_path: path to the config file to be checked
+        sections_list: list of sections
+        options_list_of_lists: list of lists of options
+        values_list_of_lists: list of lists of values
+
+    Returns:
+        errors: human-readable list of errors
+        missing_options: list of lists of [section, option, value], intended to be passed to insert
+
+    """
 
 
     config_file_path = os.path.expanduser(config_file_path)

--- a/Utils/UpdateConfig.py
+++ b/Utils/UpdateConfig.py
@@ -224,7 +224,7 @@ def insert(current_section, insert_options_list, interactive=False, newline_afte
     """
     output_lines = ""
     if len(insert_options_list):
-        output_lines += "; These options added automatically by {:s}\n".format(sys.argv[0])
+        output_lines += "; These options added automatically by {:s}\n".format(os.path.basename(sys.argv[0]))
         output_lines += "; On {:s}\n".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S+%f'))
 
     for section, option, value in insert_options_list:


### PR DESCRIPTION
This utility reads in a station .config file and parses it. It then reads in a template configuration file, and populates the template file with the values from the station .config file. 

It can handle edge cases, such as options that are commented out in the template file, but in force in the station config file. 

This is the first few lines of the station .config file for AU0006. 

```
; IMPORTANT: There always must be at least one space after the argument value and before the semicolon in front of the comment.
; For example, "parameter: value ; comment" is correct, while "parameter: value; comment" is incorrect.

[System]

stationID: AU0006
latitude: -32.0 ; WGS84 +N  (degrees )
longitude: 116.0 ; WGS84 +E (degrees)
elevation: 35 ; mean sea level EGM96 geoidal datum, not WGS84 ellipsoidal (meters)
```

When the command 

```
python -m Utils.UpdateConfig ~/source/RMS/.config -t ~/source/RMS/.configTemplate
```
The file is transformed as shown below.

```
; IMPORTANT: Unlike other RMS files, the '.config' file is never automatically
; updated. When changes are introduced to the config file in RMS, these changes
; will NOT be automatically reflected in the active '.config' file on
; individual machines. Users should manually update their '.config' file if
; changing any option from its default value is desired, or to simply stay
; up-to-date. If an option is missing from the config file, a default value
; will be automatically applied.
; An up-to-date template config '.configTemplate' file, containing the current
; options, is located in the RMS root directory.
; Run python -m Utils.AuditConfig to compare the .config file to the template.

[System]

; The assigned station ID
stationid: AU0006

; WGS84 +N (degrees)
latitude: -32.0

; WGS84 +E (degrees)
longitude: 116.0

; Mean sea level EGM96 geoidal datum, not WGS84 ellipsoidal (meters)
; Can be obtained from Google Earth or other apps. Raw GPS altitude should not
; be used as the software converts from EGM96 to WGS84 internally.
elevation: 33

; Should be set only if full CAMS compatibility is desired
cams_code: 0
```

Options that are commented out in the template such as 

```
; The description shown on the weblog (e.g. location, pointing direction)
weblog_description: none

; Server will generate obfuscated coordinates for public datasets.
; Optionally, uncomment and populate the three parameters below to use a
; specific public location if desired. The recommended precision is two decimal
; places for latitude and longitude, and ~10 m for elevation.
;
; WGS84 +N (degrees)
; public_latitude: 0.0
;
; WGS84 +E (degrees)
; public_longitude: 0.0
;
; mean sea level EGM96 (meters)
; public_elevation: 0.0
```

will be uncommented if they are required 

```
; The description shown on the weblog (e.g. location, pointing direction)
weblog_description: Baldivis (testing)

; Server will generate obfuscated coordinates for public datasets.
; Optionally, uncomment and populate the three parameters below to use a
; specific public location if desired. The recommended precision is two decimal
; places for latitude and longitude, and ~10 m for elevation.
;
; WGS84 +N (degrees)
public_latitude: -32.3310873
;
; WGS84 +E (degrees)
public_longitude: 115.8165646
;
; mean sea level EGM96 (meters)
public_elevation: 40
```

The tool can also be run interactively 

```
python -m Utils.UpdateConfig ~/source/RMS/.config -t ~/source/RMS/.configTemplate -i
```
or can be called from another program.

A rolling backup scheme is implemented, with a default of 5 backups.

```
-rw-r--r-- 1 david david 20K Aug 16 15:24 .config
-rw-r--r-- 1 david david 20K Aug 16 15:24 .config_1
-rw-r--r-- 1 david david 20K Aug 16 15:22 .config_2
-rw-r--r-- 1 david david 20K Aug 16 15:20 .config_3
-rw-r--r-- 1 david david 20K Aug 16 15:19 .config_4
-rw-r--r-- 1 david david 20K Aug 16 15:18 .config_5
-rw-r--r-- 1 david david 19K Aug 16 07:35 .configTemplate
```

Options which are in the station config file, but not in the template will be inserted at the end of the appropriate section. When run interactively, each option can be selected individually.


