### PR TITLE
Increase UDP Buffer Size Configuration Script

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -837,12 +837,9 @@ def XyHt2Geo(platepar, x, y, h):
     
     az, elev = cyTrueRaDec2ApparentAltAz(np.radians(ra_arr), np.radians(dec_arr), jd_arr, \
         np.radians(platepar.lat), np.radians(platepar.lon), platepar.refraction)
-    print(f"np.array([x]): {np.array([x])}, np.array([y]): {np.array([y])}")
-    print(f"az: {az}, elev: {elev}")
+    
     lat, lon = AEGeoidH2LatLonAlt(np.degrees(az), np.degrees(elev), h, platepar.lat, platepar.lon, platepar.elev)
-    print(f"lat: {lat}, lon: {lon}")
-    print(f"az: {az}, elev: {elev}")
-    print(f"x: {x}, y: {y}, h: {h}")
+    
     return lat, lon
 
 

--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -40,7 +40,7 @@ import RMS.Formats.Platepar
 import scipy.optimize
 from RMS.Astrometry.AtmosphericExtinction import \
     atmosphericExtinctionCorrection
-from RMS.Astrometry.Conversions import J2000_JD, date2JD, jd2Date, raDec2AltAz
+from RMS.Astrometry.Conversions import J2000_JD, date2JD, jd2Date, raDec2AltAz, AEGeoidH2LatLonAlt
 from RMS.Formats.FFfile import filenameToDatetime
 from RMS.Formats.FTPdetectinfo import (findFTPdetectinfoFile,
                                        readFTPdetectinfo, writeFTPdetectinfo)
