### PR TITLE
Add the continuous capture directories into the space quota management system

### DIFF
--- a/.config
+++ b/.config
@@ -299,7 +299,7 @@ rms_data_quota: 4000
 arch_dir_quota: 100
 
 ; Space allowance for log files
-log_files_quota: 1
+log_files_quota: 0.1
 
 ; Space allowance for the bz2 files
 bz2_files_quota: 100
@@ -307,12 +307,9 @@ bz2_files_quota: 100
 ; Space allowance for continuous capture
 continuous_capture_quota: 30
 
-
-
-
 ; Therefore the space allowed for the CapturedFiles directory is
-; rms_data_quota - (arch_dir_quota + bz2_files_quota)
-; space used by log files and .db files is ignored
+; rms_data_quota - (arch_dir_quota + bz2_files_quota + log_files_quota + continuous_capture_quota)
+; space used by .db files is ignored
 
 
 ; Toggle showing maxpixel on the screen during capture

--- a/.config
+++ b/.config
@@ -298,8 +298,17 @@ rms_data_quota: 4000
 ; Space allowance for the archived directories, and files contained within
 arch_dir_quota: 100
 
+; Space allowance for log files
+log_files_quota: 1
+
 ; Space allowance for the bz2 files
 bz2_files_quota: 100
+
+; Space allowance for continuous capture
+continuous_capture_quota: 30
+
+
+
 
 ; Therefore the space allowed for the CapturedFiles directory is
 ; rms_data_quota - (arch_dir_quota + bz2_files_quota)

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -1008,7 +1008,7 @@ def parseCapture(config, parser):
         config.bz2_files_quota = int(parser.get(section, "bz2_files_quota"))
 
     if parser.has_option(section, "log_files_quota"):
-        config.log_files_quota = int(parser.get(section, "log_files_quota"))
+        config.log_files_quota = float(parser.get(section, "log_files_quota"))
 
     if parser.has_option(section, "continuous_capture_quota"):
         config.continuous_capture_quota = int(parser.get(section, "continuous_capture_quota"))

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -380,7 +380,7 @@ class Config:
 
         # Space allocation for all of rms_data
 
-        # Disable the deletion by quota management for testing purposes
+        # Enable quota management
         self.quota_management_enabled = False
 
 
@@ -392,6 +392,13 @@ class Config:
 
         # Of that allocation for all of rms_data, this is set aside for bz2 files
         self.bz2_files_quota = None
+
+        # Of that allocation for all of rms_data, this is set aside for log files
+        self.log_files_quota = None
+
+        # Of that allocation for all of rms_data, this is set aside for continuous capture
+        self.continuous_capture_quota = None
+
 
 
         # Extra space to leave on disk for the archive (in GB) after the captured files have been taken
@@ -999,6 +1006,12 @@ def parseCapture(config, parser):
 
     if parser.has_option(section, "bz2_files_quota"):
         config.bz2_files_quota = int(parser.get(section, "bz2_files_quota"))
+
+    if parser.has_option(section, "log_files_quota"):
+        config.log_files_quota = int(parser.get(section, "log_files_quota"))
+
+    if parser.has_option(section, "continuous_capture_quota"):
+        config.continuous_capture_quota = int(parser.get(section, "continuous_capture_quota"))
 
     if parser.has_option(section, "captured_dir"):
         config.captured_dir = parser.get(section, "captured_dir")

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -400,7 +400,6 @@ class Config:
         self.continuous_capture_quota = None
 
 
-
         # Extra space to leave on disk for the archive (in GB) after the captured files have been taken
         #   into account
         self.extra_space_gb = 6

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -226,6 +226,12 @@ def objectsToDeleteByTime(top_level_dir, directories_list, quota_gb=0):
     # Reverse sort by date
     # Iterate through the list adding up the sizes until the accumulator > quota
     # Then start appending the paths to the delete lists
+
+    accumulated_size = 0
+    accumulated_deletion_size = 0
+    objects_to_delete = []
+    logged_deletion_start_time = False
+
     if len(directories_list) == 0:
         log.warn("objectsToDelete by time passed an empty list of directories")
     elif len(directories_list) == 1:
