### PR TITLE
Accurate timestamping for RMS (FT files)

### DIFF
--- a/.config
+++ b/.config
@@ -239,6 +239,9 @@ frame_dir: FramesFiles
 ; Name of directory within data_dir for raw video files
 video_dir: VideoFiles
 
+; Name of directory within data_dir for raw video timestamp (FT) files
+times_dir: TimeFiles
+
 ; Name of directory within data_dir for log files
 log_dir: logs
 
@@ -270,7 +273,7 @@ capt_dirs_to_keep: 8
 ; Number of frame file days to keep. Default is 4
 frame_days_to_keep: 4
 
-; Number of raw video folders (days) to keep. Default is 2
+; Number of raw video + corresponding FT file folders (days) to keep. Default is 2
 video_days_to_keep: 2
 
 

--- a/.config
+++ b/.config
@@ -239,7 +239,7 @@ frame_dir: FramesFiles
 ; Name of directory within data_dir for raw video files
 video_dir: VideoFiles
 
-; Name of directory within data_dir for raw video timestamp (FT) files
+; Name of directory within data_dir for timestamp (FT) files
 times_dir: TimeFiles
 
 ; Name of directory within data_dir for log files
@@ -273,8 +273,11 @@ capt_dirs_to_keep: 8
 ; Number of frame file days to keep. Default is 4
 frame_days_to_keep: 4
 
-; Number of raw video + corresponding FT file folders (days) to keep. Default is 2
+; Number of raw video folders (days) to keep. Default is 2
 video_days_to_keep: 2
+
+; Number of ft file (timestamp) folders (days) to keep. Default is 8
+times_days_to_keep: 8
 
 
 ; the next settings configure the archive management by space used on disk

--- a/.config
+++ b/.config
@@ -182,6 +182,9 @@ fov_h: 45
 ff_format: fits
 
 
+; Toggle saving of frame time files (FT files) to times_dir
+save_frame_times: true
+
 ; Toggle saving video frames at a set interval to the frame_dir
 save_frames: true
 

--- a/RMS/CaptureModeSwitcher.py
+++ b/RMS/CaptureModeSwitcher.py
@@ -112,14 +112,14 @@ def captureModeSwitcher(config, daytime_mode):
     # while True:
 
     #     if not daytime_mode.value:
-    #         log.info(f'Switching to day time mode')
+    #         log.info('Switching to day time mode')
     #         daytime_mode.value = True
 
     #         if config.switch_camera_modes:
     #             cc.cameraControlV2(config, 'SwitchDayTime')
 
     #     else:
-    #         log.info(f'Switching to night time mode')
+    #         log.info('Switching to night time mode')
     #         daytime_mode.value = False
     
     #         if config.switch_camera_modes:

--- a/RMS/Compression.py
+++ b/RMS/Compression.py
@@ -59,7 +59,7 @@ class Compressor(multiprocessing.Process):
             array1: first numpy array in shared memory of grayscale video frames
             startTime1: float in shared memory that holds time of first frame in array1
             array2: second numpy array in shared memory
-            startTime1: float in shared memory that holds time of first frame in array2
+            startTime2: float in shared memory that holds time of first frame in array2
             config: configuration class
 
         Keyword arguments:

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -404,6 +404,9 @@ class Config:
         # Enable/disable saving a live.jpg file in the data directory with the latest image
         self.live_jpg = False
 
+        # Toggle saving of frame time files (FT files) to times_dir
+        self.save_frame_times = True
+
         # Toggle saving video frames at a set interval to the frame_dir
         self.save_frames = True
 
@@ -1170,6 +1173,10 @@ def parseCapture(config, parser):
     # Enable/disable showing maxpixel on the screen
     if parser.has_option(section, "live_jpg"):
         config.live_jpg = parser.getboolean(section, "live_jpg")
