### PR TITLE
Improve handling of color and grayscale frames

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -669,16 +669,17 @@ class BufferedCapture(Process):
 
         try:
             # If diagonal samples are not identical, frame is color
-            if not np.all(frame[::stride, ::stride, 0] == frame[::stride, ::stride, 1]) or \
-               not np.all(frame[::stride, ::stride, 1] == frame[::stride, ::stride, 2]):
-                return False
-
-            # Otherwise all channels are identical.
-            return True
-
-        # If IndexError, frame is grayscale
+            is_gray = np.all(frame[::stride, ::stride, 0] == frame[::stride, ::stride, 1]) and \
+                      np.all(frame[::stride, ::stride, 1] == frame[::stride, ::stride, 2])
         except IndexError:
-            return True
+             # If IndexError, frame is grayscale
+            is_gray = True
+
+        if getattr(self, '_previous_grayscale_state', is_gray) != is_gray:
+            log.info("Frame grayscale state changed: {} -> {}".format(not is_gray, is_gray))
+            self._previous_grayscale_state = is_gray
+
+        return is_gray
 
 
     def handleGrayscaleConversion(self, frame):


### PR DESCRIPTION
This PR refines the frame-saving logic so RMS dynamically handles color vs. grayscale in both the GStreamer and OpenCV paths. On every save_frames_interval cycle, it performs a lightweight channel check to detect if the camera mode has changed (automatically or externally). If it sees a switch from color to grayscale (or vice versa), it now saves frames with the correct number of channels (one for grayscale, three for color).

Key scenarios this addresses:
	•	Automatic in-camera day/night mode changes
	•	Operator-triggered mode changes
	•	Multiple RMS stations sharing a camera
	•	Failed mode changes leaving a camera in an unexpected state

Previously, grayscale frames could be stored in three channels, or the blue channel might be used for compression when cameras changed modes unexpectedly. The OpenCV path in particular always saved three channels regardless of camera state. With this update, RMS consistently stores frames in the proper format, even if the camera toggles day/night modes or otherwise drifts between color and grayscale.