@@ -818,8 +818,32 @@ def applyPlateparToCentroids(ff_name, fps, meteor_meas, platepar, add_calstatus=
     return meteor_picks
 
 
+def XyHt2Geo(platepar, x, y, h):
+    """ Given pixel coordinates on the image and a height of the target above sea level,
+        compute geo coordinates of the point.
 
+    Arguments:
+        platepar: [Platepar object]
+        x: [float] Image X coordinate
+        y: [float] Image Y coordinate
+        h: [float] elevation of the target in meters (WGS84)
 
+    Return:
+        (lat, lon): [tuple of floats] latitude in degrees (+north), longitude in degrees (+east), 
+
+    """
+    jd_arr, ra_arr, dec_arr, _ = xyToRaDecPP([jd2Date(platepar.JD)], np.array([x]), \
+        np.array([y]), [1], platepar, extinction_correction=False, precompute_pointing_corr=True)
+    
+    az, elev = cyTrueRaDec2ApparentAltAz(np.radians(ra_arr), np.radians(dec_arr), jd_arr, \
+        np.radians(platepar.lat), np.radians(platepar.lon), platepar.refraction)
+    print(f"np.array([x]): {np.array([x])}, np.array([y]): {np.array([y])}")
+    print(f"az: {az}, elev: {elev}")
+    lat, lon = AEGeoidH2LatLonAlt(np.degrees(az), np.degrees(elev), h, platepar.lat, platepar.lon, platepar.elev)
+    print(f"lat: {lat}, lon: {lon}")
+    print(f"az: {az}, elev: {elev}")
+    print(f"x: {x}, y: {y}, h: {h}")
+    return lat, lon
 
 
 def applyAstrometryFTPdetectinfo(dir_path, ftp_detectinfo_file, platepar_file, UT_corr=0, platepar=None):

--- a/RMS/Astrometry/Conversions.py
+++ b/RMS/Astrometry/Conversions.py
@@ -662,6 +662,66 @@ def AEH2LatLonAlt(azim, elev, h, lat, lon, alt):
     return r, lat2, lon2, alt2
 
 
+def AEGeoidH2LatLonAlt(azim, elev, h, lat, lon, alt):
+    """ Given an azimuth and altitude, and Height above Geoid compute lat, lon, and lat to a point.
+
+    Arguments:
+        azim: [float] Azimuth (+E of due N) in degrees.
+        elev: [float] Elevation in degrees.
+        h: [float] Height of the point above the geoid (meters).
+        lat: [float] Latitude of observer in degrees.
+        lon: [float] Longitude of observer in degrees.
+        alt: [float] Altitude of observer in meters.
+
+    Return:
+        (lat, lon): [tuple of floats] range in meteors, latitude and longitude in degrees, 
+            WGS84 elevation in meters
+
+    """
+
+    # Convert azimuth and elevation to radians
+    azim = np.radians(azim)
+    elev = np.radians(elev)
+    lat = np.radians(lat)
+    lon = np.radians(lon)
+
+    # Convert observer's geodetic coordinates to ECEF
+    obs_x, obs_y, obs_z = latLonAlt2ECEF(lat, lon, alt)
+
+    # Calculate line-of-sight unit vector in ENU coordinates
+    los_vector_enu = np.array([
+        np.cos(elev) * np.sin(azim),  # East component
+        np.cos(elev) * np.cos(azim),  # North component
+        np.sin(elev)                 # Up component
+    ])
+
+    # Transform ENU to ECEF coordinates
+    R_enu2ecef = np.array([
+        [-np.sin(lon),  -np.sin(lat) * np.cos(lon),  np.cos(lat) * np.cos(lon)],
+        [np.cos(lon), -np.sin(lat) * np.sin(lon),  np.cos(lat) * np.sin(lon)],
+        [0, np.cos(lat), np.sin(lat)]
+    ])
+
+    los_vector = R_enu2ecef @ los_vector_enu
+
+    # Initial guess for the range
+    r0 = (h - alt) / np.sin(elev)
+    
+    # Initial guess for the range
+    r0 = (h-alt) / np.sin(elev)
+    r = r0
+    
+    # Find the target ECEF coordinates using the optimized range
+    target_x = obs_x + r * los_vector[0]
+    target_y = obs_y + r * los_vector[1]
+    target_z = obs_z + r * los_vector[2]
+      
+    # Convert target ECEF coordinates to geodetic coordinates
+    target_lat, target_lon, h2 = ecef2LatLonAlt(target_x, target_y, target_z)
+    target_lat, target_lon = np.degrees(target_lat), np.degrees(target_lon)
+
+    return target_lat, target_lon
+
 
 def cartesian2Geo(julian_date, x, y, z):
     """ Convert Cartesian ECI coordinates of a point (origin in Earth's centre) to geographical coordinates.

--- a/Scripts/update_buffers.sh
+++ b/Scripts/update_buffers.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# UDP Buffer Size Configuration Script
+# -----------------------------------
+# Purpose: Configures system UDP buffer sizes for GStreamer UDP streaming
+# Usage: sudo ./Scripts/update_buffers.sh
+#
+# This script checks and optionally updates UDP buffer sizes to handle
+# GStreamer's UDP source requirements (512KB per camera). Default Linux
+# settings are often too small, causing GStreamer warnings.
+#
+# The script will:
+# - Show current buffer sizes
+# - Warn if below recommended values (512KB min, 1MB recommended)
+# - Create backup of original settings
+# - Update settings if confirmed
+# - Show before/after comparison
+
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then 
+    echo "Please run as root (sudo)"
+    exit 1
+fi
+
+# Configuration
+RECOMMENDED_SIZE=1048576  # 1MB in bytes
+MIN_RECOMMENDED=524288    # 512KB in bytes (GStreamer requested size)
+
+# Function to convert bytes to human readable format
+human_readable() {
+    local bytes=$1
+    if [ $bytes -ge 1048576 ]; then
+        echo "$(( bytes / 1048576 )) MB"
+    else
+        echo "$(( bytes / 1024 )) KB"
+    fi
+}
+
+# Function to display buffer settings
+show_settings() {
+    local current_rmem_max=$(sysctl -n net.core.rmem_max)
+    local current_wmem_max=$(sysctl -n net.core.wmem_max)
+
+    echo "Current buffer settings:"
+    echo "----------------------"
+    echo "Receive buffer max (rmem_max): $current_rmem_max bytes ($(human_readable $current_rmem_max))"
+    echo "Send buffer max (wmem_max): $current_wmem_max bytes ($(human_readable $current_wmem_max))"
+    echo "----------------------"
+
+    # Check if buffers are below recommended size
+    local update_needed=false
+    if [ $current_rmem_max -lt $MIN_RECOMMENDED ] || [ $current_wmem_max -lt $MIN_RECOMMENDED ]; then
+        echo -e "WARNING: Current buffer sizes are below the minimum recommended size (512KB)"
+        echo "This may cause issues with GStreamer UDP buffer allocation."
+        update_needed=true
+    elif [ $current_rmem_max -lt $RECOMMENDED_SIZE ] || [ $current_wmem_max -lt $RECOMMENDED_SIZE ]; then
+        echo -e "NOTE: Current buffer sizes are below the recommended size (1MB)"
+        echo "Increasing them would provide more headroom for UDP operations."
+        update_needed=true
+    fi
+
+    if [ "$update_needed" = true ]; then
+        echo -e "\nWould you like to update the buffer sizes to the recommended values? (y/n)"
+        read -r response
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            return 0  # proceed with update
+        else
+            echo "No changes made. Exiting..."
+            exit 0
+        fi
+    else
+        echo -e "Current buffer sizes are at or above recommended values."
+        exit 0
+    fi
+}
+
+# Show initial settings and check if update is needed
+echo "CHECKING CURRENT SETTINGS:"
+show_settings
+echo
+
+# Backup original sysctl.conf
+echo "Creating backup of current sysctl.conf..."
+cp /etc/sysctl.conf /etc/sysctl.conf.backup.$(date +%Y%m%d_%H%M%S)
+
+# Function to add or update sysctl setting
+update_sysctl() {
+    local key=$1
+    local value=$2
+    
+    # Check if setting already exists
+    if grep -q "^${key}[[:space:]]*=" /etc/sysctl.conf; then
+        # Update existing setting
+        sed -i "s|^${key}[[:space:]]*=.*|${key}=${value}|" /etc/sysctl.conf
+        echo "Updated ${key} to ${value}"
+    else
+        # Add new setting
+        echo "${key}=${value}" >> /etc/sysctl.conf
+        echo "Added ${key}=${value}"
+    fi
+}
+
+echo "Updating buffer size settings..."
+
+# Update the settings
+update_sysctl "net.core.rmem_max" "$RECOMMENDED_SIZE"
+update_sysctl "net.core.wmem_max" "$RECOMMENDED_SIZE"
+
+# Apply changes
+echo "Applying changes..."
+sysctl -p >/dev/null 2>&1  # Suppress detailed output
+
+echo -e "\nAFTER CHANGES:"
+show_settings
+
+echo -e "\nDone! A backup of your original sysctl.conf has been created."


### PR DESCRIPTION
## Problem
GStreamer is reporting UDP buffer allocation warnings in the logs when `protocol: udp` is selected in `.config` :
```
GStreamer: udpsrc: warning: Could not create a buffer of requested 524288 bytes
```
This occurs because GStreamer's UDP source is requesting 512KB buffers while system defaults are often lower. Even with the warning, capture usually proceeds normally, however the smaller buffer may cause issues under high work load. 

## Solution
Added a script `update_buffers.sh` that:
- Checks current UDP buffer sizes
- Warns if buffers are below recommended sizes (512KB minimum, 1MB recommended)
- Offers to increase buffer sizes if needed
- Creates a backup of original settings
- Shows before/after comparison

## Usage
```bash
sudo ./update_buffers.sh
```

## Why
- Each camera's UDP source requests a 512KB buffer
- Default Linux buffer sizes are often too small (208KB)
- Increasing buffer size provides headroom for UDP streaming
- Helps prevent potential packet loss during traffic bursts

## Safety
- Script creates automatic backups before changes
- Prompts for confirmation before making changes
- Settings can be reverted using backup file
- Changes persist across reboots