### PR TITLE
Add FOV check for platepar

### DIFF
--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -106,6 +106,26 @@ def getPlatepar(config, night_data_dir):
                 platepar.lon = config.longitude
                 platepar.elev = config.elevation
 
+        
+        # Make sure the config and the platepar FOV are within a factor of two
+        if (platepar.fov_h is not None) and (platepar.fov_v is not None):
+            
+            # Calculate the diagonal FOV for both the platepar and the config
+            pp_fov_diag = (platepar.fov_h**2 + platepar.fov_v**2)**0.5
+            config_fov_diag = (config.fov_w**2 + config.fov_h**2)**0.5
+
+            # Compute the ratio of the FOVs
+            fov_ratio = pp_fov_diag/config_fov_diag
+
+            # If the ratio is smaller than 0.5 or greater than 2, don't use this platepar
+            if (fov_ratio < 0.5) or (fov_ratio > 2):
+                    
+                # If they don't match, don't use this platepar
+                log.info("The FOV in the platepar is not within a factor of 2 of the FOV in the config file! Not using the platepar...")
+
+                platepar = None
+                platepar_fmt = None
+
 
     # Make sure the image resolution matches
     if platepar is not None:


### PR DESCRIPTION
This pull request adds a FOV check for the platepar in the `Reprocess.py` file. The check ensures that the FOV in the platepar is within a factor of two of the FOV in the config file. If the FOV ratio is smaller than 0.5 or greater than 2, the platepar is not used. This check helps to ensure that the platepar and config file are compatible before using the platepar for further processing.

Example of when this is needed: https://globalmeteornetwork.org/weblog/US/US003F/US003F_20240924_021434_064110_detected/