### PR TITLE
Remove unwanted space from Observation Summary log

### DIFF
--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -583,7 +583,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
     except:
         pass
 
-    log.info("\n\n " + serialize(config) + "\n\n")
+    log.info("\nObservation Summary\n===================\n\n" + serialize(config) + "\n\n")
 
 
     extra_files.append(observation_summary_path_file_name)

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -583,7 +583,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
     except:
         pass
 
-    log.info("\nObservation Summary\n===================\n\n" + serialize(config) + "\n\n")
+    log.info("\n\nObservation Summary\n===================\n\n" + serialize(config) + "\n\n")
 
 
     extra_files.append(observation_summary_path_file_name)


### PR DESCRIPTION
This PR is in response to issue #399, and removes the unwanted space character from the Observation Summary log entry, also adding a title.

I'll leave this as draft until I have tested on a few of my own stations. 


