### PR TITLE
Close cam socket in ObservationSummary

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -424,6 +424,7 @@ def gatherCameraInformation(config):
         cam = dvr.DVRIPCam(re.findall(r"[0-9]+(?:\.[0-9]+){3}", config.deviceID)[0])
         if cam.login():
             sensor_type = cam.get_upgrade_info()['Hardware']
+            cam.close()
         else:
             sensor_type = "Unable to login"
     except:


### PR DESCRIPTION
Currently, ObservationSummary opens a camera socket to check the sensor type but fails to close it. DVRIP maintains the connection by querying the camera every 20 seconds throughout the capture duration. This PR addresses this issue by closing the connection after obtaining the sensor type.