### PR TITLE
Add log entry to prevent ctrl-c failure

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -68,6 +68,8 @@ def breakHandler(signum, frame):
     # Set the flag to stop capturing video
     STOP_CAPTURE = True
 
+    # This log entry is an adhoc fix to prevents Ctrl+C failure until the root cause is identified
+    log.info("Ctrl+C pressed. Setting STOP_CAPTURE to True")
 
 # Save the original event for the Ctrl+C
 ORIGINAL_BREAK_HANDLE = signal.getsignal(signal.SIGINT)


### PR DESCRIPTION
This PR address issue #482, though the underlying mechanism is unclear to me. The PR simply adds a log entry when CTRL-C is pressed. Surprisingly, this seemingly restores the functionality of CTRL-C. 