### PR TITLE
Add stationID to observation summary

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -151,7 +151,7 @@ def startObservationSummaryReport(config, duration, force_delete=False):
             force_delete: forces deletion of the observation summary database, default False
 
         returns:
-            conn: [connection] connection to database if success else None
+            conn: [connection] connection to database
 
         """
 
@@ -159,6 +159,7 @@ def startObservationSummaryReport(config, duration, force_delete=False):
     conn = getObsDBConn(config, force_delete=force_delete)
     addObsParam(conn, "start_time", datetime.datetime.utcnow() - datetime.timedelta(seconds=1))
     addObsParam(conn, "duration", duration)
+    addObsParam(conn, "stationID", config.stationID)
 
     if isRaspberryPi():
         with open('/sys/firmware/devicetree/base/model', 'r') as m:
@@ -486,6 +487,7 @@ def unserialize(self):
 
 
 if __name__ == "__main__":
+
     config = parse(os.path.expanduser("~/source/RMS/.config"))
 
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -159,7 +159,7 @@ def startObservationSummaryReport(config, duration, force_delete=False):
     conn = getObsDBConn(config, force_delete=force_delete)
     addObsParam(conn, "start_time", datetime.datetime.utcnow() - datetime.timedelta(seconds=1))
     addObsParam(conn, "duration", duration)
-    addObsParam(conn, "stationID", config.stationID)
+    addObsParam(conn, "stationID", sanitise(config.stationID, space_substitution=""))
 
     if isRaspberryPi():
         with open('/sys/firmware/devicetree/base/model', 'r') as m:
@@ -178,9 +178,9 @@ def startObservationSummaryReport(config, duration, force_delete=False):
         print("RMS Git repository not found. Skipping Git-related information.")
 
     storage_total, storage_used, storage_free = shutil.disk_usage("/")
-    addObsParam(conn, "storage_total_gb", round(storage_total / (1024 **3 ),2))
-    addObsParam(conn, "storage_used_gb", round(storage_used / (1024 **3 ),2))
-    addObsParam(conn, "storage_free_gb", round(storage_free / (1024 **3 ),2))
+    addObsParam(conn, "storage_total_gb", round(storage_total / (1024 ** 3), 2))
+    addObsParam(conn, "storage_used_gb", round(storage_used / (1024 ** 3), 2))
+    addObsParam(conn, "storage_free_gb", round(storage_free / (1024 ** 3), 2))
 
     captured_directories = captureDirectories(os.path.join(config.data_dir, config.captured_dir), config.stationID)
     addObsParam(conn, "captured_directories", captured_directories)


### PR DESCRIPTION
Iss #389 requests that staionID is added to the observation summary report txt and json files. This PR adds that feature. 

```
Summary as colon delimited text
camera_fov_h                    : 53.68 
camera_fov_v                    : 29.972716 
camera_information              : Error 
camera_lens                     : 6mm 
camera_pointing_alt             : 44.43 degrees 
camera_pointing_az              : 260.28 degrees 
capture_duration_from_fits      : 42986.413 
captured_directories            : 5 
commit_date                     : 20240829_232717 
commit_hash                     : 0ca5395172d94472da06235ec4cd40cb03209e0e 
duration                        : 100 
fits_file_shortfall             : 10 
fits_file_shortfall_as_time     : 0:01:42.400000 
fits_files_from_duration        : 9.765625 
hardware_version                : raspberry pi 5 model b rev 10 
start_time                      : 2024-08-29 23:29:55.028407 
stationID                       : AU0004 
storage_free_gb                 : 26.66 
storage_total_gb                : 116.6 
storage_used_gb                 : 85.16 
time_first_fits_file            : 2024-08-25 10:20:44.252000 
time_last_fits_file             : 2024-08-25 22:17:00.425000 
total_expected_fits             : 4198 
total_fits                      : 4188 

Summary as json
{
    "camera_fov_h": "53.68",
    "camera_fov_v": "29.972716",
    "camera_information": "Error",
    "camera_lens": "6mm",
    "camera_pointing_alt": "44.43 degrees",
    "camera_pointing_az": "260.28 degrees",
    "capture_duration_from_fits": "42986.413",
    "captured_directories": "5",
    "commit_date": "20240829_232717",
    "commit_hash": "0ca5395172d94472da06235ec4cd40cb03209e0e",
    "duration": "100",
    "fits_file_shortfall": "10",
    "fits_file_shortfall_as_time": "0:01:42.400000",
    "fits_files_from_duration": "9.765625",
    "hardware_version": "raspberry pi 5 model b rev 10",
    "start_time": "2024-08-29 23:29:55.028407",
    "stationID": "AU0004",
    "storage_free_gb": "26.66",
    "storage_total_gb": "116.6",
    "storage_used_gb": "85.16",
    "time_first_fits_file": "2024-08-25 10:20:44.252000",
    "time_last_fits_file": "2024-08-25 22:17:00.425000",
    "total_expected_fits": "4198",
    "total_fits": "4188"
}
```