### PR TITLE
Stagger camera mode switching

### DIFF
--- a/RMS/CaptureModeSwitcher.py
+++ b/RMS/CaptureModeSwitcher.py
@@ -18,12 +18,13 @@ def captureModeSwitcher(config, daytime_mode):
         daytime_mode: [multiprocessing.Value] shared boolean variable to communicate the mode switch with other processes
                             True = Day time, False = Night time
     """
+    is_first_switch = True  # Track whether it's the initial switch
 
     try:
         while True:
 
             # Initialize observer
-            o = ephem.Observer()  
+            o = ephem.Observer()
             o.lat = str(config.latitude)
             o.long = str(config.longitude)
             o.elevation = config.elevation
@@ -40,28 +41,60 @@ def captureModeSwitcher(config, daytime_mode):
             s.compute()
 
             # Based on whether next event is a sunrise or sunset, set the value for daytime_mode
-            next_rise = o.next_rising(s).datetime()
-            next_set = o.next_setting(s).datetime()
+            # Except on initial run, apply the capture_wait_seconds from the config to stagger the mode
+            # switching. This can help prevent disconnects in multi-camera setups
+            try:
+                next_rise = o.next_rising(s).datetime()
+                next_set = o.next_setting(s).datetime()
 
-            if next_set < next_rise:
-                log.info("Next event is a sunset ({}), switching to daytime mode".format(next_set))
+                if next_set < next_rise:
+                    log.info("Next event is a sunset ({}), switching to daytime mode".format(next_set))
+
+                    if config.switch_camera_modes:
+                        if not is_first_switch:
+                            time.sleep(config.capture_wait_seconds)
+                        cc.cameraControlV2(config, 'SwitchDayTime')
+
+                    daytime_mode.value = True
+                    time_to_wait = (next_set - current_time).total_seconds()
+
+                else:
+                    log.info("Next event is a sunrise ({}), switching to nighttime mode".format(next_rise))
+
+                    if config.switch_camera_modes:
+                        if not is_first_switch:
+                            time.sleep(config.capture_wait_seconds)
+                        cc.cameraControlV2(config, 'SwitchNightTime')
+
+                    daytime_mode.value = False
+                    time_to_wait = (next_rise - current_time).total_seconds()
+
+
+            # If the day last more than 24 hours, continue daytime capture for the whole day
+            except ephem.AlwaysUpError:
 
                 if config.switch_camera_modes:
+                    if not is_first_switch:
+                        time.sleep(config.capture_wait_seconds)
                     cc.cameraControlV2(config, 'SwitchDayTime')
 
                 daytime_mode.value = True
+                time_to_wait = 86400
 
-                time_to_wait = (next_set - current_time).total_seconds()
 
-            else:
-                log.info("Next event is a sunrise ({}), switching to nighttime mode".format(next_rise))
+            # If the night lasts more than 24 hours, continue nighttime capture for the whole day
+            except ephem.NeverUpError:
 
                 if config.switch_camera_modes:
+                    if not is_first_switch:
+                        time.sleep(config.capture_wait_seconds)
                     cc.cameraControlV2(config, 'SwitchNightTime')
 
                 daytime_mode.value = False
-                
-                time_to_wait = (next_rise - current_time).total_seconds()
+                time_to_wait = 86400
+
+            # Mark that the first switch has occurred
+            is_first_switch = False
 
             # Sleep until the next switch time
             time.sleep(time_to_wait)
@@ -72,7 +105,7 @@ def captureModeSwitcher(config, daytime_mode):
         log.error('CaptureModeSwitcher thread failed with following error: ' + repr(e))
 
 
-    ### For testing ###
+    ### For testing switching only ###
 
     # wait_interval = 5*60
     
@@ -102,10 +135,11 @@ if __name__ == "__main__":
 
     config = cr.loadConfigFromDirectory('.', os.path.abspath('.'))
 
-    config.latitude = 35.0572167
-    config.longitude = -106.6837667
-    config.elevation = 1520
+    config.latitude = -80.833763
+    config.longitude = -44.674523
+    config.elevation = -20
+    config.switch_camera_modes = False
 
-    # Test the time now - remove daytime_mode
+    # Test the time now - remove daytime_mode above
     # captureModeSwitcher(config)
     

--- a/RMS/CaptureModeSwitcher.py
+++ b/RMS/CaptureModeSwitcher.py
@@ -137,7 +137,6 @@ if __name__ == "__main__":
 
     config.latitude = -80.833763
     config.longitude = -44.674523
-    config.longitude =  -44.674523
     config.elevation = -20
     config.switch_camera_modes = False
 


### PR DESCRIPTION
Simultaneous camera mode switching on MCL can be unstable. This PR uses the config `capture_wait_seconds` to stagger the camera switching. On initial run, the mode switching is not delayed as capture_wait_seconds already delays start capture.