+
+    # Toggle saving of frame time files (FT files) to times_dir
+    if parser.has_option(section, "save_frame_times"):
+        config.save_frame_times = parser.getboolean(section, "save_frame_times")
 
     # Enable/disable saving video frames
     if parser.has_option(section, "save_frames"):

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -291,7 +291,7 @@ class Config:
         # Decoder for the gstreamer media backend (e.g. decodebin, avdec_h264, nvh264dec)
         self.gst_decoder = "avdec_h264"
 
-        # Toggle raw video saving + FT file saving in data_dir/video_dir + data_dir/times_dir.
+        # Toggle raw video saving in data_dir/video_dir
         self.raw_video_save = False
 
         # Duration of the raw video segment (seconds)
@@ -364,11 +364,16 @@ class Config:
         # Zero means keep them all
         self.frame_days_to_keep = 4
 
-        # Video dirs + corresponding Time dirs to keep
-        # Keep this many video dirs (days) + corresponding FT file dirs
+        # Video dirs to keep
+        # Keep this many video dirs (days)
         # Zero means keep them all
         self.video_days_to_keep = 2
-        
+
+        # Timestamp dirs to keep
+        # Keep this many ft file (timestamp) folders (days)
+        # Zero means keep them all
+        self.times_days_to_keep = 8
+
         # Space quotas in GB
 
 
@@ -970,6 +975,9 @@ def parseCapture(config, parser):
 
     if parser.has_option(section, "video_days_to_keep"):
         config.video_days_to_keep = int(parser.get(section, "video_days_to_keep"))
+
+    if parser.has_option(section, "times_days_to_keep"):
+        config.times_days_to_keep = int(parser.get(section, "times_days_to_keep"))
 
     if parser.has_option(section, "quota_management_disabled"):
         config.quota_management_disabled = parser.getboolean(section, "quota_management_disabled")

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -291,7 +291,7 @@ class Config:
         # Decoder for the gstreamer media backend (e.g. decodebin, avdec_h264, nvh264dec)
         self.gst_decoder = "avdec_h264"
 
-        # Toggle raw video saving in data_dir/video_dir.
+        # Toggle raw video saving + FT file saving in data_dir/video_dir + data_dir/times_dir.
         self.raw_video_save = False
 
         # Duration of the raw video segment (seconds)
@@ -341,6 +341,7 @@ class Config:
         self.archived_dir = "ArchivedFiles"
         self.frame_dir = "FramesFiles"
         self.video_dir = "VideoFiles"
+        self.times_dir = "TimeFiles"
 
         # days of logfiles to keep
         self.logdays_to_keep = 30
@@ -363,8 +364,8 @@ class Config:
         # Zero means keep them all
         self.frame_days_to_keep = 4
 
-        # Video dirs to keep
-        # Keep this many video dirs (days)
+        # Video dirs + corresponding Time dirs to keep
+        # Keep this many video dirs (days) + corresponding FT file dirs
         # Zero means keep them all
         self.video_days_to_keep = 2
         
@@ -995,6 +996,9 @@ def parseCapture(config, parser):
 
     if parser.has_option(section, "video_dir"):
         config.video_dir = parser.get(section, "video_dir")
+
+    if parser.has_option(section, "times_dir"):
+        config.times_dir = parser.get(section, "times_dir")
 
     if parser.has_option(section, "width"):
         config.width = parser.getint(section, "width")

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -344,7 +344,8 @@ def getRawItems(dir_path, in_frame_dir=False, unique=False):
             raw_list += [os.path.join(year_path, day_dir) for day_dir in os.listdir(year_path) if os.path.isdir(os.path.join(year_path, day_dir))]
 
 
-    # Output files with unique dates
+    # Output files with unique dates - used for counting frame files (in days) in the main function deleteOldObservations
+    # The local function above isProcessedFrameFiles lists the multiple frames data files suffixes for a single day
     if unique:
         unique_dates = []
         temp_path_list = []
@@ -652,11 +653,10 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
     free_space_status = False
     while True:
 
-        # Delete one day of video directory data + corresponding time
+        # Delete one day of video directory data
         video_dirs_remaining = deleteRawItems(video_dir)
-        times_dirs_remaining = deleteRawItems(times_dir)
 
