### PR TITLE
Increase calstar markers visibility

### DIFF
--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -915,18 +915,36 @@ class PlateTool(QtWidgets.QMainWindow):
 
         self.unsuitable_stars_visble = True
 
-        # calstar markers (main window)
-        self.calstar_markers = pg.ScatterPlotItem()
-        self.calstar_markers.setPen((0, 255, 0, 100))
+        # calstar markers outer rings (dark green) - main window
+        self.calstar_markers_outer = pg.ScatterPlotItem()
+        self.calstar_markers_outer.setPen(pg.mkPen((0, 100, 0, 255), width=1.5))
+        self.calstar_markers_outer.setBrush((0, 0, 0, 0))
+        self.calstar_markers_outer.setSize(14)
+        self.calstar_markers_outer.setSymbol('o')
+        self.calstar_markers_outer.setZValue(2)
+        self.img_frame.addItem(self.calstar_markers_outer)
+
+        # calstar markers inner rings (bright green) - main window
+        self.calstar_markers = pg.ScatterPlotItem() 
+        self.calstar_markers.setPen(pg.mkPen((50, 255, 50, 255), width=1.1))
         self.calstar_markers.setBrush((0, 0, 0, 0))
         self.calstar_markers.setSize(10)
         self.calstar_markers.setSymbol('o')
         self.calstar_markers.setZValue(2)
         self.img_frame.addItem(self.calstar_markers)
 
-        # calstar markers (zoom window)
+        # calstar markers outer rings (dark green) - zoom window
+        self.calstar_markers_outer2 = pg.ScatterPlotItem()
+        self.calstar_markers_outer2.setPen(pg.mkPen((0, 100, 0, 255), width=1.5))
+        self.calstar_markers_outer2.setBrush((0, 0, 0, 0))
+        self.calstar_markers_outer2.setSize(28)
+        self.calstar_markers_outer2.setSymbol('o')
+        self.calstar_markers_outer2.setZValue(5)
+        self.zoom_window.addItem(self.calstar_markers_outer2)
+
+        # calstar markers inner rings (bright green) - zoom window
         self.calstar_markers2 = pg.ScatterPlotItem()
-        self.calstar_markers2.setPen((0, 255, 0, 100))
+        self.calstar_markers2.setPen(pg.mkPen((50, 255, 50, 255), width=1.1))
         self.calstar_markers2.setBrush((0, 0, 0, 0))
         self.calstar_markers2.setSize(20)
         self.calstar_markers2.setSymbol('o')
@@ -1798,13 +1816,18 @@ class PlateTool(QtWidgets.QMainWindow):
             y = star_data[:, 0]
             x = star_data[:, 1]
 
+            # Set both the inner and outer rings
             self.calstar_markers.setData(x=x + 0.5, y=y + 0.5)
             self.calstar_markers2.setData(x=x + 0.5, y=y + 0.5)
+            self.calstar_markers_outer.setData(x=x + 0.5, y=y + 0.5)
+            self.calstar_markers_outer2.setData(x=x + 0.5, y=y + 0.5)
 
         else:
-
+            # Clear all markers if no stars
             self.calstar_markers.setData(pos=[])
             self.calstar_markers2.setData(pos=[])
+            self.calstar_markers_outer.setData(pos=[])
+            self.calstar_markers_outer2.setData(pos=[])
 
 
     def updatePicks(self):


### PR DESCRIPTION
This PR increases the visibility of calibration star markers in Skyfit2. Currently, the markers are very hard to see. The new markers have double light-dark rings  designed to be clearly visible against both light and dark backgrounds and to always remain visible behind any size catalog star marker.

<img width="3268" alt="Screenshot 2025-03-04 at 11 54 07 AM" src="https://github.com/user-attachments/assets/f1e2f8b1-8b67-4b06-a7d0-a6c3360bba69" />
<img width="799" alt="Screenshot 2025-03-04 at 11 55 03 AM" src="https://github.com/user-attachments/assets/9aecaaaf-dd67-45b9-a980-88949a2f2615" />
<img width="591" alt="Screenshot 2025-03-04 at 11 55 24 AM" src="https://github.com/user-attachments/assets/3dc50481-228a-4feb-839d-710e9156fa65" />
<img width="662" alt="Screenshot 2025-03-04 at 12 03 32 PM" src="https://github.com/user-attachments/assets/48560fd0-371c-439e-a38e-b0ec8ac49be2" />
