### PR TITLE
Grayscale fix with GStreamer

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -495,8 +495,8 @@ class BufferedCapture(Process):
                     log.info("GStreamer Buffer did not contain a frame.")
                     return False, None, None
 
-                # Handling for grayscale conversion
-                frame = self.handleGrayscaleConversion(map_info)
+                # Cast to uint8 if necessary
+                frame = np.ndarray(shape=self.frame_shape, buffer=map_info.data, dtype=np.uint8)
 
                 # Smooth raw pts and calculate actual timestamp
                 smoothed_pts = self.smoothPTS(gst_timestamp_ns)
@@ -665,23 +665,6 @@ class BufferedCapture(Process):
             return True
         
         return False
-
-    
-    def handleGrayscaleConversion(self, map_info):
-        """Handle conversion of frame to grayscale if necessary."""
-
-        # If the frame is already grayscale, return it as is
-        if len(self.frame_shape) == 2:
-            return np.ndarray(shape=self.frame_shape, buffer=map_info.data, dtype=np.uint8)
-
-        if (self.daytime_mode is not None) and (self.daytime_mode.value):
-            return np.ndarray(shape=self.frame_shape, buffer=map_info.data, dtype=np.uint8)
-
-        # Convert to grayscale by selecting a specific channel
-        bgr_frame = np.ndarray(shape=self.frame_shape, buffer=map_info.data, dtype=np.uint8)
-        gray_frame = bgr_frame[:, :, 0]  # Assuming the blue channel for grayscale
-        return gray_frame
-
 
 
     def moveSegment(self, splitmuxsink, fragment_id):

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1517,8 +1517,8 @@ class BufferedCapture(Process):
                     and self.video_file is None
                     and total_frames % self.config.frame_save_interval_count == 0):
 
-                    # ensure only one channel when in nightmode
-                    if (self.daytime_mode is None) or (not self.daytime_mode.value):
+                    # avoid storing duplicate data
+                    if self.convert_to_gray:
                         frame = convertToGrayscale(frame)
 
                     # In case of a mode switch, the frame shape might change (color or grayscale)


### PR DESCRIPTION
GStreamer path in *BufferedCapture.py* included a faulty method that was using blue frame for grayscale, even though result of `read()` can return all three color frames and grayscale conversion will be handled correctly later in `captureFrames()` method.

**Not tested**, please test on RPi with hardware decoding before merging!