### PR TITLE
Switch to Paramiko SSHClient with Timeouts & Logging to Investigate Rare Lockups

### DIFF
--- a/RMS/DownloadMask.py
+++ b/RMS/DownloadMask.py
@@ -19,19 +19,20 @@ These are the default settings hard coded into ConfigReader.py
 
 from __future__ import print_function, division, absolute_import
 
+import logging
 import os
 from os.path import exists as file_exists
 
 import paramiko
 
-from RMS.Logger import getLogger
-from RMS.UploadManager import _agentAuth, existsRemoteDirectory, createRemoteDirectory
+
+from RMS.UploadManager import getSSHClientAndSFTP, existsRemoteDirectory, createRemoteDirectory
 from RMS.Misc import RmsDateTime
 
 
 
 # Get the logger from the main module
-log = getLogger("logger")
+log = logging.getLogger("logger")
 
 
 
@@ -53,116 +54,119 @@ def downloadNewMask(config, port=22):
 
     log.debug('Establishing SSH connection to: ' + config.hostname + ':' + str(port) + '...')
 
+    ssh = None
+    sftp = None
+
     try:
         # Connect to host
-        t = paramiko.Transport((config.hostname, port))
-        t.start_client()
+        # Connect with timeouts
+        ssh, sftp = getSSHClientAndSFTP(
+            config.hostname,
+            port=port,
+            username=config.stationID.lower(),
+            key_filename=config.rsa_private_key,
+            timeout=60,
+            banner_timeout=60,
+            auth_timeout=60
+        )
 
-        # Authenticate the connection
-        auth_status = _agentAuth(t, config.stationID.lower(), config.rsa_private_key)
-        if not auth_status:
+        # Check that the remote directory exists
+        try:
+            sftp.stat(config.remote_dir)
+
+        except Exception as e:
+            log.error("Remote directory '" + config.remote_dir + "' does not exist!")
             return False
 
-        # Open new SFTP connection
-        sftp = paramiko.SFTPClient.from_transport(t)
 
-    except:
-        log.error('Connecting to server failed!')
-        return False
+        # Construct path to remote mask directory
+        remote_mask_path = config.remote_dir + '/' + config.remote_mask_dir
 
-    # Check that the remote directory exists
-    try:
-        sftp.stat(config.remote_dir)
+        if not existsRemoteDirectory(sftp, remote_mask_path):
+            log.info("{} does not exist, creating".format(remote_mask_path))
+            createRemoteDirectory(sftp, remote_mask_path)
+        else:
+            log.info("{} exists".format(remote_mask_path))
 
-    except Exception as e:
-        log.error("Remote directory '" + config.remote_dir + "' does not exist!")
-        return False
+        # Add path separator
+        remote_mask_path += "/"
 
+        # Upload the most recent flat
+        captured_dirs = os.listdir(os.path.join(os.path.expanduser(config.data_dir), config.captured_dir))
+        captured_dirs.sort(reverse=True)
 
-    # Construct path to remote mask directory
-    remote_mask_path = config.remote_dir + '/' + config.remote_mask_dir
+        try:
+            if captured_dirs != []:
+                for captured_dir in captured_dirs:
+                    most_recent_flat = os.path.join(os.path.expanduser(config.data_dir), config.captured_dir, captured_dir,config.flat_file)
 
-    if not existsRemoteDirectory(sftp, remote_mask_path):
-        log.info("{} does not exist, creating".format(remote_mask_path))
-        createRemoteDirectory(sftp, remote_mask_path)
-    else:
-        log.info("{} exists".format(remote_mask_path))
-
-    # Add path separator
-    remote_mask_path += "/"
-
-    # Upload the most recent flat
-    captured_dirs = os.listdir(os.path.join(os.path.expanduser(config.data_dir), config.captured_dir))
-    captured_dirs.sort(reverse=True)
-
-    try:
-        if captured_dirs != []:
-            for captured_dir in captured_dirs:
-                most_recent_flat = os.path.join(os.path.expanduser(config.data_dir), config.captured_dir, captured_dir,config.flat_file)
+                    if file_exists(most_recent_flat):
+                        break
+                    else:
+                        most_recent_flat = ""
+                log.info("Most recent flat {}".format(most_recent_flat))
 
                 if file_exists(most_recent_flat):