@@ -246,10 +252,7 @@ def objectsToDeleteByTime(top_level_dir, directories_list, quota_gb=0):
             # combine the three lists into one list sorted by date, newest first
             file_date_path_size_list = list(reversed(sorted(list(zip(file_dates_list, file_paths_list, file_sizes_list)))))
 
-    accumulated_size = 0
-    accumulated_deletion_size = 0
-    objects_to_delete = []
-    logged_deletion_start_time = False
+
     for file_date_path_size in file_date_path_size_list:
         accumulated_size += file_date_path_size[2] / (1024 ** 3)
         if accumulated_size > quota_gb:
@@ -259,7 +262,7 @@ def objectsToDeleteByTime(top_level_dir, directories_list, quota_gb=0):
                 logged_deletion_start_time = True
             objects_to_delete.append(file_date_path_size[1])
         pass
-
+    log.info("Quota allowance is                {:7.03f}GB".format(quota_gb))
     log.info("Total size of files found is      {:7.03f}GB".format(accumulated_size))
 
     if logged_deletion_start_time:

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -186,6 +186,7 @@ def usedSpaceNoRecursion(obj_path):
         n += os.path.getsize(obj_path) / 1024 ** 3
 
     for root, directory_list, file_list in path_list:
+        time.sleep(0.01)
         for _ in directory_list:
             n += 4.024 / 1024 ** 2
         for file_name in file_list:
@@ -246,6 +247,8 @@ def objectsToDeleteByTime(top_level_dir, directories_list, quota_gb=0):
     for directory_path in directories_list:
         for root, directory_list, file_list in os.walk(os.path.join(top_level_dir, directory_path)):
             for file_name in file_list:
+                # sleep to allow other processes to run
+                time.sleep(0.01)
                 file_paths_list.append(os.path.join(root, file_name))
                 file_sizes_list.append(os.path.getsize(os.path.join(root, file_name)))
                 file_dates_list.append(os.path.getmtime(os.path.join(root, file_name)))
