### PR TITLE
Change ClearFog parameter to boolean instead of string type

### DIFF
--- a/Utils/CameraControl.py
+++ b/Utils/CameraControl.py
@@ -458,10 +458,7 @@ def setCameraParam(cam, opts):
         subfld = opts[2].lower()
         val = int(opts[3])
         if subfld == 'enable':
-            if val == 1:
-                val = 'true'
-            else:
-                val = 'false'
+            val = True if val == 1 else False
 
         elif subfld == 'level':
             val = int(val)


### PR DESCRIPTION
ClearFog camera setting is not working as it incorrectly set the field value to a 'true', 'false' string. This PR assigns the field a boolean value.