-                    break
-                else:
-                    most_recent_flat = ""
-            log.info("Most recent flat {}".format(most_recent_flat))
-
-            if file_exists(most_recent_flat):
-                # Create AU002B_20231219_flat.bmp
-                remote_flat_name = "{}_{}_{}".format(captured_dir.split('_')[0], captured_dir.split('_')[1], config.flat_file)
-                log.info("Uploading to {} as {}".format(remote_mask_path, remote_flat_name))
-                sftp.put(most_recent_flat, remote_mask_path + "/" + remote_flat_name)
-                remote_files = sftp.listdir(path=remote_mask_path)
-                for file_to_test in remote_files:
-                    if "_{}".format(config.flat_file) in file_to_test:
-                        # Don't remove latest uploaded file
-                        if file_to_test != remote_flat_name:
-                            log.info("Removing old flat file {}".format(file_to_test))
-                            sftp.remove(remote_mask_path + "/" + file_to_test)
+                    # Create AU002B_20231219_flat.bmp
+                    remote_flat_name = "{}_{}_{}".format(captured_dir.split('_')[0], captured_dir.split('_')[1], config.flat_file)
+                    log.info("Uploading to {} as {}".format(remote_mask_path, remote_flat_name))
+                    sftp.put(most_recent_flat, remote_mask_path + "/" + remote_flat_name)
+                    remote_files = sftp.listdir(path=remote_mask_path)
+                    for file_to_test in remote_files:
+                        if "_{}".format(config.flat_file) in file_to_test:
+                            # Don't remove latest uploaded file
+                            if file_to_test != remote_flat_name:
+                                log.info("Removing old flat file {}".format(file_to_test))
+                                sftp.remove(remote_mask_path + "/" + file_to_test)
+                            else:
+                                log.info("Not removing newly uploaded file {}".format(file_to_test))
                         else:
-                            log.info("Not removing newly uploaded file {}".format(file_to_test))
-                    else:
-                        log.info("Not removing {}".format(file_to_test))
+                            log.info("Not removing {}".format(file_to_test))
 
 
-            else:
-                log.info("Did not find {}".format(most_recent_flat))
-    except:
-        log.warning("Could not upload latest flat")
+                else:
+                    log.info("Did not find {}".format(most_recent_flat))
+        except:
+            log.warning("Could not upload latest flat")
 
 
-    # Change the directory into file
-    remote_mask = remote_mask_path + config.mask_remote_name
+        # Change the directory into file
+        remote_mask = remote_mask_path + config.mask_remote_name
 
 
-    # Check if the remote mask file exists
-    try:
-        sftp.lstat(remote_mask)
-    
-    except IOError as e:
-        log.info('No new mask on the server!')
-        return False
+        # Check if the remote mask file exists
+        try:
+            sftp.lstat(remote_mask)
+        
+        except IOError as e:
+            log.info('No new mask on the server!')
+            return False
 
 
-    # Download the remote mask
-    log.info("Downloading {} from {} to {}".format(remote_mask, remote_mask_path, os.path.join(config.config_file_path, config.mask_file)))
-    sftp.get(remote_mask, os.path.join(config.config_file_path, config.mask_file))
-    log.info('Latest mask downloaded!')
+        # Download the remote mask
+        log.info("Downloading {} from {} to {}".format(remote_mask, remote_mask_path, os.path.join(config.config_file_path, config.mask_file)))
+        sftp.get(remote_mask, os.path.join(config.config_file_path, config.mask_file))
+        log.info('Latest mask downloaded!')
 
 
 
 
-    ### Rename the remote mask file, add a timestamp of download
-    ### This prevents the same mask being downloaded and overwriting an operator's more recent changes
+        ### Rename the remote mask file, add a timestamp of download
+        ### This prevents the same mask being downloaded and overwriting an operator's more recent changes
 
-    # Construct a new name with the time of the download included
-    dl_mask_name = remote_mask_path + 'mask_dl_' \
-        + RmsDateTime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + '.bmp'
+        # Construct a new name with the time of the download included
+        dl_mask_name = remote_mask_path + 'mask_dl_' \
+            + RmsDateTime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + '.bmp'
 
