### PR TITLE
Fix early returns and pass calstars_data to _handleFailure

### DIFF
--- a/RMS/Astrometry/ApplyRecalibrate.py
+++ b/RMS/Astrometry/ApplyRecalibrate.py
@@ -689,7 +689,7 @@ def recalibrateIndividualFFsAndApplyAstrometry(
 
     if not calstars_ffs:
         log.warning("No FF entries in CALSTARS - skipping recalibration")
-        return {}
+        return {}, []
 
     # Create a dictionary mapping FF file names in CALSTARS to datetime objects
     calstars_datetime_dict = OrderedDict()
@@ -720,7 +720,7 @@ def recalibrateIndividualFFsAndApplyAstrometry(
     if not star_catalog_status:
         log.info("Could not load the star catalog!")
         log.info(os.path.join(config.star_catalog_path, config.star_catalog_file))
-        return {}
+        return {}, []
 
     catalog_stars, _, config.star_catalog_band_ratios = star_catalog_status
 
@@ -756,7 +756,7 @@ def recalibrateIndividualFFsAndApplyAstrometry(
             log.info('ERROR! The FTPdetectinfo file does not exist: {:s}'.format(ftpdetectinfo_path))
             log.info('    The recalibration on every file was not done!')
 
-            return {}
+            return {}, []
 
         # If it exists, use it as the only file to load
         ftpdetectinfo_file_list = [os.path.basename(ftpdetectinfo_path)]

--- a/RMS/Astrometry/CheckFit.py
+++ b/RMS/Astrometry/CheckFit.py
@@ -545,7 +545,7 @@ def autoCheckFit(config, platepar, calstars_data, _fft_refinement=False):
     if not star_catalog_status:
         log.info("Could not load the star catalog!")
         log.info(os.path.join(config.star_catalog_path, config.star_catalog_file))
-        return {}
+        return platepar, False
 
     catalog_stars, _, config.star_catalog_band_ratios = star_catalog_status
 
@@ -615,7 +615,7 @@ def autoCheckFit(config, platepar, calstars_data, _fft_refinement=False):
             log.info("The total number of initially matched stars is too small! Please manually redo the plate or make sure there are enough calibration stars.")
 
             # Try to refine the platepar with FFT phase correlation and redo the ACF
-            return _handleFailure(config, platepar, calstars_list, catalog_stars, _fft_refinement)
+            return _handleFailure(config, platepar, calstars_data, catalog_stars, _fft_refinement)
 
 
         # Check if the platepar is good enough and do not estimate further parameters
@@ -642,7 +642,7 @@ def autoCheckFit(config, platepar, calstars_data, _fft_refinement=False):
         if not res.success:
 
             # Try to refine the platepar with FFT phase correlation and redo the ACF
-            return _handleFailure(config, platepar, calstars_list, catalog_stars, _fft_refinement)
+            return _handleFailure(config, platepar, calstars_data, catalog_stars, _fft_refinement)
 
 
         else:


### PR DESCRIPTION
Fix early returns in recalibrateIndividualFFsAndApplyAstrometry and in _handleFailure.
Pass calstars_data instead of calstars_list to _handleFailure.