-        log.info("Deleted dir(s) in video / ft files directory: {:s}".format(video_dir))
+        log.info("Deleted dir(s) in video files directory: {:s}".format(video_dir))
         log.info("Free space: {:.2f} GB".format(availableSpace(data_dir)/1024/1024/1024))
 
         # Break the there's enough space
@@ -696,6 +696,18 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
         log.info("Free space: {:.2f} GB".format(availableSpace(data_dir)/1024/1024/1024))
 
         # Break if there's enough space
+        if availableSpace(data_dir) > next_night_bytes:
+            free_space_status = True
+            break
+
+
+        # Delete one day of times directory data
+        times_dirs_remaining = deleteRawItems(times_dir)
+
+        log.info("Deleted dir(s) in ft files directory: {:s}".format(times_dir))
+        log.info("Free space: {:.2f} GB".format(availableSpace(data_dir)/1024/1024/1024))
+
+        # Break the there's enough space
         if availableSpace(data_dir) > next_night_bytes:
             free_space_status = True
             break
@@ -860,12 +872,11 @@ def deleteOldDirs(data_dir, config):
     orig_count = 0
     final_count = 0
     times_dir = os.path.join(data_dir, config.times_dir)
-    
-    # Keep the same number of these dirs as the videos
-    if config.video_days_to_keep > 0:
+
+    if config.times_days_to_keep > 0:
         timesdir_list = getRawItems(times_dir)
         orig_count = len(timesdir_list)
-        while len(timesdir_list) > config.video_days_to_keep:
+        while len(timesdir_list) > config.times_days_to_keep:
             prev_length = len(timesdir_list)
             timesdir_list = deleteRawItems(times_dir)
             if len(timesdir_list) == prev_length:

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -308,24 +308,29 @@ def getNightDirs(dir_path, stationID):
     return dir_list
 
 
-def getRawItems(dir_path, in_frame_dir=False, unique=False):
-    """ Returns a sorted list of video/time directories or frame files.
-        In case of frames directory, only adds to the list the processed frames-(archive, timelapse, json) files and
-        not directories as they may be unprocessed.
+def getRawItems(dir_path, in_video_dir=False, unique=False):
+    """ Designed to work with dir_path = frame_dir, video_dir, OR times_dir
+        For video_dir: returns a sorted list of directories with mkv clips
+        For frame_dir: returns a sorted list of processed frames-(archive, timelapse, json) files
+        For times_dir: returns a sorted list of processed frame times (ft file) archives
+        
+        Directories are not added for frame_dir or times_dir as they may not have gone through post-processing;
+        post-processing ensures raw directories for these are removed
 
     Arguments:
-        dir_path: [str] Path to the raw video / frames directory.
-        in_frame_dir: [bool] Set this to True when dir_path is frames directory. False by default.
-        unique: [bool] Set this to True to get unique files by date
+        dir_path: [str] Path to the raw video / frames / frame times directory.
+        in_video_dir: [bool] Set this to True when dir_path is video directory. False by default.
+        unique: [bool] Set this to True to get unique files by date 
 
     Return:
-        dir_list: [list] A list of directories / files in the raw video / frame directories, each corresponding to one day of data
+        dir_list: [list] A list of directories / files in the raw video / frame / frame time directories,
+            each corresponding to one day of data
 
     """
 
     # Helper function to check frames file conditions
     def isProcessedFrameFile(path):
-        suffix = ['_frametimes.json', '_frames_timelapse.mp4', '_frames.tar.gz', '_frames.tar.bz2']
+        suffix = ['_frametimes.json', '_frames_timelapse.mp4', '_frames.tar.gz', '_frames.tar.bz2', '_frametimes.tar.bz2']
         return (os.path.isfile(path) and any(path.endswith(end) for end in suffix))
 
     # Get a list of directories / files in the given directory
@@ -334,17 +339,21 @@ def getRawItems(dir_path, in_frame_dir=False, unique=False):
     
     raw_list = []
     
+    # All of raw video, frame, and frame time directories follow Year/Day/Hour/ hierarchy for files.
     for year in os.listdir(dir_path):
         year_path = os.path.join(dir_path, year)
 
-        if in_frame_dir:
-            raw_list += [os.path.join(year_path, day_file) for day_file in os.listdir(year_path) if isProcessedFrameFile(os.path.join(year_path, day_file))]
+        if in_video_dir:
+            raw_list += [os.path.join(year_path, day_dir) for day_dir in os.listdir(year_path) if \
+                         os.path.isdir(os.path.join(year_path, day_dir))]
         else:
-            raw_list += [os.path.join(year_path, day_dir) for day_dir in os.listdir(year_path) if os.path.isdir(os.path.join(year_path, day_dir))]
+            raw_list += [os.path.join(year_path, day_file) for day_file in os.listdir(year_path) if \
+                         isProcessedFrameFile(os.path.join(year_path, day_file))]
 
 
     # Output files with unique dates - used for counting frame files (in days) in the main function deleteOldObservations
-    # The local function above isProcessedFrameFiles lists the multiple frames data files suffixes for a single day
+    # The local function above isProcessedFrameFiles lists the multiple frames data files suffixes that could exist for 
+    # a single day
     if unique:
         unique_dates = []
         temp_path_list = []
@@ -423,32 +432,37 @@ def deleteNightFolders(dir_path, config, delete_all=False):
     return getNightDirs(dir_path, config.stationID)
 
 
-def deleteRawItems(dir_path, delete_all=False, in_frame_dir=False, unique=False):
-    """ Deletes raw video/time directories or frames data files, to free up disk space. In case of frames directory,
-        it only will check for and delete old processed files (timelapses, archives, and json files) per day
-        and not directories as they may be unprocessed.
+def deleteRawItems(dir_path, delete_all=False, in_video_dir=False, unique=False):
+    """ Designed to work with dir_path = frame_dir, video_dir, OR times_dir
+        Uses the output of getRawItems. It deletes single item(s) unless delete_all = True.
+
+        For video_dir: delete a single day's directory with mkv clips, 
+        For frame_dir: delete a single day's SET of processed frames-(archive, timelapse, json) files
+        For times_dir: delete a single day's archive of processed frame times (ft file)
+        
+        Directories are not deleted for frame_dir or times_dir as they may not have gone through post-processing;
+        post-processing ensures raw directories for these are removed
 
     Arguments:
-        dir_path: [str] Path to the data directory
-
-    Keyword arguments:
-        delete_all: [bool] If True, all raw video / frame folders will be deleted. False by default.
-        in_frame_dir: [bool] Set this to True when dir_path is frames directory. False by default.
-        unique: [bool] Set this to True to get unique files by date
+        dir_path: [str] Path to the raw video / frames / frame times directory.
+        delete_all: [bool] If True, all raw video / frame / frame time data will be deleted. False by default.
+        in_video_dir: [bool] Set this to True when dir_path is video directory. False by default.
+        unique: [bool] Set this to True to get unique files by date 
 
     Return:
         dir_list: [list] A list of remaining raw video/frame directories/files in the data directory.
     """
 
     # Get the list of raw directories/files
-    del_list = getRawItems(dir_path, in_frame_dir=in_frame_dir)
+    del_list = getRawItems(dir_path, in_video_dir=in_video_dir)
 
     # Delete the raw video / frames directories / files, respectively
     for item in del_list:
         
         # Delete the next directory or file(s) in the list, i.e. the oldest ones
         try:
-            if in_frame_dir:
+            # For frames_dir or times_dir
+            if not in_video_dir:
                 
                 # For frame files, each day has a triplet of files: an archive (gz or bz2), a timelapse, and a json file
                 # We match file date for this batch of files for one day. The file base names are of type STATIONID_YYYYMMDD-DoY_*
@@ -460,6 +474,7 @@ def deleteRawItems(dir_path, delete_all=False, in_frame_dir=False, unique=False)
                 for file in files_to_delete:
                     os.remove(file)
 