@@ -324,6 +327,7 @@ def rmList(delete_list, dummy_run=True):
     """
 
     for full_path in delete_list:
+        time.sleep(0.01)
         full_path = os.path.expanduser(full_path)
         try:
             if dummy_run:

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -337,6 +337,11 @@ def rmList(delete_list, dummy_run=True, log_deletions=True):
         elif files_to_delete_count > 1:
             log.info("Deleting {} files, anticipated time {:.0f} seconds".format(files_to_delete_count, files_to_delete_count / 500))
 
+    elif len(delete_list) > 100:
+        log.info("Deleting {} files, anticipated time {:.0f} seconds, files will not be logged individually"
+                            .format(files_to_delete_count, files_to_delete_count / 500))
+        log_deletions = False
+
     for full_path in delete_list:
         # sleep to allow other threads to run
         time.sleep(0.001)

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -69,28 +69,33 @@ def quotaReport(capt_dir_quota, config, after=False):
         rep += ("Directory quotas before management\n")
     rep += ("--------------------------------------------\n")
     rep += ("Space used                              \n")
-    rep += ("                       log files : {:7.02f}GB\n".format(usedSpace(log_dir)))
-    rep += ("                    frames files : {:7.02f}GB  \n".format(frames_files_used_space))
-    rep += ("                      time files : {:7.02f}GB  \n".format(time_files_used_space))
-    rep += ("                     video files : {:7.02f}GB  \n".format(video_files_used_space))
-    rep += ("    total for continuous capture : {:7.02f}GB\n".format(continuous_capture_used_space))
-
-    rep += ("            bz2 files space used : {:7.02f}GB  \n".format(sizeBz2Files(config)))
-    rep += (" archived directories space used : {:7.02f}GB  \n".format(sizeArchivedDirs(config)))
-    rep += ("              total for archives : {:7.02f}GB\n".format(usedSpace(archived_dir)))
-    rep += ("   captured directory space used : {:7.02f}GB\n".format(usedSpace(captured_dir)))
-    rep += ("   total space used for RMS_data : {:7.02f}GB\n".format(usedSpace(config.data_dir)))
     rep += "\n"
-    rep += ("Quotas allowed                          \n")
-    rep += ("                  bz2 file quota : {:7.02f}GB\n".format(config.bz2_files_quota))
-    rep += ("      archived directories quota : {:7.02f}GB\n".format(config.arch_dir_quota))
-    rep += ("                 log files quota : {:7.02f}GB\n".format(config.log_files_quota))
-    rep += ("        continuous capture quota : {:7.02f}GB\n".format(config.continuous_capture_quota))
-    rep += ("          remaining for captured : {:7.02f}GB\n".format(capt_dir_quota))
-    rep += ("        total quota for RMS_data : {:7.02f}GB\n".format(config.rms_data_quota))
+    rep += ("                          log files : {:7.02f}GB\n".format(usedSpace(log_dir)))
+    rep += ("                       frames files : {:7.02f}GB\n".format(frames_files_used_space))
+    rep += ("                         time files : {:7.02f}GB\n".format(time_files_used_space))
+    rep += ("                        video files : {:7.02f}GB\n".format(video_files_used_space))
+    rep += ("       total for continuous capture : {:7.02f}GB\n".format(continuous_capture_used_space))
+
+    rep += ("               bz2 files space used : {:7.02f}GB\n".format(sizeBz2Files(config)))
+    rep += ("    archived directories space used : {:7.02f}GB\n".format(sizeArchivedDirs(config)))
+    rep += ("                 total for archives : {:7.02f}GB\n".format(usedSpace(archived_dir)))
+
+    rep += ("      captured directory space used : {:7.02f}GB\n".format(usedSpace(captured_dir)))
+    rep += ("      total space used for RMS_data : {:7.02f}GB\n".format(usedSpace(config.data_dir)))
+
+    rep += "\n"
+    rep += ("Quotas allowed                                  \n")
+
+    rep += ("           total quota for RMS_data : {:7.02f}GB\n".format(config.rms_data_quota))
+    rep += ("                     bz2 file quota : {:7.02f}GB\n".format(config.bz2_files_quota))
+    rep += ("         archived directories quota : {:7.02f}GB\n".format(config.arch_dir_quota))
+    rep += ("                    log files quota : {:7.02f}GB\n".format(config.log_files_quota))
+    rep += ("           continuous capture quota : {:7.02f}GB\n".format(config.continuous_capture_quota))
+    rep += (" quota remaining for captured files : {:7.02f}GB\n".format(capt_dir_quota))
+
     rep += "\n"
     rep += ("Space on drive                          \n")
-    rep += ("        Available space on drive : {:7.02f}GB\n".format(availableSpace(config.data_dir) / (1024 ** 3)))
+    rep += ("           Available space on drive : {:7.02f}GB\n".format(availableSpace(config.data_dir) / (1024 ** 3)))
     rep += ("--------------------------------------------\n")
 
     return rep

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -933,6 +933,7 @@ def deleteByQuota(archived_dir, capt_dir_quota, captured_dir, config):
         None
     """
 
+    log.info("Starting quota based disc space management...")
     log.info(quotaReport(capt_dir_quota, config, after=False))
 
     delete_list = objectsToDelete(captured_dir, config.stationID, capt_dir_quota, bz2=False)

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -950,7 +950,7 @@ def deleteByQuota(archived_dir, capt_dir_quota, captured_dir, config):
     delete_list = objectsToDeleteByTime(config.data_dir,
                                         [config.frame_dir, config.times_dir, config.video_dir],
                                         config.continuous_capture_quota)
-    rmList(delete_list, dummy_run=not config.quota_management_enabled, log_deletions=False)
+    rmList(delete_list, dummy_run=not config.quota_management_enabled)
 
 
 

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -186,7 +186,7 @@ def usedSpaceNoRecursion(obj_path):
         n += os.path.getsize(obj_path) / 1024 ** 3
 
     for root, directory_list, file_list in path_list:
