### PR TITLE
Add timeout to device.emit

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -502,8 +502,8 @@ class BufferedCapture(Process):
             # GStreamer
             if GST_IMPORTED and (self.config.media_backend == 'gst') and (not self.media_backend_override):
 
-                # Pull a frame from the GStreamer pipeline
-                sample = self.device.emit("pull-sample")
+                # Pull a frame from the GStreamer pipeline with a .5 sec timeout
+                sample = self.device.emit("try-pull-sample", 500 * Gst.MSECOND)
                 if not sample:
                     log.info("GStreamer pipeline did not emit a sample.")
                     return False, None, None


### PR DESCRIPTION
On occasion, the GStreamer pipeline can hang indefinitely. This tends to happen when multiple concurrent streams are requested. The IMX291 seems to handle up to three concurrent streams per profile. Some IMX307s will hang the pipeline indefinitely when more than one stream is requested (Show LiveStream during capture). 
This PR requests the pipeline to emit frames with a timeout.
