### PR TITLE
Correct default config value for weblog

### DIFF
--- a/.config
+++ b/.config
@@ -32,7 +32,7 @@ cams_code: 0
 ; ----------------------
 
 ; Show this camera on the GMN weblog
-weblog_enable: false
+weblog_enable: true
 
 ; The description shown on the weblog (e.g. location, pointing direction)
 weblog_description: none


### PR DESCRIPTION
Address issue #414. This enables weblog in the default config file.