-        time.sleep(0.01)
+        time.sleep(0.001)
         for _ in directory_list:
             n += 4.024 / 1024 ** 2
         for file_name in file_list:

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -328,8 +328,13 @@ def rmList(delete_list, dummy_run=True, log_deletions=True):
         None
     """
 
+    if delete_list is None:
+        log.warn("rmList passed a list of None")
+        return
+
+    files_to_delete_count = len(delete_list)
     if not log_deletions:
-        files_to_delete_count = len(delete_list)
+
         if files_to_delete_count < 1:
             log.info("Nothing to delete")
         elif files_to_delete_count == 1:

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -939,27 +939,34 @@ def deleteByQuota(archived_dir, capt_dir_quota, captured_dir, config):
     """
 
     log.info("Starting quota based disc space management...")
+
+    # Log the actual use and quotas before the start of the work
     log.info(quotaReport(capt_dir_quota, config, after=False))
 
+    # Manage size of the captured directory
     delete_list = objectsToDelete(captured_dir, config.stationID, capt_dir_quota, bz2=False)
     rmList(delete_list, dummy_run= not config.quota_management_enabled)
 
+    # Manage the size of the archived directory
     delete_list = objectsToDelete(archived_dir, config.stationID, config.arch_dir_quota, bz2=False)
     rmList(delete_list, dummy_run= not config.quota_management_enabled)
 
+    # Manage the size of the bz2 files
     delete_list = objectsToDelete(archived_dir, config.stationID, config.bz2_files_quota, bz2=True)
     rmList(delete_list, dummy_run= not config.quota_management_enabled)
 
+    # Manage the size of the log files
     delete_list = objectsToDeleteByTime(config.data_dir, [config.log_dir], config.log_files_quota)
     rmList(delete_list, dummy_run=not config.quota_management_enabled)
 
+    # Manage the size of the continuous capture directories
     delete_list = objectsToDeleteByTime(config.data_dir,
                                         [config.frame_dir, config.times_dir, config.video_dir],
                                         config.continuous_capture_quota)
     rmList(delete_list, dummy_run=not config.quota_management_enabled)
 
 
-
+    # Log the actual use and the quotas after the work
     log.info(quotaReport(capt_dir_quota, config, after=True))
 
 

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -226,7 +226,7 @@ def objectsToDeleteByTime(top_level_dir, directories_list, quota_gb=0):
     # Make three lists and zip together into file dates, file paths, file sizes in GB
     # Reverse sort by date
     # Iterate through the list adding up the sizes until the accumulator > quota
-    # Then start appending the paths to the delete lists
+    # Then start appending the paths to the delete list
 
     accumulated_size = 0
     accumulated_deletion_size = 0
@@ -340,7 +340,7 @@ def rmList(delete_list, dummy_run=True, log_deletions=True):
         elif files_to_delete_count == 1:
             log.info("Deleting {} file".format(files_to_delete_count))
         elif files_to_delete_count > 1:
