### PR TITLE
continue framestamps.json for current day after reboot

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -684,7 +684,7 @@ class BufferedCapture(Process):
 
 
 
-    def moveSegment(self, splitmuxsink, fragment_id):
+    def move_segment(self, splitmuxsink, fragment_id):
         """
         Custom callback for splitmuxsink's format-location signal to name and move each segment as its
         created. Generates a timestamp-based folder structure: Year/Day-Of-Year/Hour/ per video segment
@@ -874,7 +874,7 @@ class BufferedCapture(Process):
                 if video_file_dir is not None:
                     
                     splitmuxsink = self.pipeline.get_by_name("splitmuxsink0")
-                    splitmuxsink.connect("format-location", self.moveSegment)
+                    splitmuxsink.connect("format-location", self.move_segment)
 
                 # Transition through states
                 log.info("Starting pipeline state transitions...")

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -684,7 +684,7 @@ class BufferedCapture(Process):
 
 
 
-    def move_segment(self, splitmuxsink, fragment_id):
+    def moveSegment(self, splitmuxsink, fragment_id):
         """
         Custom callback for splitmuxsink's format-location signal to name and move each segment as its
         created. Generates a timestamp-based folder structure: Year/Day-Of-Year/Hour/ per video segment
@@ -870,11 +870,11 @@ class BufferedCapture(Process):
                     raise ValueError("Could not create pipeline")
                 
                 # If raw video saving is enabled, Connect the "format-location" signal to the 
-                # move_segment function
+                # moveSegment function
                 if video_file_dir is not None:
                     
                     splitmuxsink = self.pipeline.get_by_name("splitmuxsink0")
-                    splitmuxsink.connect("format-location", self.move_segment)
+                    splitmuxsink.connect("format-location", self.moveSegment)
 
                 # Transition through states
                 log.info("Starting pipeline state transitions...")


### PR DESCRIPTION
The framestamps.json file would start counting from 0 after a reboot. This fixes it by initializing the starting raw frame value from an existing framestamp file for the current day, if it exists. 