### PR TITLE
Define .config Path Relative to RMS Root

### DIFF
--- a/RMS/Astrometry/CyFunctions.pyxbld
+++ b/RMS/Astrometry/CyFunctions.pyxbld
@@ -5,9 +5,13 @@ def make_ext(modname, pyxfilename):
     # Use extra compile arguments for this Cython
     import RMS.ConfigReader as cr
     from distutils.extension import Extension
+    from RMS.Misc import getRmsRootDir
+    import os
 
     # Load the configuration file
-    config = cr.parse(".config")
+    config_filename = '.config'
+    config_path = os.path.join(getRmsRootDir(), config_filename)
+    config = cr.parse(config_path)
 
     # Use additional compile arguments
     ext = Extension(name = modname,

--- a/RMS/CompressionCy.pyxbld
+++ b/RMS/CompressionCy.pyxbld
@@ -5,9 +5,13 @@ def make_ext(modname, pyxfilename):
     # Use extra compile arguments for this Cython
     import RMS.ConfigReader as cr
     from distutils.extension import Extension
+    from RMS.Misc import getRmsRootDir
+    import os
 
     # Load the configuration file
-    config = cr.parse(".config")
+    config_filename = '.config'
+    config_path = os.path.join(getRmsRootDir(), config_filename)
+    config = cr.parse(config_path)
 
     # Use additional compile arguments
     ext = Extension(name = modname,

--- a/RMS/Routines/Grouping3Dcy.pyxbld
+++ b/RMS/Routines/Grouping3Dcy.pyxbld
@@ -5,9 +5,13 @@ def make_ext(modname, pyxfilename):
     # Use extra compile arguments for this Cython
     import RMS.ConfigReader as cr
     from distutils.extension import Extension
+    from RMS.Misc import getRmsRootDir
+    import os
 
     # Load the configuration file
-    config = cr.parse(".config")
+    config_filename = '.config'
+    config_path = os.path.join(getRmsRootDir(), config_filename)
+    config = cr.parse(config_path)
 
     # Use additional compile arguments
     ext = Extension(name = modname,

--- a/RMS/Routines/MorphCy.pyxbld
+++ b/RMS/Routines/MorphCy.pyxbld
@@ -5,9 +5,13 @@ def make_ext(modname, pyxfilename):
     # Use extra compile arguments for this Cython
     import RMS.ConfigReader as cr
     from distutils.extension import Extension
+    from RMS.Misc import getRmsRootDir
+    import os
 
     # Load the configuration file
-    config = cr.parse(".config")
+    config_filename = '.config'
+    config_path = os.path.join(getRmsRootDir(), config_filename)
+    config = cr.parse(config_path)
 
     # Use additional compile arguments
     ext = Extension(name = modname,


### PR DESCRIPTION
Currently, RMS can only function when the working directory is the RMS root directory because the `.config` path is defined relative to the working directory in the .pyxbld files. This is inconvenient when, for instance, we want to use RMS functions in other projects. This PR defines the `.config' path relative to the RMS root directory regardless of the actual working directory path. 