### PR TITLE
Permit log file deletion only when days_to_keep > 0 

### DIFF
--- a/.config
+++ b/.config
@@ -259,7 +259,8 @@ extra_space_gb: 5
 ; Number of ArchivedFiles folders to keep. Default is 20
 arch_dirs_to_keep: 20
 
-; Number of days of logs to keep. Default is 30
+; Number of days of logs to keep. Default is 30.
+; Setting to 0 inhibits log file deletion.
 logdays_to_keep: 30
 
 ; Control additional logging of console output messages

--- a/.config
+++ b/.config
@@ -260,7 +260,7 @@ extra_space_gb: 5
 arch_dirs_to_keep: 20
 
 ; Number of days of logs to keep. Default is 30.
-; Setting to 0 inhibits log file deletion.
+; If set to 0, logs will not be deleted.
 logdays_to_keep: 30
 
 ; Control additional logging of console output messages

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -955,7 +955,7 @@ def deleteOldLogfiles(data_dir, config, days_to_keep=None):
             # Get the file modification time
             file_mtime = os.stat(log_file_path).st_mtime
 
-            # If the file is older than the date to purge to, delete it
+            # If the file is older than the date to purge to and days_to_keep >0, delete it
             if file_mtime < date_to_purge_to and days_to_keep > 0:
                 try:
                     os.remove(log_file_path)

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -939,9 +939,6 @@ def deleteOldLogfiles(data_dir, config, days_to_keep=None):
     # Date to purge before
     if days_to_keep is None:
         days_to_keep = int(config.logdays_to_keep)
-
-
-
     date_to_purge_to = datetime.datetime.now() - datetime.timedelta(days=days_to_keep)
     date_to_purge_to = timestamp(date_to_purge_to)
 

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -955,7 +955,8 @@ def deleteOldLogfiles(data_dir, config, days_to_keep=None):
             # Get the file modification time
             file_mtime = os.stat(log_file_path).st_mtime
 
-            # If the file is older than the date to purge to and days_to_keep >0, delete it
+            # If the file is older than the date to purge to and days_to_keep >0
+            # delete it
             if file_mtime < date_to_purge_to and days_to_keep > 0:
                 try:
                     os.remove(log_file_path)

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -955,7 +955,7 @@ def deleteOldLogfiles(data_dir, config, days_to_keep=None):
             # Get the file modification time
             file_mtime = os.stat(log_file_path).st_mtime
 
-            # If the file is older than the date to purge to and days_to_keep >0
+            # If the file is older than the date to purge to and days_to_keep > 0
             # delete it
             if file_mtime < date_to_purge_to and days_to_keep > 0:
                 try:

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -939,6 +939,9 @@ def deleteOldLogfiles(data_dir, config, days_to_keep=None):
     # Date to purge before
     if days_to_keep is None:
         days_to_keep = int(config.logdays_to_keep)
+
+
+
     date_to_purge_to = datetime.datetime.now() - datetime.timedelta(days=days_to_keep)
     date_to_purge_to = timestamp(date_to_purge_to)
 
@@ -956,12 +959,12 @@ def deleteOldLogfiles(data_dir, config, days_to_keep=None):
             file_mtime = os.stat(log_file_path).st_mtime
 
             # If the file is older than the date to purge to, delete it
-            if file_mtime < date_to_purge_to:
+            if file_mtime < date_to_purge_to and days_to_keep > 0:
                 try:
                     os.remove(log_file_path)
                     log.info("deleted {}".format(fl))
                 except Exception as e:
-                    log.warning('unable to delete {}: '.format(log_file_path) + repr(e)) 
+                    log.warning('unable to delete {}: '.format(log_file_path) + repr(e))
                 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The pull request refers to Issue #549. 

When 

```
logdays_to_keep: 0
```

Deletion of logfiles should be inhibited. This pull request permits log file deletion only when logdays_to_keep > 0.