### PR TITLE
Compute and use WGS84 height where appropriate

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -44,6 +44,7 @@ from RMS.Astrometry.Conversions import J2000_JD, date2JD, jd2Date, raDec2AltAz, 
 from RMS.Formats.FFfile import filenameToDatetime
 from RMS.Formats.FTPdetectinfo import (findFTPdetectinfoFile,
                                        readFTPdetectinfo, writeFTPdetectinfo)
+from RMS.GeoidHeightEGM96 import mslToWGS84Height
 from RMS.Math import angularSeparation, cartesianToPolar, polarToCartesian
 
 pyximport.install(setup_args={'include_dirs':[np.get_include()]})
@@ -838,7 +839,23 @@ def XyHt2Geo(platepar, x, y, h):
     az, elev = cyTrueRaDec2ApparentAltAz(np.radians(ra_arr), np.radians(dec_arr), jd_arr, \
         np.radians(platepar.lat), np.radians(platepar.lon), platepar.refraction)
     
-    lat, lon = AEGeoidH2LatLonAlt(np.degrees(az), np.degrees(elev), h, platepar.lat, platepar.lon, platepar.elev)
+    # TODO: precompute height
+    
+    # Calculate WGS84 height
+    wgs84_height = mslToWGS84Height(
+        np.radians(platepar.lat),
+        np.radians(platepar.lon),
+        platepar.elev
+    )
+    
+    lat, lon = AEGeoidH2LatLonAlt(
+        np.degrees(az),
+        np.degrees(elev),
+        h,
+        platepar.lat,
+        platepar.lon,
+        wgs84_height
+    )
     
     return lat, lon
 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -19,7 +19,10 @@ from __future__ import absolute_import, division, print_function
 import math
 import os
 import sys
+import numpy as np
+
 from RMS.Misc import getRmsRootDir
+from RMS.GeoidHeightEGM96 import mslToWGS84Height
 
 # Consolidated version-specific imports and definitions
 if sys.version_info[0] == 3:
@@ -863,6 +866,21 @@ def parseSystem(config, parser):
 
     if parser.has_option(section, "elevation"):
         config.elevation = parser.getfloat(section, "elevation")
+    
+    if parser.has_option(section, "wgs84_height"):
+        config.wgs84_height = parser.getfloat(section, "wgs84_height")
+    else:
+        try:
+            # Calculate WGS84 height if not provided
+            config.wgs84_height = mslToWGS84Height(
+                np.radians(config.latitude),
+                np.radians(config.longitude),
+                config.elevation,
+                config
+            )
+        except Exception as e:
+            config.wgs84_height = config.elevation
+            print("Warning: Calculating WGS84 height failed {}. Using Geoid height instead.".format(str(e)))
         
 
     if parser.has_option(section, "cams_code"):

--- a/RMS/GeoidHeightEGM96.py
+++ b/RMS/GeoidHeightEGM96.py
@@ -12,6 +12,7 @@ import numpy as np
 import scipy.interpolate
 
 import RMS.ConfigReader as cr
+from RMS.Misc import getRmsRootDir
 
 
 def loadEGM96Data(dir_path, file_name):
@@ -32,6 +33,23 @@ def loadEGM96Data(dir_path, file_name):
 
     return geoid_heights
 
+
+def loadEGM96DataFromConfig(config=None):
+    """ Load a file with EGM96 data from the given config.
+    If no config given, use the root config.
+
+    """
+
+    # Load the root configuration file if no config specified
+    if not config:
+        config_filename = '.config'
+        config_path = os.path.join(getRmsRootDir(), config_filename)
+        config = cr.parse(config_path)
+
+    # Load the geoid heights
+    geoid_heights = loadEGM96Data(config.egm96_path, config.egm96_file_name)
+
+    return geoid_heights
 
 
 def interpolateEGM96Data(geoid_heights):
@@ -55,8 +73,7 @@ def interpolateEGM96Data(geoid_heights):
     return geoid_model
 
 
-
-def mslToWGS84Height(lat, lon, msl_height, config):
+def mslToWGS84Height(lat, lon, msl_height, config=None):
     """ Given the height above sea level (using the EGM96 model), compute the height above the WGS84
         ellipsoid.
 
@@ -72,7 +89,7 @@ def mslToWGS84Height(lat, lon, msl_height, config):
     """
 
     # Load the geoid heights array
-    GEOID_HEIGHTS = loadEGM96Data(config.egm96_path, config.egm96_file_name)
+    GEOID_HEIGHTS = loadEGM96DataFromConfig(config)
 
     # Init the interpolated geoid model
     GEOID_MODEL = interpolateEGM96Data(GEOID_HEIGHTS)
@@ -90,7 +107,7 @@ def mslToWGS84Height(lat, lon, msl_height, config):
 
 
 
-def wgs84toMSLHeight(lat, lon, wgs84_height, config):
+def wgs84toMSLHeight(lat, lon, wgs84_height, config=None):
     """ Given the height above the WGS84 ellipsoid compute the height above sea level (using the EGM96 model).
 
     Arguments:
@@ -105,7 +122,7 @@ def wgs84toMSLHeight(lat, lon, wgs84_height, config):
     """
 
     # Load the geoid heights array
-    GEOID_HEIGHTS = loadEGM96Data(config.egm96_path, config.egm96_file_name)
+    GEOID_HEIGHTS = loadEGM96DataFromConfig(config)
 
     # Init the interpolated geoid model
     GEOID_MODEL = interpolateEGM96Data(GEOID_HEIGHTS)

--- a/Utils/ShowerAssociation.py
+++ b/Utils/ShowerAssociation.py
@@ -362,7 +362,7 @@ def estimateMeteorHeight(config, meteor_obj, shower):
     earth_radius = EARTH.EQUATORIAL_RADIUS/np.sqrt(1.0 - (EARTH.E**2)*np.sin(np.radians(config.latitude))**2)
 
     # Compute the distance from Earth's centre to the station (including the sea level height of the station)
-    re_dist = earth_radius + config.elevation
+    re_dist = earth_radius + config.wgs84_height
 
     ### ###
 
@@ -496,7 +496,7 @@ def showerAssociation(config, ftpdetectinfo_list, shower_code=None, show_plot=Fa
 
 
         # Init container for meteor observation
-        meteor_obj = MeteorSingleStation(cam_code, config.latitude, config.longitude, config.elevation, 
+        meteor_obj = MeteorSingleStation(cam_code, config.latitude, config.longitude, config.wgs84_height, 
                                          ff_name)
 
         # Infill the meteor structure


### PR DESCRIPTION
This PR computes and utilizes WGS84 height when necessary. It introduces a config.wgs84_height variable, which is calculated from config.elevation. Additionally, it updates the shower association to incorporate the WGS84 height. However, there’s still work to be done on precomputing the pp wgs84_ht.