-            log.info("Deleting {} files, anticipated time {:.0f} seconds".format(files_to_delete_count, files_to_delete_count / 500))
+            log.info("Deleting {} files, anticipated time {:.0f} seconds".format(files_to_delete_count, files_to_delete_count / 100))
 
     elif len(delete_list) > 100:
         log.info("Deleting {} files, anticipated time {:.0f} seconds, files will not be logged individually"
@@ -1113,7 +1113,7 @@ if __name__ == '__main__':
     arg_parser.add_argument('-c', '--config', nargs=1, metavar='CONFIG_PATH', type=str, help="Path to a config file")
     cml_args = arg_parser.parse_args()
 
-    print("Disc use routine checks -these should all produce similar results")
+    print("Disc use routine checks - these should all produce similar results")
     print("Used space no recursion   {:.5f}GB".format(usedSpaceNoRecursion("~/source/RMS")))
     print("Used space with recursion {:.5f}GB".format(usedSpaceRecursive("~/source/RMS")))
     print("Used space from OS        {:.5f}GB".format(usedSpaceFromOS("~/source/RMS")))


### PR DESCRIPTION
This PR is in response to issue #541.

It adds the continuous capture directories into the space quota management system. This is required because the CapturedFiles directory needs to be made smaller to account for the space taken by the continuous capture directories.

It also addresses a new issue. DeleteOldObservations is now being called when capture is in progress. time.sleep calls have been added to prevent dropped frames. 

All files across the three continuous capture directories sorted in time order, newest at the top of the list. An accumulator iterates over the list of files until the size of files matches the quota. The remaining files on the list are deleted. 

```
2025/04/04 13:54:53-INFO-DeleteOldObservations-line:941 - Starting quota based disc space management...
2025/04/04 13:55:07-INFO-DeleteOldObservations-line:942 - 

-----------------------------------------------
Directory quotas before management
-----------------------------------------------
Space used                              

                          log files :    0.00GB
                       frames files :    4.04GB
                         time files :    0.09GB
                        video files :   15.41GB
       total for continuous capture :   19.54GB
                          bz2 files :    3.66GB
               archived directories :    7.23GB
                 total for archives :   10.90GB
               captured directories :  144.74GB
                 total for RMS_data :  175.17GB

Quotas allowed                                  
           total quota for RMS_data :  550.00GB
                     bz2 file quota :   30.00GB
         archived directories quota :   30.00GB
                    log files quota :    1.00GB
           continuous capture quota :   18.00GB
 quota remaining for captured files :  471.00GB

Space on drive                          
           Available space on drive : 1144.36GB
-----------------------------------------------

2025/04/04 13:55:08-INFO-DeleteOldObservations-line:239 - Managing directory logs
2025/04/04 13:55:08-INFO-DeleteOldObservations-line:248 - Working on directory logs
2025/04/04 13:55:08-INFO-DeleteOldObservations-line:269 - Quota allowance is                  1.000GB
2025/04/04 13:55:08-INFO-DeleteOldObservations-line:270 - Total size of files found is        0.001GB
2025/04/04 13:55:08-INFO-DeleteOldObservations-line:276 - Within quota, not required to delete any files.
2025/04/04 13:55:09-INFO-DeleteOldObservations-line:241 - Managing directories:
2025/04/04 13:55:09-INFO-DeleteOldObservations-line:243 -     FramesFiles
2025/04/04 13:55:09-INFO-DeleteOldObservations-line:243 -     TimeFiles
2025/04/04 13:55:09-INFO-DeleteOldObservations-line:243 -     VideoFiles
2025/04/04 13:55:09-INFO-DeleteOldObservations-line:248 - Working on directory FramesFiles
2025/04/04 13:55:23-INFO-DeleteOldObservations-line:248 - Working on directory TimeFiles
2025/04/04 13:55:27-INFO-DeleteOldObservations-line:248 - Working on directory VideoFiles
2025/04/04 13:55:40-INFO-DeleteOldObservations-line:265 - Deleting files before 20250331_113826
2025/04/04 13:55:40-INFO-DeleteOldObservations-line:269 - Quota allowance is                 18.000GB
2025/04/04 13:55:40-INFO-DeleteOldObservations-line:270 - Total size of files found is       19.537GB
2025/04/04 13:55:40-INFO-DeleteOldObservations-line:273 - Total size of files to delete is    1.540GB
2025/04/04 13:55:40-INFO-DeleteOldObservations-line:274 - Size after management will be      17.997GB
2025/04/04 13:55:40-INFO-DeleteOldObservations-line:346 - Deleting 1462 files, anticipated time 3 seconds, files will not be logged individually
2025/04/04 13:56:01-INFO-DeleteOldObservations-line:963 - 

-----------------------------------------------
Directory quotas after management
-----------------------------------------------
Space used                              

                          log files :    0.00GB
                       frames files :    3.34GB
                         time files :    0.09GB
                        video files :   14.57GB
       total for continuous capture :   18.00GB
                          bz2 files :    3.66GB
               archived directories :    7.23GB
                 total for archives :   10.90GB
               captured directories :  144.75GB
                 total for RMS_data :  173.65GB

Quotas allowed                                  
           total quota for RMS_data :  550.00GB
                     bz2 file quota :   30.00GB
         archived directories quota :   30.00GB
                    log files quota :    1.00GB
           continuous capture quota :   18.00GB
 quota remaining for captured files :  471.00GB

Space on drive                          
           Available space on drive : 1145.73GB
-----------------------------------------------

2025/04/04 13:56:01-INFO-DeleteOldObservations-line:795 - Need 43.07 GB for next night

```