+            # For video_dir
             else:
                 shutil.rmtree(item)
 
@@ -470,8 +485,8 @@ def deleteRawItems(dir_path, delete_all=False, in_frame_dir=False, unique=False)
         if not delete_all:
             break
 
-    # Return the list of remaining raw frame/video directories
-    return getRawItems(dir_path, in_frame_dir=in_frame_dir, unique=unique)
+    # Return the list of remaining raw video / frame / frame time directories
+    return getRawItems(dir_path, in_video_dir=in_video_dir, unique=unique)
 
 
 
@@ -653,24 +668,24 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
     while True:
 
         # Delete one day of video directory data
-        video_dirs_remaining = deleteRawItems(video_dir)
+        video_dirs_remaining = deleteRawItems(video_dir, in_video_dir=True)
 
         log.info("Deleted dir(s) in video files directory: {:s}".format(video_dir))
         log.info("Free space: {:.2f} GB".format(availableSpace(data_dir)/1024/1024/1024))
 
-        # Break the there's enough space
+        # Break if there's enough space
         if availableSpace(data_dir) > next_night_bytes:
             free_space_status = True
             break
 
 
         # Delete one day of frame directory data
-        frame_dirs_remaining = deleteRawItems(frame_dir, in_frame_dir=True)
+        frame_dirs_remaining = deleteRawItems(frame_dir)
 
         log.info("Deleted files in frame directory: {:s}".format(frame_dir))
         log.info("Free space: {:.2f} GB".format(availableSpace(data_dir)/1024/1024/1024))
 
-        # Break the there's enough space
+        # Break if there's enough space
         if availableSpace(data_dir) > next_night_bytes:
             free_space_status = True
             break
@@ -682,7 +697,7 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
         log.info("Deleted dir in captured directory: {:s}".format(captured_dir))
         log.info("Free space: {:.2f} GB".format(availableSpace(data_dir)/1024/1024/1024))
 
-        # Break the there's enough space
+        # Break if there's enough space
         if availableSpace(data_dir) > next_night_bytes:
             free_space_status = True
             break
@@ -706,7 +721,7 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
         log.info("Deleted dir(s) in ft files directory: {:s}".format(times_dir))
         log.info("Free space: {:.2f} GB".format(availableSpace(data_dir)/1024/1024/1024))
 
-        # Break the there's enough space
+        # Break if there's enough space
         if availableSpace(data_dir) > next_night_bytes:
             free_space_status = True
             break
@@ -719,7 +734,7 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
 
         # If no folders left to delete, try to delete archived files
         if (len(captured_dirs_remaining) + len(archived_dirs_remaining) + 
-            len(frame_dirs_remaining) + len(video_dirs_remaining) + len(times_dirs_remaining)== 0):
+            len(frame_dirs_remaining) + len(video_dirs_remaining) + len(times_dirs_remaining) == 0):
 
             log.info("Deleted all Capture, Archived, Frame, Video and Time directories, deleting archived bz2 files...")
 
@@ -838,11 +853,11 @@ def deleteOldDirs(data_dir, config):
     final_count = 0
     frame_dir = os.path.join(data_dir, config.frame_dir)
     if config.frame_days_to_keep > 0:
-        framedir_list = getRawItems(frame_dir, in_frame_dir=True, unique=True)
+        framedir_list = getRawItems(frame_dir, unique=True)
         orig_count = len(framedir_list)
         while len(framedir_list) > config.frame_days_to_keep:
             prev_length = len(framedir_list)
-            framedir_list = deleteRawItems(frame_dir, in_frame_dir=True, unique=True)
+            framedir_list = deleteRawItems(frame_dir, unique=True)
             if len(framedir_list) == prev_length:
                 log.error("Failed to delete folder from FrameFiles. Exiting loop.")
                 break
@@ -855,11 +870,11 @@ def deleteOldDirs(data_dir, config):
     final_count = 0
     video_dir = os.path.join(data_dir, config.video_dir)
     if config.video_days_to_keep > 0:
