### PR TITLE
continuous capture retry with lock file check

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -1125,14 +1125,16 @@ if __name__ == "__main__":
 
 
                 ### Stop reboot tries if it's time to capture ###
-                if isinstance(start_time, bool):
-                    if start_time:
-                        break
+                if (not config.continuous_capture):
+                    
+                    if isinstance(start_time, bool):
+                        if start_time:
+                            break
 
-                time_now = RmsDateTime.utcnow()
-                waiting_time = start_time - time_now
-                if waiting_time.total_seconds() <= 0:
-                    break
+                    time_now = RmsDateTime.utcnow()
+                    waiting_time = start_time - time_now
+                    if waiting_time.total_seconds() <= 0:
+                        break
 
                 ### ###
 


### PR DESCRIPTION
For issue #495 

The block including start_time checking is skipped in case of continuous capture, allowing retry for a full 4 hours before capture start.

Previously, as start_time is set to True for continuous capture, reboot retry won't occur if a lock_file is present and
`waiting_time = start_time - time_now`
will throw an error. 