### PR TITLE
Rawpy install error on Pi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ if 'win' in sys.platform and "darwin" not in sys.platform:
 else:
 
     # Check if running on the Pi
-    if 'arm' in os.uname()[4]:
+    if any(arch in os.uname()[4].lower() for arch in ['arm', 'aarch']):
         print("Not installing rawpy because it is not available on the Pi...")
 
     else:


### PR DESCRIPTION
RMS is trying to install rawpy on Raspberry Pi that reports the architecture as 'aarch64' rather than just containing 'arm'. This causes an error as rawpy is not available on Pi. This PR prevents attempting to install rawpy on those systems.