### PR TITLE
Feature filenameontrackstack

### DIFF
--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -337,6 +337,8 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
     else:
         filenam = os.path.join(dir_path, os.path.basename(dir_path) + "_track_stack.jpg")
 
+    # Overlay the filename on the image
+
     if overlay_file_name:
         print("Overlaying filename: {}".format(os.path.basename(filenam)))
         ax.text(10, stack_img.shape[0] + 30, os.path.basename(filenam), color='grey', fontsize=6, fontname='Source Sans Pro',

--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -35,7 +35,7 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         platepars_all_recalibrated.json file.
 
     Arguments:
-        dir_path: [str] Path to the directory with image files.
+        dir_paths: [str] Path to the directory with image files.
         config: [Config instance]
 
     Keyword arguments:
@@ -48,6 +48,8 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         darkbackground: [bool] force the sky background to be dark
         out_dir: target folder to save into
         scalefactor: factor to scale the canvas by; default 1, increase if image cropped
+        draw_constellations: [bool] Show constellation lines on stacked image
+        one_core_free: [bool] leave one core free whilst processing
         overlay_file_name: [bool] show the filename on the completed image
     """
     start_time = time.time()

--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -338,11 +338,11 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         filenam = os.path.join(dir_path, os.path.basename(dir_path) + "_track_stack.jpg")
 
     # Overlay the filename on the image
-
     if overlay_file_name:
         print("Overlaying filename: {}".format(os.path.basename(filenam)))
         ax.text(10, stack_img.shape[0] + 30, os.path.basename(filenam), color='grey', fontsize=6, fontname='Source Sans Pro',
                 weight='ultralight')
+
     plt.savefig(filenam, bbox_inches='tight', pad_inches=0, dpi=dpi, facecolor='k', edgecolor='k')
     print('saved to {}'.format(filenam))
     #

--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -29,7 +29,8 @@ import datetime
 
 def trackStack(dir_paths, config, border=5, background_compensation=True, 
         hide_plot=False, showers=None, darkbackground=False, out_dir=None,
-        scalefactor=None, draw_constellations=False, one_core_free=False):
+        scalefactor=None, draw_constellations=False, one_core_free=False,
+        overlay_file_name=False):
     """ Generate a stack with aligned stars, so the sky appears static. The folder should have a
         platepars_all_recalibrated.json file.
 
@@ -47,6 +48,7 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         darkbackground: [bool] force the sky background to be dark
         out_dir: target folder to save into
         scalefactor: factor to scale the canvas by; default 1, increase if image cropped
+        overlay_file_name: [bool] show the filename on the completed image
     """
     start_time = time.time()
     # normalise the path in a platform neutral way
@@ -334,6 +336,11 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         filenam = os.path.join(out_dir, os.path.basename(dir_path) + "_track_stack.jpg")
     else:
         filenam = os.path.join(dir_path, os.path.basename(dir_path) + "_track_stack.jpg")
+
+    if overlay_file_name:
+        print("Overlaying filename: {}".format(os.path.basename(filenam)))
+        ax.text(10, stack_img.shape[0] + 30, os.path.basename(filenam), color='grey', fontsize=6, fontname='Source Sans Pro',
+                weight='ultralight')
     plt.savefig(filenam, bbox_inches='tight', pad_inches=0, dpi=dpi, facecolor='k', edgecolor='k')
     print('saved to {}'.format(filenam))
     #
@@ -476,6 +483,9 @@ if __name__ == "__main__":
     arg_parser.add_argument('-o', '--output', type=str,
         help="""folder to save the image in.""")
 
+    arg_parser.add_argument('-n', '--overlayfilename', action="store_true",
+                            help="""Overlay filename on image.""")
+
     arg_parser.add_argument('-f', '--scalefactor', type=int,
         help="""scale factor to apply. Increase if image is cropped""")
 
@@ -508,4 +518,5 @@ if __name__ == "__main__":
     trackStack(dir_paths, config, background_compensation=(not cml_args.bkgnormoff),
         hide_plot=cml_args.hideplot, showers=showers,
         darkbackground=cml_args.darkbackground, out_dir=cml_args.output, scalefactor=cml_args.scalefactor,
-        draw_constellations=cml_args.constellations, one_core_free=cml_args.freecore)
+        draw_constellations=cml_args.constellations, one_core_free=cml_args.freecore,
+        overlay_file_name = cml_args.overlayfilename)

--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -30,7 +30,7 @@ import datetime
 def trackStack(dir_paths, config, border=5, background_compensation=True, 
         hide_plot=False, showers=None, darkbackground=False, out_dir=None,
         scalefactor=None, draw_constellations=False, one_core_free=False,
-        overlay_file_name=False):
+        textoption=0):
     """ Generate a stack with aligned stars, so the sky appears static. The folder should have a
         platepars_all_recalibrated.json file.
 
@@ -339,10 +339,18 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
     else:
         filenam = os.path.join(dir_path, os.path.basename(dir_path) + "_track_stack.jpg")
 
-    # Overlay the filename on the image
-    if overlay_file_name:
-        print("Overlaying filename: {}".format(os.path.basename(filenam)))
-        ax.text(10, stack_img.shape[0] + 30, os.path.basename(filenam), color='grey', fontsize=6, fontname='Source Sans Pro',
+    # Overlay the filename on the image\
+    bf = os.path.basename(filenam)
+
+    # Overlay filename only
+    if textoption[0] == 1:
+        ax.text(10, stack_img.shape[0] + 30, bf, color='grey', fontsize=6, fontname='Source Sans Pro',
+                weight='ultralight')
+
+    # Overlay stationID, YYYY-MM-DD Meteor count
+    if textoption[0] == 2:
+        annotation = "{}  {}-{}-{}      Meteors: {}".format(bf[0:6],bf[7:11],bf[11:13],bf[13:15],num_plotted)
+        ax.text(10, stack_img.shape[0] + 30, annotation, color='grey', fontsize=6, fontname='Source Sans Pro',
                 weight='ultralight')
 
     plt.savefig(filenam, bbox_inches='tight', pad_inches=0, dpi=dpi, facecolor='k', edgecolor='k')
@@ -487,8 +495,11 @@ if __name__ == "__main__":
     arg_parser.add_argument('-o', '--output', type=str,
         help="""folder to save the image in.""")
 
-    arg_parser.add_argument('-n', '--overlayfilename', action="store_true",
-                            help="""Overlay filename on image.""")
+    arg_parser.add_argument('-t', '--textoption', nargs=1, type=int,
+                            help="""Add text beneath image. 
+                                        0 - No text
+                                        1 - Filename 
+                                        2 - Station id, date, meteor count""")
 
     arg_parser.add_argument('-f', '--scalefactor', type=int,
         help="""scale factor to apply. Increase if image is cropped""")
@@ -523,4 +534,4 @@ if __name__ == "__main__":
         hide_plot=cml_args.hideplot, showers=showers,
         darkbackground=cml_args.darkbackground, out_dir=cml_args.output, scalefactor=cml_args.scalefactor,
         draw_constellations=cml_args.constellations, one_core_free=cml_args.freecore,
-        overlay_file_name = cml_args.overlayfilename)
+        textoption = cml_args.textoption)

