### PR TITLE
Cleanup for *.so files in the repository folder

### DIFF
--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -51,6 +51,10 @@ rm -r build
 echo "Running pyclean for thorough cleanup..."
 pyclean . -v --debris all
 
+# Cleanup for *.so files in the repository folder
+echo "Cleaning up *.so files in the repository..."
+find . -name "*.so" -type f -delete
+
 # Set the flag indicating that the RMS dir is reset
 echo "1" > $UPDATEINPROGRESSFILE
 


### PR DESCRIPTION
I'm hoping this addresses #349. In any case, this PR adds a cleanup of all *.so files in the source dir when RMS_update is run.