### PR TITLE
Patch 6

### DIFF
--- a/.config
+++ b/.config
@@ -321,8 +321,11 @@ postprocess_at_end: false
 ; postprocess_at_end is false, or after capture ends if true.
 postprocess_delay: 0
 
-; Ran capture continuously, through day/night
+; Run capture continuously, through day/night
 continuous_capture: false
+
+; Switch camera settings between day/night modes, for when continuous_capture is enabled
+switch_camera_modes: false
 
 [Build]
 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -446,6 +446,9 @@ class Config:
         # Run capture continuously, during the day or night
         self.continuous_capture = False
 
+        # Switch camera settings between day/night modes, for when continuous_capture is enabled
+        self.switch_camera_modes = False
+
         ##### Upload
 
         # Flag determining if uploading is enabled or not
@@ -1237,6 +1240,9 @@ def parseCapture(config, parser):
     if parser.has_option(section, "continuous_capture"):
         config.continuous_capture = parser.getboolean(section, "continuous_capture")
 
+    # Load option to switch camera settings between day/night modes, for when continuous_capture is enabled
+    if parser.has_option(section, "switch_camera_modes"):
+        config.switch_camera_modes = parser.getboolean(section, "switch_camera_modes")
 
 def parseUpload(config, parser):
     section = "Upload"

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -536,18 +536,15 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
                         log.info("No frames timelapse for {} found in {}, generating new timelapse...".format(day, year_dir))
 
                         # Make the name of the timelapse file from day directory
-                        # The day's timelapse is stored in its corresponding year's directory
+                        # The day's timelapse and its framestamps.json are both stored in their corresponding year's directory
                         frames_timelapse_path = os.path.join(year_dir, "{}_{}_frames_timelapse.mp4".format(config.stationID, day))
-
-                        # Generate the timelapse and cleanup
-                        generateTimelapseFromFrames(day_dir, frames_timelapse_path)
-
-                        # Add the timelapse to the extra files
-                        extra_files.append(frames_timelapse_path)
-
-                        # Add the day's frame/timestaps json file to extra files if available
                         timelapse_json_path = os.path.join(year_dir, "{}_{}_framestamps.json".format(config.stationID, day))
 
+                        # Generate the timelapse and cleanup
+                        generateTimelapseFromFrames(day_dir, frames_timelapse_path, timelapse_json_path, cleanup_mode='tar')
+
+                        # Add the timelapse and its framestamps.json to the extra files
+                        extra_files.append(frames_timelapse_path)
                         extra_files.append(timelapse_json_path)
 
 

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -42,7 +42,7 @@ import RMS.ConfigReader as cr
 from RMS.Logger import initLogging
 from RMS.BufferedCapture import BufferedCapture
 from RMS.CaptureDuration import captureDuration
-from RMS.CameraModeSwitcher import cameraModeSwitcher
+from RMS.CaptureModeSwitcher import captureModeSwitcher
 from RMS.Compression import Compressor
 from RMS.DeleteOldObservations import deleteOldObservations
 from RMS.DetectStarsAndMeteors import detectStarsAndMeteors
@@ -1296,14 +1296,14 @@ if __name__ == "__main__":
             # Setup shared value to communicate day/night switch between processes.
             daytime_mode = multiprocessing.Value(ctypes.c_bool, False)
 
-            # Setup camera mode switcher on another thread
-            cam_switcher = threading.Thread(target=cameraModeSwitcher, args=(config, daytime_mode))
+            # Setup the capture mode switcher on another thread
+            capture_switcher = threading.Thread(target=captureModeSwitcher, args=(config, daytime_mode))
             
-            # To make sure switcher thread exits automatically at the end
-            cam_switcher.daemon = True
+            # To make sure the capture switcher thread exits automatically at the end
+            capture_switcher.daemon = True
             
-            cam_switcher.start()
-            log.info('Started camera mode switcher on separate thread')
+            capture_switcher.start()
+            log.info('Started capture mode switcher on a separate thread')
 
         else:
             daytime_mode = None

