### PR TITLE
Silence full TensorFlow nuisance messages

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -25,6 +25,7 @@ from RMS.Misc import getRmsRootDir
 if sys.version_info[0] == 3:
     from configparser import NoOptionError, RawConfigParser
 else:
+    os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
     from ConfigParser import NoOptionError, RawConfigParser
     FileNotFoundError = IOError  # Map FileNotFoundError to IOError in Python 2
 

--- a/RMS/MLFilter.py
+++ b/RMS/MLFilter.py
@@ -26,6 +26,7 @@ try:
     TFLITE_AVAILABLE = True
 except ImportError:
     try:
+        os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
         from tensorflow.lite.python.interpreter import Interpreter
         TFLITE_AVAILABLE = True
         USING_FULL_TF = True


### PR DESCRIPTION
If tflite-runtime is not present, this PR silences TensorFlow nuisance messages about GPU not being configured.