### PR TITLE
Experimental configurable SFTP parameters branch

### DIFF
--- a/.config
+++ b/.config
@@ -369,6 +369,24 @@ hostname: gmn.uwo.ca
 ; Standard SSH port
 host_port: 22
 
+; === SFTP Performance Parameters ===
+; These control how aggressively files are transferred
+
+; Window size (bytes in flight before requiring acknowledgment)
+; Default: 2147483648 (2GB) - good for stable connections
+; For ADSL/unstable connections: 32768 (32KB)
+window_size: 2147483648
+
+; Number of bytes to transfer before rekeying the connection
+; Default: 1073741824 (1GB) - good for stable connections
+; For ADSL/unstable connections: 10485760 (10MB)
+rekey_bytes: 1073741824
+
+; Block size for file transfers (bytes)
+; Default: 32768 (32KB) - good for stable connections
+; For ADSL/unstable connections: 8192 (8KB)
+block_size: 32768
+
 ; Path to the SSH private key
 rsa_private_key: ~/.ssh/id_rsa
 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -478,6 +478,19 @@ class Config:
         # SSH port
         self.host_port = 22
 
+        # SFTP performance parameters
+        # Default Paramiko window size (2GB) - good for decent connections
+        self.window_size = 2147483648  # 2^31 = 2GB
+
+        # Default Paramiko max packet size
+        self.max_packet_size = 32768  # 32KB
+
+        # Default Paramiko rekey bytes (1GB)
+        self.rekey_bytes = 1073741824  # 1GB
+
+        # Default block size for SFTP transfers
+        self.block_size = 32768  # 32KB
+
         # Location of the SSH private key
         self.rsa_private_key = os.path.expanduser("~/.ssh/id_rsa")
 
@@ -1302,6 +1315,22 @@ def parseUpload(config, parser):
     # SSH port
     if parser.has_option(section, "host_port"):
         config.host_port = parser.getint(section, "host_port")
+
+    # SFTP window size - controls data in-flight before requiring ACK
+    if parser.has_option(section, "window_size"):
+        config.window_size = parser.getint(section, "window_size")
+        
+    # SFTP max packet size
+    if parser.has_option(section, "max_packet_size"):
+        config.max_packet_size = parser.getint(section, "max_packet_size")
+        
+    # SFTP rekey bytes - how much data before rekeying
+    if parser.has_option(section, "rekey_bytes"):
+        config.rekey_bytes = parser.getint(section, "rekey_bytes")
+        
+    # SFTP block size - chunk size for file transfers
+    if parser.has_option(section, "block_size"):
+        config.block_size = parser.getint(section, "block_size")
 
     # Location of the SSH private key
     if parser.has_option(section, "rsa_private_key"):

--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -1798,10 +1798,19 @@ class EventMonitor(multiprocessing.Process):
 
 
 
-                upload_status = uploadSFTP(self.syscon.hostname, self.syscon.stationID.lower(),
-                                 event_monitor_directory,self.syscon.event_monitor_remote_dir,archives,
-                                 rsa_private_key=self.config.rsa_private_key, allow_dir_creation=True, 
-                                 port=self.config.host_port)
+                upload_status = uploadSFTP(self.syscon.hostname,
+                                           self.syscon.stationID.lower(),
+                                           event_monitor_directory,
+                                           self.syscon.event_monitor_remote_dir,
+                                           archives,
+                                           rsa_private_key=self.config.rsa_private_key,
+                                           allow_dir_creation=True, 
+                                           port=self.config.host_port,
+                                           window_size=self.config.window_size,
+                                           max_packet_size=self.config.max_packet_size,
+                                           rekey_bytes=self.config.rekey_bytes,
+                                           block_size=self.config.block_size
+                                           )
 
 
                 if upload_status:


### PR DESCRIPTION
@g7gpr, this is in regards to issue #546. I've implemented the SFTP throttling adjustments for fragile connections as discussed. 

I haven't tested this implementation at all, so please feel free to adjust the code and experiment with the parameters to find what works best for your connection. 

The key parameters you can adjust are:
- window_size: Controls how much data can be in-flight (default 2GB,  maybe try 32KB)
- rekey_bytes: Controls how often the connection rekeys (default 1GB, ,  maybe try 10MB)
- block_size: Controls transfer chunk size (default 32KB, ,  maybe try 8KB)

I'm curious if it will make a difference.