### PR TITLE
Log stderr, GStreamer, and optionally stdout messages

### DIFF
--- a/.config
+++ b/.config
@@ -215,6 +215,11 @@ arch_dirs_to_keep: 20
 ; number of days of logs to keep. Default is 30
 logdays_to_keep: 30
 
+; Control additional logging of console output messages
+; Set to true to include extra console output in log file
+; Note: This does not affect normal logging, only additional console messages
+log_stdout: false
+
 ; number of bz2 compressed archive folders to keep. Default 20
 bz2_files_to_keep: 20
 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -345,6 +345,9 @@ class Config:
         # days of logfiles to keep
         self.logdays_to_keep = 30
 
+        # Toggle logging stdout messages
+        self.log_stdout = False
+
         # ArchDirs and bzs to keep
         # keep this many ArchDirs. Zero means keep them all
         self.arch_dirs_to_keep = 20
@@ -913,6 +916,9 @@ def parseCapture(config, parser):
 
     if parser.has_option(section, "logdays_to_keep"):
         config.logdays_to_keep = int(parser.get(section, "logdays_to_keep"))
+
+    if parser.has_option(section, "log_stdout"):
+        config.log_stdout = parser.getboolean(section, "log_stdout")
 
     if parser.has_option(section, "arch_dirs_to_keep"):
         config.arch_dirs_to_keep = int(parser.get(section, "arch_dirs_to_keep"))


### PR DESCRIPTION
This PR enhances logging capabilities with the following changes:

1. Enables logging of stderr messages.
2. Adds support for logging GStreamer messages when available.
3. Introduces a new configuration option to optionally log stdout messages (defaults to False)

These improvements are particularly useful for debugging, especially when capturing messages that are not explicitly logged through the main logging system.

The new config option `log_stdout` allows operators to include additional console output in the log file, providing more context when troubleshooting issues.