### PR TITLE
Compensate for half-pixel shift caused by the 2×2 mean filter

### DIFF
--- a/RMS/ExtractStars.py
+++ b/RMS/ExtractStars.py
@@ -159,6 +159,10 @@ def extractStars(img, img_median=None, mask=None, gamma=1.0, max_star_candidates
     sigma_fitted = np.sqrt(sigma_x_fitted**2 + sigma_y_fitted**2)
     fwhm = 2.355*sigma_fitted
 
+    # Compensate for half-pixel shift caused by the 2×2 mean filter
+    x_arr = [x + 0.5 for x in x_arr]
+    y_arr = [y + 0.5 for y in y_arr]
+
     return x_arr, y_arr, amplitude, intensity, fwhm
 
 


### PR DESCRIPTION
Fixed half-pixel offset in star detection by adding a 0.5 pixel correction. The 2×2 mean convolution filter introduced in extractStars() causes a systematic half-pixel shift in detected coordinates. This PR adds compensation to ensure accurate star positions while maintaining the noise-reduction benefits of the filter.