### PR TITLE
Reboot camera and check connection after mode switching

### DIFF
--- a/camera_settings.json
+++ b/camera_settings.json
@@ -11,6 +11,8 @@
     ["SetParam", "Encode", "Video", "Compression", "H.264"],
     ["SetParam", "Encode", "Video", "Resolution", "720P"],
     ["SetParam", "Encode", "Video", "BitRateControl", "VBR"],
+    ["SetParam", "Encode", "Video", "BitRate", "4096"],
+    ["SetParam", "Encode", "Video", "GOP", "2"],
     ["SetParam", "Encode", "Video", "FPS", "25"],
     ["SetParam", "Encode", "Video", "Quality", "6"],
     ["SetParam", "Encode", "AudioEnable", "0"],
@@ -18,7 +20,7 @@
     ["SetParam", "Encode", "SecondStream", "0"],
 
     ["SetParam", "Camera", "ClearFog", "enable", "0"],
-    ["SetParam", "Camera", "ClearFog", "level", "50"],
+    ["SetParam", "Camera", "ClearFog", "level", "30"],
     ["SetParam", "Camera", "Style", "type1"],
     ["SetParam", "Camera", "AeSensitivity", "1"],
     ["SetParam", "Camera", "ApertureMode", "0"],
@@ -47,18 +49,19 @@
   "day": [
     ["CameraTime", "set"],
     ["SetParam", "Camera", "DayNightColor", "1"],
-    ["SetParam", "Camera", "BLCMode", "1"],
     ["SetParam", "Camera", "ElecLevel", "50"],
     ["SetParam", "Camera", "BroadTrends", "AutoGain", "1"],
+    ["SetParam", "Camera", "ClearFog", "enable", "1"],
+    ["SetParam", "Camera", "ClearFog", "level", "30"],
     ["reboot"]
   ],
 
   "night": [
     ["CameraTime", "set"],
     ["SetParam", "Camera", "DayNightColor", "2"],
-    ["SetParam", "Camera", "BLCMode", "0"],
     ["SetParam", "Camera", "ElecLevel", "60"],
     ["SetParam", "Camera", "BroadTrends", "AutoGain", "0"],
+    ["SetParam", "Camera", "ClearFog", "enable", "0"],
     ["reboot"]
   ]
 }

--- a/camera_settings.json
+++ b/camera_settings.json
@@ -49,7 +49,8 @@
     ["SetParam", "Camera", "DayNightColor", "1"],
     ["SetParam", "Camera", "BLCMode", "1"],
     ["SetParam", "Camera", "ElecLevel", "50"],
-    ["SetParam", "Camera", "BroadTrends", "AutoGain", "1"]
+    ["SetParam", "Camera", "BroadTrends", "AutoGain", "1"],
+    ["reboot"]
   ],
 
   "night": [
@@ -57,6 +58,7 @@
     ["SetParam", "Camera", "DayNightColor", "2"],
     ["SetParam", "Camera", "BLCMode", "0"],
     ["SetParam", "Camera", "ElecLevel", "60"],
-    ["SetParam", "Camera", "BroadTrends", "AutoGain", "0"]
+    ["SetParam", "Camera", "BroadTrends", "AutoGain", "0"],
+    ["reboot"]
   ]
 }


### PR DESCRIPTION
Camera image settings become inconsistent after DayNightColor mode changes. Specifically, when switching from night to day mode, images exhibit poor quality (crushed shadows without increased highlight details) until the camera is rebooted. Image quality is restored only after a camera reboot.

This PR implements a camera reboot after mode switching and adds connection verification to ensure proper camera operation.

The revised process flow is as follows:
1. Set camera mode switching flag when capture mode changes.
2. Probe camera connection to verify availability.
3. Apply camera mode switching commands, now including an automatic reboot via camera_settings.json.
4. Wait 5 seconds for the camera to register all commands (NEW).
5. Verify camera connection re-establishment (NEW).
6. Proceed with normal capture operations.

Note that existing prerelease testers would have to manually edit their custom `camera_settings.json` to add a reboot command. This PR only changes the `camera_settings_template.json`.

I would still recommend leaving the auto reboot as is (daily reboot) as a bricked camera may be unreachable until it auto-reboots.