### PR TITLE
Get the path to the RMS root directory without importing the whole codebase

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -20,22 +20,14 @@ import math
 import os
 import sys
 
+# Consolidated version-specific imports and definitions
 if sys.version_info[0] == 3:
     import importlib.util
+    from configparser import NoOptionError, RawConfigParser
 else:
     import pkgutil
-
-try:
-    # Python 3
-    from configparser import NoOptionError, RawConfigParser 
-
-except:
-    # Python 2
     from ConfigParser import NoOptionError, RawConfigParser
-
-# Map FileNotFoundError to IOError in Python 2 as it does not exist
-if sys.version_info[0] < 3:
-    FileNotFoundError = IOError
+    FileNotFoundError = IOError  # Map FileNotFoundError to IOError in Python 2
 
 # Used to determine detection parameters which will change in ML filtering is available
 try:

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -19,13 +19,12 @@ from __future__ import absolute_import, division, print_function
 import math
 import os
 import sys
+from RMS.Misc import getRmsRootDir
 
 # Consolidated version-specific imports and definitions
 if sys.version_info[0] == 3:
-    import importlib.util
     from configparser import NoOptionError, RawConfigParser
 else:
-    import pkgutil
     from ConfigParser import NoOptionError, RawConfigParser
     FileNotFoundError = IOError  # Map FileNotFoundError to IOError in Python 2
 
@@ -229,26 +228,8 @@ def loadConfigFromDirectory(cml_args_config, dir_path):
 class Config:
     def __init__(self):
 
-        # Get the path to the RMS root directory without importing the whole codebase
-        if sys.version_info[0] == 3:
-            # Python 3.x: Use importlib to find the RMS module
-            rms_spec = importlib.util.find_spec('RMS')
-            if rms_spec is None or rms_spec.origin is None:
-                raise ImportError("RMS module not found.")
-
-            # Get the absolute path to the RMS root directory
-            self.rms_root_dir = os.path.abspath(os.path.dirname(os.path.dirname(rms_spec.origin)))
-        else:
-            # Python 2.7: Use pkgutil (deprecated) to locate the RMS module
-            loader = pkgutil.get_loader('RMS')
-            if loader is None:
-                raise ImportError("RMS module not found.")
-
-            # Get the filename associated with the loader
-            rms_file = loader.get_filename()
-
-            # Get the absolute path to the RMS root directory
-            self.rms_root_dir = os.path.abspath(os.path.dirname(os.path.dirname(rms_file)))
+        # Get the path to the RMS root directory
+        self.rms_root_dir = getRmsRootDir()
 
         # default config file absolute path
         self.config_file_name = os.path.join(self.rms_root_dir, '.config')

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -20,7 +20,10 @@ import math
 import os
 import sys
 
-import RMS
+if sys.version_info[0] == 3:
+    import importlib.util
+else:
+    import pkgutil
 
 try:
     # Python 3
@@ -234,8 +237,26 @@ def loadConfigFromDirectory(cml_args_config, dir_path):
 class Config:
     def __init__(self):
 
-        # Get the package root directory
-        self.rms_root_dir = os.path.abspath(os.path.join(os.path.dirname(RMS.__file__), os.pardir))
+        # Get the path to the RMS root directory without importing the whole codebase
+        if sys.version_info[0] == 3:
+            # Python 3.x: Use importlib to find the RMS module
+            rms_spec = importlib.util.find_spec('RMS')
+            if rms_spec is None or rms_spec.origin is None:
+                raise ImportError("RMS module not found.")
+
+            # Get the absolute path to the RMS root directory
+            self.rms_root_dir = os.path.abspath(os.path.dirname(os.path.dirname(rms_spec.origin)))
+        else:
+            # Python 2.7: Use pkgutil (deprecated) to locate the RMS module
+            loader = pkgutil.get_loader('RMS')
+            if loader is None:
+                raise ImportError("RMS module not found.")
+
+            # Get the filename associated with the loader
+            rms_file = loader.get_filename()
+
+            # Get the absolute path to the RMS root directory
+            self.rms_root_dir = os.path.abspath(os.path.dirname(os.path.dirname(rms_file)))
 
         # default config file absolute path
         self.config_file_name = os.path.join(self.rms_root_dir, '.config')

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -18,9 +18,11 @@ import datetime
 if sys.version_info[0] < 3:
     import Tkinter as tkinter
     import tkFileDialog as filedialog
+    import pkgutil
 else:
     import tkinter
     from tkinter import filedialog
+    import importlib.util
 
 
 import numpy as np
@@ -709,3 +711,28 @@ def maxDistBetweenPoints(points_x, points_y):
 
     return max_separation
 
