### PR TITLE
Obfuscate passwords in log

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -34,7 +34,7 @@ from multiprocessing import Process, Event, Value
 import cv2
 import numpy as np
 
-from RMS.Misc import ping
+from RMS.Misc import ping, obfuscatePassword
 from RMS.Routines.GstreamerCapture import GstVideoFile
 from RMS.Formats.ObservationSummary import getObsDBConn, addObsParam
 
@@ -586,7 +586,10 @@ class BufferedCapture(Process):
          # Combine all parts of the pipeline
         pipeline_str = "{:s} {:s} {:s}".format(source_to_tee, processing_branch, storage_branch)
 
-        log.debug("GStreamer pipeline string: {:s}".format(pipeline_str))
+        # Obfuscate the password in the pipeline string before logging
+        obfuscated_pipeline_str = obfuscatePassword(pipeline_str)
+
+        log.debug("GStreamer pipeline string: {:s}".format(obfuscated_pipeline_str))
 
         # Set the pipeline to PLAYING state with retries
         for attempt in range(max_retries):

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -9,6 +9,7 @@ import errno
 import logging
 import subprocess
 import random
+import re
 import string
 import inspect
 import datetime
@@ -743,3 +744,32 @@ def getRmsRootDir():
 
         # Get the absolute path to the RMS root directory
         return os.path.abspath(os.path.dirname(os.path.dirname(rms_file)))
+
+
+def obfuscatePassword(url):
+    """
+    Obfuscate the password in a given URL string if it's not empty or the default.
+
+    This function attempts to find the password in RTSP URLs or in URL parameters. 
+    If a non-empty and non-default password is found, it is replaced with '****'.
+
+    Arguments:
+        url: [str] The URL string that may contain a password.
+
+    Returns:
+        str: The URL with the password obfuscated, if present and not empty or default.
+             If the password is empty or 'password', the original URL is returned.
+             If an error occurs during obfuscation, returns "[URL_REDACTED_DUE_TO_ERROR]".
+    """
+    try:
+        pattern = r'(rtsp://.*?:.*?@|user=.*?&password=)(.*?)(&|$)'
+        match = re.search(pattern, url)
+        if match:
+            password = match.group(2)
+            if password and password != 'password':
+                return re.sub(pattern, r'\1****\3', url)
+        return url
+    except Exception as e:
+        logging.error("Error in obfuscate_password: %s", str(e))
+        return "[URL_REDACTED_DUE_TO_ERROR]"
+    


### PR DESCRIPTION
Currently, camera passwords are logged in plain text. Since logs are sometimes shared for troubleshooting, operators may unwittingly expose their passwords. Although the majority of cameras use default passwords, some have non-default passwords that should not be logged. This PR obfuscates camera passwords in the logged URL if they differ from the default password.