--- a/Utils/GenerateTimelapse.py
+++ b/Utils/GenerateTimelapse.py
@@ -319,37 +319,33 @@ def generateTimelapseFromFrames(day_dir, video_path, framestamps_path, fps=30, c
 
 if __name__ == "__main__":
 
-    # ### COMMAND LINE ARGUMENTS
+    ### COMMAND LINE ARGUMENTS
 
-    # # Init the command line arguments parser
-    # arg_parser = argparse.ArgumentParser(description="Convert all FF files in a folder to a movie")
+    # Init the command line arguments parser
+    arg_parser = argparse.ArgumentParser(description="Convert all FF files in a folder to a movie")
 
-    # arg_parser.add_argument('dir_path', metavar='DIR_PATH', type=str, \
-    #     help='Path to directory with FF files.')
+    arg_parser.add_argument('dir_path', metavar='DIR_PATH', type=str, \
+        help='Path to directory with FF files.')
 
-    # arg_parser.add_argument('-fps', '--fps', metavar='FPS', type=int, \
-    #     help='FPS to use for video.')
+    arg_parser.add_argument('-fps', '--fps', metavar='FPS', type=int, \
+        help='FPS to use for video.')
 
-    # arg_parser.add_argument('-x', '--nodel', action="store_true", \
-    #     help="""Do not delete generated JPG file.""")
+    arg_parser.add_argument('-x', '--nodel', action="store_true", \
+        help="""Do not delete generated JPG file.""")
     
-    # arg_parser.add_argument('-o', '--output', metavar='OUTPUT', type=str, \
-    #     help='Output video file name.')
+    arg_parser.add_argument('-o', '--output', metavar='OUTPUT', type=str, \
+        help='Output video file name.')
     
-    # arg_parser.add_argument('--hires', action="store_true", \
-    #                         help='Make a higher resolution timelapse. The video file will be larger.')
+    arg_parser.add_argument('--hires', action="store_true", \
+                            help='Make a higher resolution timelapse. The video file will be larger.')
 
-    # # Parse the command line arguments
-    # cml_args = arg_parser.parse_args()
+    # Parse the command line arguments
+    cml_args = arg_parser.parse_args()
 
-    # #########################
+    #########################
 
 
-    # dir_path = os.path.normpath(cml_args.dir_path)
+    dir_path = os.path.normpath(cml_args.dir_path)
 
-    # # Generate the timelapse
-    # generateTimelapse(dir_path, keep_images=cml_args.nodel, fps=cml_args.fps, output_file=cml_args.output, hires=cml_args.hires)
-
-    generateTimelapseFromFrames("/home/rms/Desktop/RMS_data/FramesFiles/2024/20241123-328", \
-                                "/home/rms/Desktop/RMS_data/FramesFiles/2024/US000F_20241123-328_frames_timelapse.mp4", \
-                                "/home/rms/Desktop/RMS_data/FramesFiles/2024/US000F_20241123-328_framestamps.json")
+    # Generate the timelapse
+    generateTimelapse(dir_path, keep_images=cml_args.nodel, fps=cml_args.fps, output_file=cml_args.output, hires=cml_args.hires)

--- a/Utils/GenerateTimelapse.py
+++ b/Utils/GenerateTimelapse.py
@@ -13,6 +13,7 @@ import shutil
 import cv2
 import glob
 import tarfile
+import json
 
 from PIL import ImageFont
 
@@ -180,16 +181,19 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
     print("Total time:", RmsDateTime.utcnow() - t1)
 
 
-def generateTimelapseFromFrames(day_dir, video_path, fps=30, crf=26, cleanup_mode='none',
+def generateTimelapseFromFrames(day_dir, video_path, framestamps_path, fps=30, crf=26, cleanup_mode='none',
                               compression='bz2', filelist=None):
     """
     Generate a timelapse video from frame images and optionally cleanup the
-    source directory.
+    source directory. The function requires a corresponding "framestamps.json" file to be present
+    in day_dir's parent directory (This would be produced by RawFrameSave.py during capture) for
+    adding timestamps to the video.
 
     Keyword arguments:
         day_dir: [str] Directory containing a day of frame image files. day_dir is expected to have
                        subdirectories by the hour of day "00", "01", ..., "23"
         video_path: [str] Output path for the generated video.
+        framestamps_path: [str] Path to framestamps.json file for the day the timelapse is produced for.
         fps: [int] Frames per second for the output video. 30 by default.
         crf: [int] Constant Rate Factor for video compression. 26 by default.
         cleanup_mode: [str] Cleanup mode after video creation.
@@ -199,17 +203,56 @@ def generateTimelapseFromFrames(day_dir, video_path, fps=30, crf=26, cleanup_mod
     """
 
     # Combine all files paths
-    images_files = [img for img in sorted(glob.glob(os.path.join(day_dir, "*/*.jpg")))] + \
-                   [img for img in sorted(glob.glob(os.path.join(day_dir, "*/*.png")))]
+    image_files = [img for img in sorted(glob.glob(os.path.join(day_dir, "*/*.jpg")))] + \
+                  [img for img in sorted(glob.glob(os.path.join(day_dir, "*/*.png")))]
 
-    if len(images_files) == 0:
+    if len(image_files) == 0:
         print("No images found.")
         return
+
+    raw_dir_tmp_path = ""
+
+    # Add timestamp to frames based on the day's corresponding framestamps.json if present 
+    if os.path.exists(framestamps_path):
+
+        # Load up the framestamps
+        framestamps = {}
+        with open(framestamps_path, 'r') as fs:
+            framestamps = json.load(fs)
+
+        # Create temporary directory
+        raw_dir_tmp_path = os.path.join(day_dir, "temp_raw_img_dir")
+
+        if os.path.exists(raw_dir_tmp_path):
+            shutil.rmtree(raw_dir_tmp_path)
+            print("Deleted directory : " + raw_dir_tmp_path)
+
+        mkdirP(raw_dir_tmp_path)
+        print("Created directory : " + raw_dir_tmp_path)
+        print("Preparing files for the timelapse...")
+
+        # image_files and framestamp indices are both sorted by name 
+        for index, img_path in enumerate(image_files):
+
+            # Draw text to image
+            image = cv2.imread(img_path)
+            cv2.putText(image, framestamps[str(index)], (10, image.shape[0] - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.4, (255, 255, 255), 1, cv2.LINE_AA)
+
+            # Save the labelled image to disk
+            timestamped_img_path = os.path.join(raw_dir_tmp_path, 'temp_{:05d}.jpg'.format(index))
+            cv2.imwrite(timestamped_img_path, image, [cv2.IMWRITE_JPEG_QUALITY, 100])
+
+            # Update the new frame path in the image_file list
+            image_files[index] = timestamped_img_path
+
+    else:
+        print("Path to framestamps.json file not found; continuing without placing timestamps on frames")
+
 
     # Create a text file listing all the images
     list_file_path = os.path.join(day_dir, "filelist.txt")
     with open(list_file_path, 'w') as f:
-        for img_path in images_files:
+        for img_path in image_files:
             f.write("file '{0}'\n".format(img_path))
 
     if platform.system() in ['Linux', 'Darwin']:  # Darwin is macOS
@@ -234,6 +277,11 @@ def generateTimelapseFromFrames(day_dir, video_path, fps=30, crf=26, cleanup_mod
     if os.path.exists(video_path) and os.path.getsize(video_path) > 0:
         print("Video created successfully at {0}".format(video_path))
 
+        # Delete temporary directory and files inside
+        if os.path.exists(raw_dir_tmp_path):
+            shutil.rmtree(raw_dir_tmp_path)
+            print("Deleted temporary directory : " + raw_dir_tmp_path)
+            
         # Cleanup based on the specified mode
         if cleanup_mode == 'delete':
             try:
@@ -271,33 +319,37 @@ def generateTimelapseFromFrames(day_dir, video_path, fps=30, crf=26, cleanup_mod
 
 if __name__ == "__main__":
 
-    ### COMMAND LINE ARGUMENTS
+    # ### COMMAND LINE ARGUMENTS
 
-    # Init the command line arguments parser
-    arg_parser = argparse.ArgumentParser(description="Convert all FF files in a folder to a movie")
+    # # Init the command line arguments parser
+    # arg_parser = argparse.ArgumentParser(description="Convert all FF files in a folder to a movie")
 
-    arg_parser.add_argument('dir_path', metavar='DIR_PATH', type=str, \
-        help='Path to directory with FF files.')
+    # arg_parser.add_argument('dir_path', metavar='DIR_PATH', type=str, \
+    #     help='Path to directory with FF files.')
 
-    arg_parser.add_argument('-fps', '--fps', metavar='FPS', type=int, \
-        help='FPS to use for video.')
+    # arg_parser.add_argument('-fps', '--fps', metavar='FPS', type=int, \
+    #     help='FPS to use for video.')
 
-    arg_parser.add_argument('-x', '--nodel', action="store_true", \
-        help="""Do not delete generated JPG file.""")
+    # arg_parser.add_argument('-x', '--nodel', action="store_true", \
+    #     help="""Do not delete generated JPG file.""")
     
-    arg_parser.add_argument('-o', '--output', metavar='OUTPUT', type=str, \
-        help='Output video file name.')
+    # arg_parser.add_argument('-o', '--output', metavar='OUTPUT', type=str, \
+    #     help='Output video file name.')
     
-    arg_parser.add_argument('--hires', action="store_true", \
-                            help='Make a higher resolution timelapse. The video file will be larger.')
+    # arg_parser.add_argument('--hires', action="store_true", \
+    #                         help='Make a higher resolution timelapse. The video file will be larger.')
 
-    # Parse the command line arguments
-    cml_args = arg_parser.parse_args()
+    # # Parse the command line arguments
+    # cml_args = arg_parser.parse_args()
 
-    #########################
+    # #########################
 
 
-    dir_path = os.path.normpath(cml_args.dir_path)
+    # dir_path = os.path.normpath(cml_args.dir_path)
 
-    # Generate the timelapse
-    generateTimelapse(dir_path, keep_images=cml_args.nodel, fps=cml_args.fps, output_file=cml_args.output, hires=cml_args.hires)
+    # # Generate the timelapse
+    # generateTimelapse(dir_path, keep_images=cml_args.nodel, fps=cml_args.fps, output_file=cml_args.output, hires=cml_args.hires)
+
+    generateTimelapseFromFrames("/home/rms/Desktop/RMS_data/FramesFiles/2024/20241123-328", \
+                                "/home/rms/Desktop/RMS_data/FramesFiles/2024/US000F_20241123-328_frames_timelapse.mp4", \
+                                "/home/rms/Desktop/RMS_data/FramesFiles/2024/US000F_20241123-328_framestamps.json")


### PR DESCRIPTION
- continuous_capture and camera mode switching during day and night are now independent of each other. A new config option "switch_camera_modes" is responsible for the latter.

- raw frames timelapses will now have timestamps printed in the bottom left of the frame, in case a valid corresponding framestamps.json file is found.