### PR TITLE
Add support for VideoFormat, ClearFog, and BroadTrends Camera Settings

### DIFF
--- a/Scripts/RMS_SetCameraParams.sh
+++ b/Scripts/RMS_SetCameraParams.sh
@@ -27,6 +27,7 @@ python -m Utils.CameraControl CameraTime set
 python -m Utils.CameraControl CloudConnection off
 
 # set the Video Encoder parameters
+python -m Utils.CameraControl SetParam General VideoFormat PAL
 python -m Utils.CameraControl SetParam Encode Video Compression H.264
 python -m Utils.CameraControl SetParam Encode Video Resolution 720P
 python -m Utils.CameraControl SetParam Encode Video BitRateControl VBR
@@ -37,6 +38,8 @@ python -m Utils.CameraControl SetParam Encode VideoEnable 1
 python -m Utils.CameraControl SetParam Encode SecondStream 0
 
 # camera parameters
+python -m Utils.CameraControl SetParam Camera ClearFog enable 0
+python -m Utils.CameraControl SetParam Camera ClearFog level 50
 python -m Utils.CameraControl SetParam Camera Style type1
 python -m Utils.CameraControl SetParam Camera AeSensitivity 1
 python -m Utils.CameraControl SetParam Camera ApertureMode 0
@@ -51,6 +54,8 @@ python -m Utils.CameraControl SetParam Camera ExposureParam Level 0
 python -m Utils.CameraControl SetParam Camera ExposureParam MostTime 40000
 python -m Utils.CameraControl SetParam Camera GainParam AutoGain 1
 python -m Utils.CameraControl SetParam Camera GainParam Gain 60
+python -m Utils.CameraControl SetParam Camera BroadTrends AutoGain 0
+python -m Utils.CameraControl SetParam Camera BroadTrends Gain 50
 python -m Utils.CameraControl SetParam Camera IRCUTMode 0
 python -m Utils.CameraControl SetParam Camera IrcutSwap 0
 python -m Utils.CameraControl SetParam Camera Night_nfLevel 0


### PR DESCRIPTION
This PR adds the following settings to `RMS_SetCameraParams.sh`:
```
python -m Utils.CameraControl SetParam General VideoFormat PAL
python -m Utils.CameraControl SetParam Camera ClearFog enable 0
python -m Utils.CameraControl SetParam Camera ClearFog level 50
python -m Utils.CameraControl SetParam Camera BroadTrends AutoGain 0
python -m Utils.CameraControl SetParam Camera BroadTrends Gain 50
```
Setting VideoFormat to PAL ensures that the camera is not accidentally set to NTSC, which would affect the evenness of the frame rate.

**ClearFog** and **BroadTrends** are set to their default values in case they were changed to other settings for day observation. Setting **BroadTrends AutoGain** to 0 allows preservation of highlights during day observation.

The PR also changes the name and format of the resulting JSON files saved with **CameraControl SaveSettings**. The JSON files are now indented. An additional `location.json` file is created to save the VideoFormat. The net#.json files are renamed to more explicit names.



