### PR TITLE
Fix rounding error in free scape calculation

### DIFF
--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -21,7 +21,7 @@ check_disk_space() {
     local dir=$1
     local required_mb=$2
     
-    # Get available space in KB and convert to MB
+    # Get available space in MB
     local available_mb=$(df -m "$dir" | awk 'NR==2 {print $4}')
     
     if [ "$available_mb" -lt "$required_mb" ]; then

--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -22,7 +22,7 @@ check_disk_space() {
     local required_mb=$2
     
     # Get available space in KB and convert to MB
-    local available_mb=$(df -P "$dir" | awk 'NR==2 {print $4/1024}' | cut -d. -f1)
+    local available_mb=$(df -m "$dir" | awk 'NR==2 {print $4}')
     
     if [ "$available_mb" -lt "$required_mb" ]; then
         echo "Error: Insufficient disk space in $dir. Need ${required_mb}MB, have ${available_mb}MB"


### PR DESCRIPTION
The PR #505 has a disk space calculation error. When free space exceeds 1TB, `df` outputs scientific notation (e.g. 1.024e+06). The script's `cut -d. -f1` then incorrectly extracts just the first digit, so 1TB free space is misinterpreted as 1MB. This causes the update script to erroneously exit with "insufficient space", preventing updates on systems with >1TB free space until the script is manually fixed.