-    sftp.posix_rename(remote_mask, dl_mask_name)
+        sftp.posix_rename(remote_mask, dl_mask_name)
 
-    log.info('Remote mask renamed to: ' + dl_mask_name)
+        log.info('Remote mask renamed to: ' + dl_mask_name)
 
-    ### ###
+    finally:
+        if sftp:
+            sftp.close()
+        if ssh:
+            ssh.close()
 
     return True
 

--- a/RMS/DownloadMask.py
+++ b/RMS/DownloadMask.py
@@ -37,7 +37,7 @@ log = logging.getLogger("logger")
 
 
 
-def downloadNewMask(config, port=22):
+def downloadNewMask(config):
     """ Connect to the central server and download a new mask file, if available. """
 
     if config.mask_download_permissive:
@@ -60,7 +60,7 @@ def downloadNewMask(config, port=22):
         # Connect with timeouts
         ssh, sftp = getSSHClientAndSFTP(
             config.hostname,
-            port=port,
+            port=config.host_port,
             username=config.stationID.lower(),
             key_filename=config.rsa_private_key,
             timeout=60,
@@ -167,7 +167,7 @@ def downloadNewMask(config, port=22):
         if ssh:
             log.debug("Closing SSH client connection")
             ssh.close()
-            
+
     return True
 
 
@@ -197,4 +197,4 @@ if __name__ == "__main__":
 
 
     # Test mask downloading
-    downloadNewMask(config, port=22)
+    downloadNewMask(config)

--- a/RMS/DownloadMask.py
+++ b/RMS/DownloadMask.py
@@ -162,10 +162,12 @@ def downloadNewMask(config, port=22):
 
     finally:
         if sftp:
+            log.debug("Closing SFTP channel")
             sftp.close()
         if ssh:
+            log.debug("Closing SSH client connection")
             ssh.close()
-
+            
     return True
 
 

--- a/RMS/DownloadMask.py
+++ b/RMS/DownloadMask.py
@@ -52,8 +52,6 @@ def downloadNewMask(config, port=22):
         log.debug("Can't contact the server: RSA private key file not found.")
         return False
 
-    log.debug('Establishing SSH connection to: ' + config.hostname + ':' + str(port) + '...')
-
     ssh = None
     sftp = None
 

--- a/RMS/DownloadPlatepar.py
+++ b/RMS/DownloadPlatepar.py
@@ -85,10 +85,12 @@ def downloadNewPlatepar(config):
 
     finally:
         if sftp:
+            log.debug("Closing SFTP channel")
             sftp.close()
         if ssh:
+            log.debug("Closing SSH client connection")
             ssh.close()
-
+            
     return True
 
 

--- a/RMS/DownloadPlatepar.py
+++ b/RMS/DownloadPlatepar.py
@@ -34,7 +34,7 @@ def downloadNewPlatepar(config):
         # Connect with timeouts
         ssh, sftp = getSSHClientAndSFTP(
             config.hostname,
-            port=22,
+            port=config.host_port,
             username=config.stationID.lower(),
             key_filename=config.rsa_private_key,
             timeout=60,
@@ -90,7 +90,7 @@ def downloadNewPlatepar(config):
         if ssh:
             log.debug("Closing SSH client connection")
             ssh.close()
-            
+
     return True
 
 

--- a/RMS/DownloadPlatepar.py
+++ b/RMS/DownloadPlatepar.py
@@ -2,17 +2,18 @@
 
 from __future__ import print_function, division, absolute_import
 
+import logging
 import os
 from os.path import exists as file_exists
 
 import paramiko
 
-from RMS.Logger import getLogger
-from RMS.UploadManager import _agentAuth
+
+from RMS.UploadManager import getSSHClientAndSFTP
 from RMS.Misc import RmsDateTime
 
 # Get the logger from the main module
-log = getLogger("logger")
+log = logging.getLogger("logger")
 
 
 
@@ -27,66 +28,68 @@ def downloadNewPlatepar(config):
 
     log.debug('Establishing SSH connection to: ' + config.hostname + ':' + str(config.host_port) + '...')
 
+    ssh = None
+    sftp = None
+
     try:
         # Connect to host
-        t = paramiko.Transport((config.hostname, config.host_port))
-        t.start_client()
+        # Connect with timeouts
+        ssh, sftp = getSSHClientAndSFTP(
+            config.hostname,
+            port=22,
+            username=config.stationID.lower(),
+            key_filename=config.rsa_private_key,
+            timeout=60,
+            banner_timeout=60,
+            auth_timeout=60
+        )
 
-        # Authenticate the connection
-        auth_status = _agentAuth(t, config.stationID.lower(), config.rsa_private_key)
-        if not auth_status:
+        # Check that the remote directory exists
+        try:
+            sftp.stat(config.remote_dir)
+
+        except Exception as e:
+            log.error("Remote directory '" + config.remote_dir + "' does not exist!")
             return False
 
-        # Open new SFTP connection
-        sftp = paramiko.SFTPClient.from_transport(t)
 
-    except:
-        log.error('Connecting to server failed!')
-        return False
+        # Construct path to remote platepar directory
+        remote_platepar_path = config.remote_dir + '/' + config.remote_platepar_dir + '/'
 
-
-    # Check that the remote directory exists
-    try:
-        sftp.stat(config.remote_dir)
-
-    except Exception as e:
-        log.error("Remote directory '" + config.remote_dir + "' does not exist!")
-        return False
+        # Change the directory into file
+        remote_platepar = remote_platepar_path + config.platepar_remote_name
 
 
-    # Construct path to remote platepar directory
-    remote_platepar_path = config.remote_dir + '/' + config.remote_platepar_dir + '/'
-
-    # Change the directory into file
-    remote_platepar = remote_platepar_path + config.platepar_remote_name
-
-
-    # Check if the remote platepar file exists
-    try:
-        sftp.lstat(remote_platepar)
-    
-    except IOError as e:
-        log.info('No new platepar on the server!')
-        return False
+        # Check if the remote platepar file exists
+        try:
+            sftp.lstat(remote_platepar)
+        
+        except IOError as e:
+            log.info('No new platepar on the server!')
+            return False
 
 
-    # Download the remote platepar
-    sftp.get(remote_platepar, os.path.join(config.config_file_path, config.platepar_name))
+        # Download the remote platepar
+        sftp.get(remote_platepar, os.path.join(config.config_file_path, config.platepar_name))
 
-    log.info('Latest platepar downloaded!')
+        log.info('Latest platepar downloaded!')
 
 
-    ### Rename the downloaded platepar file, add a timestamp of download
+        ### Rename the downloaded platepar file, add a timestamp of download
 
-    # Construct a new name with the time of the download included
-    dl_pp_name = remote_platepar_path + 'platepar_dl_' \
-        + RmsDateTime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + '.cal'
+        # Construct a new name with the time of the download included
+        dl_pp_name = remote_platepar_path + 'platepar_dl_' \
+            + RmsDateTime.utcnow().strftime('%Y%m%d_%H%M%S.%f') + '.cal'
 
-    sftp.posix_rename(remote_platepar, dl_pp_name)
+        sftp.posix_rename(remote_platepar, dl_pp_name)
 
-    log.info('Remote platepar renamed to: ' + dl_pp_name)
+        log.info('Remote platepar renamed to: ' + dl_pp_name)
 
-    ### ###
+    finally:
+        if sftp:
+            sftp.close()
+        if ssh:
+            ssh.close()
 
     return True
 

--- a/RMS/DownloadPlatepar.py
+++ b/RMS/DownloadPlatepar.py
@@ -26,8 +26,6 @@ def downloadNewPlatepar(config):
         log.debug("Can't contact the server: RSA private key file not found.")
         return False
 
-    log.debug('Establishing SSH connection to: ' + config.hostname + ':' + str(config.host_port) + '...')
-
     ssh = None
     sftp = None
 

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -8,6 +8,7 @@ import ctypes
 import multiprocessing
 import time
 import datetime
+import logging
 
 import binascii
 import paramiko
@@ -21,7 +22,7 @@ except:
     import queue as Queue
 
 
-from RMS.Logger import getLogger
+
 from RMS.Misc import mkdirP, RmsDateTime
 
 # Map FileNotFoundError to IOError in Python 2 as it does not exist
@@ -29,61 +30,7 @@ if sys.version_info[0] < 3:
     FileNotFoundError = IOError
 
 # Get the logger from the main module
-log = getLogger("logger")
-
-
-def _agentAuth(transport, username, rsa_private_key):
-    """ Attempt to authenticate to the given transport using any of the private keys available from an SSH 
-        agent or from a local private RSA key file (assumes no pass phrase).
-
-    Arguments:
-        transport: [paramiko.Transport object] Connection handle.
-        username: [str] Username which will be used to connect to the host.
-        rsa_private_key: [str] Path to the RSA private key on the system.
-
-    Return:
-        [bool] True if successful, False otherwise.
-    """
-
-    # Try loading the private key
-    ki = None
-    try:
-        ki = paramiko.RSAKey.from_private_key_file(rsa_private_key)
-
-    except Exception as e:
-        log.error('Failed loading SSH key given in the config ' + rsa_private_key + str(e))
-
-
-    # Find all available keys if the private key was not found
-    if ki is None:
-        log.info("Loading all available keys from the SSH agent...")
-        agent = paramiko.Agent()
-        agent_keys = agent.get_keys()
-
-    else:
-        agent_keys = (ki,)
-
-
-    if len(agent_keys) == 0:
-        log.warning('No keys found, cannot authenticate!')
-        return False
-
-    # Try a key until finding the one which works
-    for key in agent_keys:
-
-        if key is not None:
-            log.info('Trying ssh-agent key {}'.format(binascii.hexlify(key.get_fingerprint())))
-
-            # Try the key to authenticate
-            try:
-                transport.auth_publickey(username, key)
-                log.info('... success!')
-                return True
-
-            except paramiko.SSHException as e:
-                log.warning('... failed! - %s', e)
-
-    return False
+log = logging.getLogger("logger")
 
 
 def existsRemoteDirectory(sftp,path):
@@ -181,8 +128,76 @@ def createRemoteDirectory(sftp, path):
         return False
 
 
-def uploadSFTP(hostname, username, dir_local, dir_remote, file_list, port=22, 
-        rsa_private_key=os.path.expanduser('~/.ssh/id_rsa'), allow_dir_creation=False):
+def getSSHClientAndSFTP(hostname,
+                        port=22,
+                        username=None,
+                        key_filename=None,
+                        timeout=300,
+                        banner_timeout=300,
+                        auth_timeout=300,
+                        keepalive_interval=30
+                        ):
+    """
+    Return (ssh, sftp) after authenticating via key or agent fallback, 
+    and optionally setting timeouts/keepalive.
+    """
+    log.info(f"Paramiko version: {paramiko.__version__}")
+    log.info(f"Establishing SSH connection to: {hostname}:{port}...")
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    # Try key_filename first
+    try:
+        ssh.connect(
+            hostname,
+            port=port,
+            username=username,
+            key_filename=key_filename,
+            timeout=timeout,
+            banner_timeout=banner_timeout,
+            auth_timeout=auth_timeout
+        )
+        log.info("SSHClient connected successfully (key file).")
+
+    except paramiko.AuthenticationException as e:
+        log.warning("Key-file auth failed: %s. Trying agent fallback...", e)
+        ssh.connect(
+            hostname,
+            port=port,
+            username=username,
+            look_for_keys=True,
+            timeout=timeout,
+            banner_timeout=banner_timeout,
+            auth_timeout=auth_timeout
+        )
+        log.info("SSHClient connected via agent fallback.")
+
+    except paramiko.SSHException as e:
+        log.error(f"SSH error: {e}")
+        raise
+
+    # Optionally set keepalive
+    transport = ssh.get_transport()
+    if transport and keepalive_interval > 0:
+        transport.set_keepalive(keepalive_interval)
+        log.info(f"Keepalive set to {keepalive_interval} seconds")
+
+    # Open SFTP
+    log.info("Opening SFTP channel...")
+    sftp = ssh.open_sftp()
+    log.info("SFTP channel opened.")
+
+    return ssh, sftp
+
+
+def uploadSFTP(hostname, username, dir_local, dir_remote, file_list, port=22,
+               rsa_private_key=os.path.expanduser('~/.ssh/id_rsa'),
+               allow_dir_creation=False,
+               connect_timeout=300,         # 5 minutes for socket connect
+               banner_timeout=300,  # 5 minutes to receive SSH banner
+               auth_timeout=300,     # 5 minutes for auth
+               keepalive_interval=30):
     """ Upload the given list of files using SFTP. The upload only supports uploading files from one local
         directory to one remote directory. The files are uploaded only if they do not already exist on the 
         server, or if they are of different size than the local files.
@@ -214,35 +229,35 @@ def uploadSFTP(hostname, username, dir_local, dir_remote, file_list, port=22,
         log.info('No files to upload!')
         return True
 
-    # Connect and use paramiko Transport to negotiate SSH2 across the connection
+    # Connect and use paramiko SFTP to negotiate SSH2 across the connection
     # The whole thing is in a try block because if an error occurs, the connection will be closed at the end
+
+    ssh = None
+    sftp = None
+
     try:
+        # Connect with timeouts
+        ssh, sftp = getSSHClientAndSFTP(
+            hostname,
+            port=port,
+            username=username,
+            key_filename=rsa_private_key,
+            timeout=connect_timeout,
+            banner_timeout=banner_timeout,
+            auth_timeout=auth_timeout
+        )
 
-        log.info('Establishing SSH connection to: ' + hostname + ':' + str(port) + '...')
-
-        # Connect to host
-        t = paramiko.Transport((hostname, port))
-        t.start_client()
-
-        # Authenticate the connection
-        auth_status = _agentAuth(t, username, rsa_private_key)
-        if not auth_status:
-            return False
-
-        # Open new SFTP connection
-        sftp = paramiko.SFTPClient.from_transport(t)
-
-        # If permitted, check if directory exists and create
+        # Optionally ensure remote directory exists
         if allow_dir_creation:
+            log.info("Checking/creating remote dir '{}'".format(dir_remote))
             if not existsRemoteDirectory(sftp, dir_remote):
                 createRemoteDirectory(sftp, dir_remote)
 
-        # Check that the remote directory exists
+        # Verify remote dir
         try:
             sftp.stat(dir_remote)
-
         except Exception as e:
-            log.error("Remote directory '" + dir_remote + "' does not exist!")
+            log.error("Remote directory '{}' does not exist or is not accessible: {}".format(dir_remote, e))
             return False
 
         # Go through all files
@@ -263,10 +278,11 @@ def uploadSFTP(hostname, username, dir_local, dir_remote, file_list, port=22,
                 
                 # If the remote and the local file are of the same size, skip it
                 if local_file_size == remote_info.st_size:
-                    log.info('The file already exists on the server!')
+                    log.info("The file '{}' already exists on the server and is the same size. Skipping.".format(remote_file))
                     continue
             
             except IOError as e:
+                # Means remote file doesn't exist yet, so proceed
                 pass
                 
 
@@ -274,38 +290,34 @@ def uploadSFTP(hostname, username, dir_local, dir_remote, file_list, port=22,
             # Upload the file to the server if it isn't already there
             log.info('Copying ' + local_file + ' ({:3.2f}MB) to '.format(int(local_file_size)/ (1024*1024)) + remote_file)
             sftp.put(local_file, remote_file)
+            log.info("Upload completed, verifying...")
 
 
             # Check that the size of the remote file is correct, indicating a successful upload
-            try:
-                remote_info = sftp.lstat(remote_file)
-                
-                # If the remote and the local file are of the same size, skip it
-                if local_file_size != remote_info.st_size:
-                    log.info('The file upload did not finish, aborting and trying again...')
-                    return False
-
-                else:
-                    log.info("File upload verified: {:s}".format(remote_file))
+            remote_info = sftp.lstat(remote_file)
             
-
-            except IOError as e:
+            # If the remote and the local file are of the same size, skip it
+            if local_file_size != remote_info.st_size:
+                log.info('The file upload did not finish, aborting and trying again...')
                 return False
 
-
-
-        t.close()
-
+            log.info("File upload verified: {:s}".format(remote_file))
+            
         return True
 
     except Exception as e:
-        log.error(e, exc_info=True)
-        try:
-            t.close()
-        except:
-            pass
-
+        log.error("Exception during SFTP upload: {}".format(e), exc_info=True)
         return False
+
+    finally:
+        # Close SFTP and SSH if open
+        if sftp is not None:
+            log.info("Closing SFTP channel")
+            sftp.close()
+        if ssh is not None:
+            log.info("Closing SSH client connection")
+            ssh.close()
+
 
 
 
@@ -503,7 +515,8 @@ class UploadManager(multiprocessing.Process):
                 tries += 1 
                 self.file_queue.put(file_name)
 
-                time.sleep(2)
+                # Given the network a moment to recover between attempts
+                time.sleep(10)
 
             # Check if the upload was tried too many times
             if tries >= retries:


### PR DESCRIPTION
We’ve had sporadic reports of lockups that are not reproducible in our test environment. The lockups are happening in UploadManager:
```
2025/01/13 14:28:25-INFO-StartCapture-line:683 - Uploading data before exiting...
2025/01/13 14:28:25-INFO-UploadManager-line:222 - Establishing SSH connection to: gmn.uwo.ca:22...
2025/01/13 14:28:26-INFO-UploadManager-line:76 - Trying ssh-agent key b'b3e09fd48cfea47fcf9d502c74436898'
2025/01/13 14:28:27-INFO-UploadManager-line:81 - ... success!

---------------- HANGS HERE INDEFINITELY --------------

2025/01/13 14:28:27-INFO-UploadManager-line:276 - Copying /home/rms/RMS_data/ArchivedFiles/US001P_20250113_003623_928590_detected.tar.bz2 (60.14MB) to files/US001P_20250113_003623_928590_detected.tar.bz2
2025/01/13 14:29:39-INFO-UploadManager-line:290 - File upload verified: files/US001P_20250113_003623_928590_detected.tar.bz2
2025/01/13 14:29:39-INFO-UploadManager-line:495 - Upload successful!
```

### This PR
- **Replaces** the low-level `Transport` usage with Paramiko’s recommended `SSHClient().connect()` approach.  
- **Adds** generous (5 minutes) connection-level timeouts (`timeout`, `banner_timeout`, `auth_timeout`) to avoid infinite waits on bad networks.  
- **Enables** a 30‑second keepalive (`transport.set_keepalive(...)`) so idle connections aren’t silently dropped on slow machines/connections.  
- **Refactors** authentication fallback—if the primary private key fails, it still falls back to the SSH agent.  
- **Introduces** more debug logging (including Paramiko version) to help us diagnose if issues persist.  
- **Increases** retry/backoff from 2 to 10 seconds, giving more time for the network to stabilize between attempts.
- **Ensures** we properly close SSH and SFTP sessions in a `try/finally` block to prevent lingering connections.

### Why?
- I haven’t been able to reproduce the reported lockups locally. This change is my best guess at a fix and prevention.  
- The expanded debug logs will make it easier to pinpoint what’s happening if a station still sees hangs.
- Properly closing resources should reduce the risk of orphaned sessions that might have caused issues.

### Sample Log:
```
025/01/22 21:31:53-INFO-DownloadMask-line:50 - Checking for new mask on the server...
2025/01/22 21:31:53-INFO-UploadManager-line:144 - Paramiko version: 3.4.1
2025/01/22 21:31:53-INFO-UploadManager-line:145 - Establishing SSH connection to: gmn.uwo.ca:22...
2025/01/22 21:31:54-INFO-UploadManager-line:161 - SSHClient connected successfully (key file).
2025/01/22 21:31:54-INFO-UploadManager-line:184 - Keepalive set to 30 seconds
2025/01/22 21:31:54-INFO-UploadManager-line:187 - Opening SFTP channel...
2025/01/22 21:31:54-INFO-UploadManager-line:189 - SFTP channel opened.
2025/01/22 21:31:55-INFO-DownloadMask-line:89 - files/masks exists
2025/01/22 21:31:55-INFO-DownloadMask-line:107 - Most recent flat /home/bolide/RMS_data/US005A/CapturedFiles/US005A_20250122_013222_354396/flat.bmp
2025/01/22 21:31:55-INFO-DownloadMask-line:112 - Uploading to files/masks/ as US005A_20250122_flat.bmp
2025/01/22 21:31:56-INFO-DownloadMask-line:122 - Not removing newly uploaded file US005A_20250122_flat.bmp
2025/01/22 21:31:56-INFO-DownloadMask-line:142 - No new mask on the server!
```
