### PR TITLE
Disable observation summary report creation when given video file

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -383,7 +383,7 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         detector=detector)
 
     # Open the observation summary report
-    if not video_file:
+    if video_file is None:
         log.info(startObservationSummaryReport(config, duration, force_delete=False))
 
     # Start buffered capture

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -383,7 +383,8 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         detector=detector)
 
     # Open the observation summary report
-    log.info(startObservationSummaryReport(config, duration, force_delete=False))
+    if not video_file:
+        log.info(startObservationSummaryReport(config, duration, force_delete=False))
 
     # Start buffered capture
     bc.startCapture()


### PR DESCRIPTION
Updates RMS/StartCapture.py to not produce an observation summary when using a video file (Resolves #417 )