### PR TITLE
Fix syntax in converted print to log entries

### DIFF
--- a/Utils/GenerateTimelapse.py
+++ b/Utils/GenerateTimelapse.py
@@ -71,7 +71,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
         rmtreeWithLogging(dir_tmp_path)
 		
     mkdirP(dir_tmp_path)
-    log.info("Created directory : " + dir_tmp_path)
+    log.info("Created directory : {}".format(dir_tmp_path))
     
     log.info("Preparing files for the timelapse...")
     c = 0
@@ -120,7 +120,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
 
         # Print elapsed time
         if c % 30 == 0:
-            print("{:>5d}/{:>5d}, Elapsed: {:s}".format(c + 1, len(ff_list), \
+            print("{:>5d}/{:>5d}, Elapsed: {:s}".format(c, len(ff_list), \
                 str(RmsDateTime.utcnow() - t1)), end="\r")
             sys.stdout.flush()
 
@@ -145,7 +145,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
             + " -movflags faststart -threads 2 -g 15 -vf \"hqdn3d=4:3:6:4.5,lutyuv=y=gammaval(0.77)\" " \
             + mp4_path
 
-        log.info("Creating timelapse using {:s}...".format(software_name))
+        log.info("Creating timelapse using {}...".format(software_name))
         log.info(com)
         subprocess.call([com], shell=True)
 
@@ -175,7 +175,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
     if os.path.exists(dir_tmp_path) and not keep_images:
         rmtreeWithLogging(dir_tmp_path)
 		
-    log.info("Total time:", RmsDateTime.utcnow() - t1)
+    log.info("Total time: {}".format(RmsDateTime.utcnow() - t1))
 
 
 def rmtreeWithLogging(directory_path):


### PR DESCRIPTION
Fix syntax issue introduced when some 'print' were recently converted to 'log.info'.