### PR TITLE
Improved raw items (videos and frames) deletion

### DIFF
--- a/.config
+++ b/.config
@@ -267,11 +267,11 @@ bz2_files_to_keep: 20
 ; Number of CapturedFiles folders to keep. Default is 8
 capt_dirs_to_keep: 8
 
-; Number of frame folders (days) to keep. Default is 8
-frame_dirs_to_keep: 4
+; Number of frame file days to keep. Default is 4
+frame_days_to_keep: 4
 
 ; Number of raw video folders (days) to keep. Default is 2
-video_dirs_to_keep: 2
+video_days_to_keep: 2
 
 
 ; the next settings configure the archive management by space used on disk

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -361,12 +361,12 @@ class Config:
         # Frame dirs to keep
         # Keep this many frame dirs (days)
         # Zero means keep them all
-        self.frame_dirs_to_keep = 4
+        self.frame_days_to_keep = 4
 
         # Video dirs to keep
         # Keep this many video dirs (days)
         # Zero means keep them all
-        self.video_dirs_to_keep = 2
+        self.video_days_to_keep = 2
         
         # Space quotas in GB
 
@@ -964,11 +964,11 @@ def parseCapture(config, parser):
     if parser.has_option(section, "capt_dirs_to_keep"):
         config.capt_dirs_to_keep = int(parser.get(section, "capt_dirs_to_keep"))
 
-    if parser.has_option(section, "frame_dirs_to_keep"):
-        config.bz2_files_to_keep = int(parser.get(section, "frame_dirs_to_keep"))
+    if parser.has_option(section, "frame_days_to_keep"):
+        config.frame_days_to_keep = int(parser.get(section, "frame_days_to_keep"))
 
-    if parser.has_option(section, "video_dirs_to_keep"):
-        config.video_dirs_to_keep = int(parser.get(section, "video_dirs_to_keep"))
+    if parser.has_option(section, "video_days_to_keep"):
+        config.video_days_to_keep = int(parser.get(section, "video_days_to_keep"))
 
     if parser.has_option(section, "quota_management_disabled"):
         config.quota_management_disabled = parser.getboolean(section, "quota_management_disabled")


### PR DESCRIPTION
This PR is for clarity within the DeleteOldObservations code:

- changes the naming convention of frame_dirs_to_keep to frame_days_to_keep

- changes the naming convention of functions getRawDirs / deleteRawDirs to getRawItems / deleteRawItems
 
- improved language in comments and docstrings of the above functions

- in FramesFiles, each day consists of three processed files (frames archive, timelapse and frametime json). The code now automatically handles the frame_days_to_keep config option against this detail gracefully