-        videodir_list = getRawItems(video_dir)
+        videodir_list = getRawItems(video_dir, in_video_dir=True)
         orig_count = len(videodir_list)
         while len(videodir_list) > config.video_days_to_keep:
             prev_length = len(videodir_list)
-            videodir_list = deleteRawItems(video_dir)
+            videodir_list = deleteRawItems(video_dir, in_video_dir=True)
             if len(videodir_list) == prev_length:
                 log.error("Failed to delete folder from VideoFiles. Exiting loop.")
                 break
@@ -867,11 +882,10 @@ def deleteOldDirs(data_dir, config):
     log.info('Purged {} days of old folders from VideoFiles'.format(orig_count - final_count))
 
 
-    # Deleting old video timestamp (ft file) dirs.
+    # Deleting old video timestamp (ft file) archives.
     orig_count = 0
     final_count = 0
     times_dir = os.path.join(data_dir, config.times_dir)
-
     if config.times_days_to_keep > 0:
         timesdir_list = getRawItems(times_dir)
         orig_count = len(timesdir_list)

--- a/RMS/Formats/FFStruct.py
+++ b/RMS/Formats/FFStruct.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division, absolute_import
 
 class FFStruct:
-    """ Default structure for a FF file.
+    """ Default structure for an FF file.
     """
     
     def __init__(self):

--- a/RMS/Formats/FTStruct.py
+++ b/RMS/Formats/FTStruct.py
@@ -1,0 +1,14 @@
+""" Definition of an FT file structure. Helps store timestamps of individual frames for raw mkv segment capture """
+
+from __future__ import print_function, division, absolute_import
+
+class FTStruct:
+    """ Default structure for an FT file to store frame timestamps.
+    """
+
+    def __init__(self):
+        # List of tuples: [(frame_number, timestamp), ...]
+        self.timestamps = []
+
+    def __repr__(self):
+        return "FTStruct with timestamp for {:d} frames.\n".format(len(self.timestamps))

--- a/RMS/Formats/FTfile.py
+++ b/RMS/Formats/FTfile.py
@@ -1,0 +1,103 @@
+""" Functions for reading/writing FT files in .bin format """
+
+
+from __future__ import print_function, division, absolute_import
+
+import os
+import struct
+
+import numpy as np
+
+from RMS.Formats.FTStruct import FTStruct
+
+
+def read(directory, filename):
+    """ Read FT*.bin file from the specified directory.
+
+    Args:
+        directory: [str] Path to directory containing file.
+        filename: [str] Name of FT*.bin file.
+
+    Returns:
+        ft: FTStruct object populated with data from the file.
+    """
+
+    filepath = os.path.join(directory, filename)
+
+    with open(filepath, "rb") as ft_file:
+        ft = FTStruct()
+        
+        # Read number of frames
+        n_frames = int(np.fromfile(ft_file, dtype=np.uint32, count=1))
+
+        # Read timestamps
+        for _ in range(n_frames):
+            frame_number = int(np.fromfile(ft_file, dtype=np.uint32, count=1))
+            timestamp = float(np.fromfile(ft_file, dtype=np.float64, count=1))
+            ft.timestamps.append((frame_number, timestamp))
+
+    return ft
+
+
+def write(ft, directory, filename):
+    """ Write FT structure to a .bin file in the specified directory.
+
+    Args:
+        ft: FTStruct object containing data to write.
+        directory: [str] Path to the directory where the file will be written.
+        filename: [str] Name of the file which will be written.
+    """
+
+    ft_full_path = os.path.join(directory, filename)
+
+    with open(ft_full_path, "wb") as ft_file:
+
+        # Write number of frames
+        n_frames = len(ft.timestamps)
+        ft_file.write(struct.pack("I", n_frames))
+
+        # Write each frame number and timestamp
+        for frame_number, timestamp in ft.timestamps:
+            ft_file.write(struct.pack("I", frame_number))
+            ft_file.write(struct.pack("d", timestamp))     
+
+
+if __name__ == '__main__':
+    pass
+
+    # ### TEST ###
+
+    # # Load a .bin file
+    # dir_path = "D:/Dropbox/RPi_Meteor_Station/samples/sample_bins"
+
+    # file_name = 'FF453_20150620_201239_920_0058880.bin'
+
+    # # Read the FF file
+    # ff = read(dir_path, file_name)
+
+    # print(ff)
+
+    # # file_name_fits = file_name.replace('.bin', '.fits')
+
+    # # # Write the read FF file as FITS
+    # # write(ff, dir_path, file_name_fits, fmt='fits')
+
+    # # # Read the FFfits
+    # # ff = read(dir_path, file_name_fits)
+
+
+    # # Save as new CAMS format
+    # file_name_new_bin = file_name[:-5] + '_new.bin'
+
+    # write(ff, dir_path, file_name_new_bin, fmt='bin')
+
+    # # Read the newly written file
+    # ff = read(dir_path, file_name_new_bin)
+
+
+    # import matplotlib.pyplot as plt
+
+    # plt.imshow(ff.maxpixel, cmap='gray', vmin=0, vmax=255)
+    # plt.show()
+
+    # print(ff)

--- a/RMS/Formats/FTfile.py
+++ b/RMS/Formats/FTfile.py
@@ -63,41 +63,31 @@ def write(ft, directory, filename):
 
 
 if __name__ == '__main__':
-    pass
 
-    # ### TEST ###
+    import tempfile
+    
+    # Temporary directory for test files
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_filename = "FT_test.bin"
+        test_filepath = os.path.join(temp_dir, test_filename)
 
-    # # Load a .bin file
-    # dir_path = "D:/Dropbox/RPi_Meteor_Station/samples/sample_bins"
+        # Create a sample FTStruct object
+        original_ft = FTStruct()
+        original_ft.timestamps = [
+            (1, 0.033),
+            (2, 0.066),
+            (3, 0.099),
+            (4, 0.132),
+        ]
 
-    # file_name = 'FF453_20150620_201239_920_0058880.bin'
+        # Write the FTStruct to a file
+        print("Writing FT file to {}".format(test_filepath))
+        write(original_ft, temp_dir, test_filename)
 
-    # # Read the FF file
-    # ff = read(dir_path, file_name)
+        # Read the FTStruct back from the file
+        print("Reading FT file from {}".format(test_filepath))
+        loaded_ft = read(temp_dir, test_filename)
 
-    # print(ff)
-
-    # # file_name_fits = file_name.replace('.bin', '.fits')
-
-    # # # Write the read FF file as FITS
-    # # write(ff, dir_path, file_name_fits, fmt='fits')
-
-    # # # Read the FFfits
-    # # ff = read(dir_path, file_name_fits)
-
-
-    # # Save as new CAMS format
-    # file_name_new_bin = file_name[:-5] + '_new.bin'
-
-    # write(ff, dir_path, file_name_new_bin, fmt='bin')
-
-    # # Read the newly written file
-    # ff = read(dir_path, file_name_new_bin)
-
-
-    # import matplotlib.pyplot as plt
-
-    # plt.imshow(ff.maxpixel, cmap='gray', vmin=0, vmax=255)
-    # plt.show()
-
-    # print(ff)
+        # Verify the content matches
+        assert original_ft.timestamps == loaded_ft.timestamps, "Timestamps do not match!"
+        print("Test passed: Written and read timestamps match.")

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -234,7 +234,8 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
             night_data_dir_name)
 
     # Full path to the time files directories
-    ft_file_dir = os.path.join(os.path.abspath(config.data_dir), config.times_dir)
+    if config.save_frame_times:
+        ft_file_dir = os.path.join(os.path.abspath(config.data_dir), config.times_dir)
 
     # Full path to the saved frames directory
     if config.save_frames:
@@ -273,9 +274,10 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         mkdirP(night_data_dir)
         log.info('Data directory: ' + night_data_dir)
 
-    # Make a directory for the time files
-    mkdirP(ft_file_dir)
-    log.info('Saved FT files directory: {}'.format(ft_file_dir))
+    # Make a directory for the time files if configured
+    if config.save_frame_times:
+        mkdirP(ft_file_dir)
+        log.info('Saved FT files directory: {}'.format(ft_file_dir))
 
     # Make a directory for the saved frames
     if saved_frames_dir is not None:

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -240,11 +240,13 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
     else:
         saved_frames_dir = None
 
-    # Full path to the video files directory
+    # Full path to the video files + corresponding time files directories 
     if config.raw_video_save:
         saved_video_dir = os.path.join(os.path.abspath(config.data_dir), config.video_dir)
+        ft_file_dir = os.path.join(os.path.abspath(config.data_dir), config.times_dir)
     else:
         saved_video_dir = None
+        ft_file_dir = None
 
 
 
@@ -277,10 +279,12 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         mkdirP(saved_frames_dir)
         log.info('Saved frames directory: {}'.format(saved_frames_dir))
 
-    # Make a directory for the saved videos
+    # Make a directory for the saved videos + corresponding time files
     if saved_video_dir is not None:
         mkdirP(saved_video_dir)
+        mkdirP(ft_file_dir)
         log.info('Saved videos directory: {}'.format(saved_video_dir))
+        log.info('Saved FT files directory: {}'.format(ft_file_dir))
 
     # Copy the used config file to the capture directory
     if os.path.isfile(config.config_file_name):

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -234,20 +234,20 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         night_data_dir = os.path.join(os.path.abspath(config.data_dir), config.captured_dir, \
             night_data_dir_name)
 
+    # Full path to the time files directories
+    ft_file_dir = os.path.join(os.path.abspath(config.data_dir), config.times_dir)
+
     # Full path to the saved frames directory
     if config.save_frames:
         saved_frames_dir = os.path.join(os.path.abspath(config.data_dir), config.frame_dir)
     else:
         saved_frames_dir = None
 
-    # Full path to the video files + corresponding time files directories 
+    # Full path to the video files
     if config.raw_video_save:
         saved_video_dir = os.path.join(os.path.abspath(config.data_dir), config.video_dir)
-        ft_file_dir = os.path.join(os.path.abspath(config.data_dir), config.times_dir)
     else:
         saved_video_dir = None
-        ft_file_dir = None
-
 
 
     # Add a note about Patreon supporters
@@ -274,17 +274,19 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         mkdirP(night_data_dir)
         log.info('Data directory: ' + night_data_dir)
 
+    # Make a directory for the time files
+    mkdirP(ft_file_dir)
+    log.info('Saved FT files directory: {}'.format(ft_file_dir))
+
     # Make a directory for the saved frames
     if saved_frames_dir is not None:
         mkdirP(saved_frames_dir)
         log.info('Saved frames directory: {}'.format(saved_frames_dir))
 
-    # Make a directory for the saved videos + corresponding time files
+    # Make a directory for the saved videos
     if saved_video_dir is not None:
         mkdirP(saved_video_dir)
-        mkdirP(ft_file_dir)
         log.info('Saved videos directory: {}'.format(saved_video_dir))
-        log.info('Saved FT files directory: {}'.format(ft_file_dir))
 
     # Copy the used config file to the capture directory
     if os.path.isfile(config.config_file_name):


### PR DESCRIPTION
Since the last update that changed the way raw video segments are named and stored, here are the changes this PR makes towards accurate timestamping of these segments:

1. An empty array is initialized to store the pts at the initialization of BufferedCapture.

2. ~~Every call to read() will append a new pts to the array.~~

3. Gstreamer callback moveSegment is called when a clip is ready. The segment is stored in the hierarchy under VideoFiles, while the pts array is flushed to a corresponding FT file under config.data_dir/TimeFiles (configureable), which follows a similar directory structure as the videos (Year/Day-of-Year/Hour/)

4. The timestamp array in memory is immediately cleared to store the next segment's pts.

In addition, each FT file and corresponding video segment are now named after ~~their first timestamp, and not using current time (RmsDateTime.utcnow).~~