--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -343,14 +343,15 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
     bf = os.path.basename(filenam)
 
     # Overlay filename only
-    if textoption[0] == 1:
-        ax.text(10, stack_img.shape[0] + 30, bf, color='grey', fontsize=6, fontname='Source Sans Pro',
-                weight='ultralight')
+    if textoption is not None:
+        if textoption[0] == 1:
+            ax.text(10, stack_img.shape[0] + 30, bf, color='grey', fontsize=6, fontname='Source Sans Pro',
+                    weight='ultralight')
 
     # Overlay stationID, YYYY-MM-DD Meteor count
-    if textoption[0] == 2:
-        annotation = "{}  {}-{}-{}      Meteors: {}".format(bf[0:6],bf[7:11],bf[11:13],bf[13:15],num_plotted)
-        ax.text(10, stack_img.shape[0] + 30, annotation, color='grey', fontsize=6, fontname='Source Sans Pro',
+        if textoption[0] == 2:
+            annotation = "{}  {}-{}-{}      Meteors: {}".format(bf[0:6],bf[7:11],bf[11:13],bf[13:15],num_plotted)
+            ax.text(10, stack_img.shape[0] + 30, annotation, color='grey', fontsize=6, fontname='Source Sans Pro',
                 weight='ultralight')
 
     plt.savefig(filenam, bbox_inches='tight', pad_inches=0, dpi=dpi, facecolor='k', edgecolor='k')


### PR DESCRIPTION
This feature was requested by a single operator many months ago, and adds the ability to add either

0) nothing
1) the filename
2) the stationID, date and meteor count to a TrackStack

I don't believe that this functionality is required by many operator, however before I delete this branch, offering this PR. 