### PR TITLE
Fix mask file log messages in DetectionTools

### DIFF
--- a/RMS/DetectionTools.py
+++ b/RMS/DetectionTools.py
@@ -55,23 +55,20 @@ def loadImageCalibration(dir_path, config, dtype=None, byteswap=False):
 
     # Load the mask if given
     if mask_path:
-        
         mask = MaskImage.loadMask(mask_path)
 
-        # If the mask is all white, set it to None
-        if (mask is not None) and np.all(mask.img == 255):
-            print('Mask is all white, setting it to None.')
-            mask = None
+        if mask is not None:
+            info_msg = 'Loaded mask: {:s} '.format(mask_path)
 
-    if mask is not None:
-        print('Loaded mask:', mask_path)
-        log.info('Loaded mask: {:s}'.format(mask_path))
+            # If the mask is all white, set it to None
+            if np.all(mask.img == 255):
+                info_msg += '(all white)'
+                mask = None
 
-    else:
-        log.info('No mask file has been found.')
-
-
-
+            print(info_msg)
+            log.info(info_msg)
+        else:
+            log.info('No mask file has been found.')
 
     # Try loading the dark frame
     dark = None


### PR DESCRIPTION
 Avoid printing 'No mask file has been found' continuously on the console when mask is all white. Also add this info to the log, that will be like this:

2025/01/30 04:46:05-INFO-DetectionTools-line:69 - Loaded mask: /root/RMS_data/config/BR001Z/mask.bmp (all white)