+
+def getRmsRootDir():
+    """
+        Return the path to the RMS root directory without importing the whole
+        codebase
+    """
+    if sys.version_info[0] == 3:
+        # Python 3.x: Use importlib to find the RMS module
+        rms_spec = importlib.util.find_spec('RMS')
+        if rms_spec is None or rms_spec.origin is None:
+            raise ImportError("RMS module not found.")
+
+        # Get the absolute path to the RMS root directory
+        return os.path.abspath(os.path.dirname(os.path.dirname(rms_spec.origin)))
+    else:
+        # Python 2.7: Use pkgutil (deprecated) to locate the RMS module
+        loader = pkgutil.get_loader('RMS')
+        if loader is None:
+            raise ImportError("RMS module not found.")
+
+        # Get the filename associated with the loader
+        rms_file = loader.get_filename()
+
+        # Get the absolute path to the RMS root directory
+        return os.path.abspath(os.path.dirname(os.path.dirname(rms_file)))

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -2614,7 +2614,7 @@ class PlateTool(QtWidgets.QMainWindow):
         self.dir_path = dir_path
 
         # Update the path to the RMS root directory
-        self.rms_root_dir = getRmsRootDir()
+        self.config.rms_root_dir = getRmsRootDir()
         
         # Swap the fixed variable name
         if hasattr(self, "star_aperature_radius"):

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -44,16 +44,11 @@ from RMS.Routines.GreatCircle import fitGreatCircle, greatCircle, greatCirclePha
 from RMS.Routines.MaskImage import getMaskFile
 from RMS.Routines import RollingShutterCorrection
 from RMS.Routines.MaskImage import loadMask, MaskStructure, getMaskFile
-from RMS.Misc import maxDistBetweenPoints
+from RMS.Misc import maxDistBetweenPoints, getRmsRootDir
 
 import pyximport
 pyximport.install(setup_args={'include_dirs': [np.get_include()]})
 from RMS.Astrometry.CyFunctions import subsetCatalog, equatorialCoordPrecession
-
-if sys.version_info[0] == 3:
-    import importlib.util
-else:
-    import pkgutil
 
 
 class QFOVinputDialog(QtWidgets.QDialog):
@@ -2618,26 +2613,8 @@ class PlateTool(QtWidgets.QMainWindow):
         # Set the dir path in case it changed
         self.dir_path = dir_path
 
-        # Update the path to the RMS root directory without importing the whole codebase
-        if sys.version_info[0] == 3:
-            # Python 3.x: Use importlib to find the RMS module
-            rms_spec = importlib.util.find_spec('RMS')
-            if rms_spec is None or rms_spec.origin is None:
-                raise ImportError("RMS module not found.")
-
-            # Get the absolute path to the RMS root directory
-            self.rms_root_dir = os.path.abspath(os.path.dirname(os.path.dirname(rms_spec.origin)))
-        else:
-            # Python 2.7: Use pkgutil (deprecated) to locate the RMS module
-            loader = pkgutil.get_loader('RMS')
-            if loader is None:
-                raise ImportError("RMS module not found.")
-
-            # Get the filename associated with the loader
-            rms_file = loader.get_filename()
-
-            # Get the absolute path to the RMS root directory
-            self.rms_root_dir = os.path.abspath(os.path.dirname(os.path.dirname(rms_file)))
+        # Update the path to the RMS root directory
+        self.rms_root_dir = getRmsRootDir()
         
         # Swap the fixed variable name
         if hasattr(self, "star_aperature_radius"):


### PR DESCRIPTION
 Optimize RMS module location without full import (Python 2/3 compatible)

Changes
- Replace direct `import RMS` with version-specific module location methods
- Use `importlib.util.find_spec()` for Python 3.x
- Use `pkgutil.get_loader()` for Python 2.7 (with deprecation note)
- Determine RMS root directory without importing the entire module

 Benefits
1. **Memory Efficiency**: Avoids loading the entire RMS module into memory when only the path is needed
2. **Performance**: Faster initialization as it skips full module import


Implementation
```python
if sys.version_info[0] == 3:
    import importlib.util
else:
    import pkgutil

...

# Get the path to the RMS root directory without importing the whole codebase
if sys.version_info[0] == 3:
    # Python 3.x: Use importlib to find the RMS module
    rms_spec = importlib.util.find_spec('RMS')
    if rms_spec is None or rms_spec.origin is None:
        raise ImportError("RMS module not found.")
    # Get the absolute path to the RMS root directory
    self.rms_root_dir = os.path.abspath(os.path.dirname(os.path.dirname(rms_spec.origin)))
else:
    # Python 2.7: Use pkgutil (deprecated) to locate the RMS module
    loader = pkgutil.get_loader('RMS')
    if loader is None:
        raise ImportError("RMS module not found.")
    # Get the filename associated with the loader
    rms_file = loader.get_filename()
    # Get the absolute path to the RMS root directory
    self.rms_root_dir = os.path.abspath(os.path.dirname(os.path.dirname(rms_file)))
```

Tested successfully on python 3.x