### PR TITLE
Fix/single file path size

### DIFF
--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -156,6 +156,10 @@ def usedSpaceNoRecursion(obj_path):
 
     obj_path = os.path.expanduser(obj_path)
     path_list, n = os.walk(obj_path), 0
+
+    if os.path.isfile(obj_path):
+        n += os.path.getsize(obj_path) / 1024 ** 2
+
     for root, directory_list, file_list in path_list:
         for _ in directory_list:
             n += 4.024 / 1024 ** 2

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -158,7 +158,7 @@ def usedSpaceNoRecursion(obj_path):
     path_list, n = os.walk(obj_path), 0
 
     if os.path.isfile(obj_path):
-        n += os.path.getsize(obj_path) / 1024 ** 2
+        n += os.path.getsize(obj_path) / 1024 ** 3
 
     for root, directory_list, file_list in path_list:
         for _ in directory_list:

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -201,6 +201,7 @@ def objectsToDelete(object_path, stationID, quota_gb=0, bz2=False):
     else:
         object_list = getNightDirs(object_path, stationID)
 
+
     # reverse it to put newest at top
     object_list.reverse()
 
@@ -236,8 +237,12 @@ def rmList(delete_list, dummy_run=True):
                 log.info("Config setting inhibited deletion of {}".format(os.path.basename(full_path)))
             else:
                 if os.path.exists(full_path):
-                    shutil.rmtree(full_path)
-                    log.info("Deleted {}".format(os.path.basename(full_path)))
+                    if os.path.isdir(full_path):
+                        shutil.rmtree(full_path)
+                        log.info("Deleted directory {}".format(os.path.basename(full_path)))
+                    if os.path.isfile(full_path):
+                        os.remove(full_path)
+                        log.info("Deleted file {}".format(os.path.basename(full_path)))
                 else:
                     log.warning("Attempted to delete {}, which did not exist".format(full_path))
         except:


### PR DESCRIPTION
#517 refers to incorrect file size calculation when a bz2 file size is being calculated for quota management. This fixes that issue.

```
--------------------------------------------
Directory quotas before management
--------------------------------------------
Space used
   Total space used for RMS_data :  119.66GB
            bz2 files space used :   19.71GB
 archived directories space used :    4.91GB
              total for archives :   24.62GB
   Captured directory space used :   93.80GB
Quotas allowed
        Total quota for RMS_data :   70.00GB
                  bz2 file quota :    3.00GB
      Archived directories quota :    5.00GB
          Remaining for captured :   62.00GB
Space on drive
        Available space on drive :   60.08GB
--------------------------------------------


--------------------------------------------
Directory quotas after management
--------------------------------------------
Space used
   Total space used for RMS_data :   67.31GB
            bz2 files space used :    2.87GB
 archived directories space used :    4.91GB
              total for archives :    7.78GB
   Captured directory space used :   58.29GB
Quotas allowed
        Total quota for RMS_data :   70.00GB
                  bz2 file quota :    3.00GB
      Archived directories quota :    5.00GB
          Remaining for captured :   62.00GB
Space on drive
        Available space on drive :  111.68GB
--------------------------------------------
```
