### PR TITLE
Patch 5

### DIFF
--- a/.config
+++ b/.config
@@ -322,7 +322,7 @@ postprocess_at_end: false
 postprocess_delay: 0
 
 ; Ran capture continuously, through day/night
-continuous_capture: true
+continuous_capture: false
 
 [Build]
 

--- a/RMS/CameraModeSwitcher.py
+++ b/RMS/CameraModeSwitcher.py
@@ -27,8 +27,8 @@ def cameraModeSwitcher(config, daytime_mode):
         o.long = str(config.longitude)
         o.elevation = config.elevation
 
-        # The Sun should be about 8 degrees below the horizon when the camera modes switch
-        o.horizon = '-8'
+        # The Sun should be about 9 degrees below the horizon when the camera modes switch
+        o.horizon = '-9'
 
         # Set the current time
         current_time = RmsDateTime.utcnow()

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -586,11 +586,14 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
 
     if config.raw_video_save:
 
-        # (for 720p capture) Taking a ~0.25 Mbps average video bitrate
+        # Taking a ~0.25 Mbps average video bitrate (default 720p capture @ 25 fps)
         raw_video_bytes = duration*0.25*(1024**2)
 
         # Roughly scaling for higher resolutions
         raw_video_bytes *= (config.width*config.height)/(1280*720)
+
+        # Roughly scaling for fps
+        raw_video_bytes *= (config.fps)/(25)
 
         next_night_bytes += raw_video_bytes
 

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -576,6 +576,28 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
     # Always leave at least 2 GB free for archive
     next_night_bytes += config.extra_space_gb*(1024**3)
 
+
+    # Calculating space for raw frames and videos.
+    # In case of continuous capture, frames and videos will be captured throughout the day (86400 seconds).
+    # Else, they will happen as long as nighttime capture is runnning
+
+    if config.continuous_capture:
+        duration = 86400
+
+    if config.raw_video_save:
+
+        # (for 720p capture) Taking a ~0.25 Mbps average video bitrate
+        raw_video_bytes = duration*0.25*(1024**2)
+
+        # Roughly scaling for higher resolutions
+        raw_video_bytes *= (config.width*config.height)/(1280*720)
+
+        next_night_bytes += raw_video_bytes
+
+
+    if config.save_frames: # (estimated value of 3GB maximum for 24 hours)
+        next_night_bytes += 3*(1024**3)
+
     ######
 
     log.info("Need {:.2f} GB for next night".format(next_night_bytes/1024/1024/1024))

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -540,8 +540,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
                         frames_timelapse_path = os.path.join(year_dir, "{}_{}_frames_timelapse.mp4".format(config.stationID, day))
 
                         # Generate the timelapse and cleanup
-                        generateTimelapseFromFrames(day_dir, frames_timelapse_path, fps=30, crf=20,
-                                                    cleanup_mode='tar', compression='bz2')
+                        generateTimelapseFromFrames(day_dir, frames_timelapse_path)
 
                         # Add the timelapse to the extra files
                         extra_files.append(frames_timelapse_path)

--- a/Utils/GenerateTimelapse.py
+++ b/Utils/GenerateTimelapse.py
@@ -143,7 +143,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
         com = "cd " + dir_path + ";" \
             + software_name + nostdin + " -v quiet -r "+ str(fps) +" -y -i " + temp_img_path \
             + " -vcodec libx264 -pix_fmt yuv420p -crf " + str(crf) \
-            + " -movflags faststart -g 15 -vf \"hqdn3d=4:3:6:4.5,lutyuv=y=gammaval(0.77)\" " \
+            + " -movflags faststart -threads 2 -g 15 -vf \"hqdn3d=4:3:6:4.5,lutyuv=y=gammaval(0.77)\" " \
             + mp4_path
 
         print("Creating timelapse using {:s}...".format(software_name))
@@ -180,7 +180,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
     print("Total time:", RmsDateTime.utcnow() - t1)
 
 
-def generateTimelapseFromFrames(day_dir, video_path, fps=30, crf=20, cleanup_mode='none',
+def generateTimelapseFromFrames(day_dir, video_path, fps=30, crf=26, cleanup_mode='none',
                               compression='bz2', filelist=None):
     """
     Generate a timelapse video from frame images and optionally cleanup the
@@ -191,7 +191,7 @@ def generateTimelapseFromFrames(day_dir, video_path, fps=30, crf=20, cleanup_mod
                        subdirectories by the hour of day "00", "01", ..., "23"
         video_path: [str] Output path for the generated video.
         fps: [int] Frames per second for the output video. 30 by default.
-        crf: [int] Constant Rate Factor for video compression. 20 by default.
+        crf: [int] Constant Rate Factor for video compression. 26 by default.
         cleanup_mode: [str] Cleanup mode after video creation.
                       Options: 'none', 'delete', 'tar'. 'none' by default.
         compression: [str] Compression method for tar.
@@ -224,7 +224,7 @@ def generateTimelapseFromFrames(day_dir, video_path, fps=30, crf=20, cleanup_mod
     encode_command = [
         software_name, "-nostdin", "-f", "concat", "-safe", "0", "-v", "quiet",
         "-r", str(fps), "-y", "-i", list_file_path, "-c:v", "libx264",
-        "-crf", str(crf), "-g", "15", video_path
+        "-crf", str(crf), "-threads", "2", "-g", "15", video_path
     ]
 
     # Execute the command


### PR DESCRIPTION
- Updated GenerateTimelapse.py so that ffmpeg uses two threads when processing timelapses. The CRF for generating timelapses from raw frames has also been increased to produce smaller file sizes.

- Updated DeleteOldObservations.py such that it considers extra space for raw frames and video clips if saving is enabled.