### PR TITLE
MigrateConfig: recognize config section header even with inline comments

### DIFF
--- a/Utils/MigrateConfig.py
+++ b/Utils/MigrateConfig.py
@@ -115,8 +115,10 @@ def updateConfig(original_config_file, template_config_file, args, backup=True):
             continue
 
         # save current section
-        if l[0] == "[" and l[-1] == "]":
-            section = l
+        m = re.match(r'\s*(\[[^\]]+\])', l)
+        if m:
+            # keep only the bracketed section name (e.g. "[System]")
+            section = m.group(1)
             continue
 
         bits = re.split(": ", l)
@@ -180,8 +182,9 @@ def updateConfig(original_config_file, template_config_file, args, backup=True):
                 continue
 
             # save current section
-            if l[0] == "[" and l[-1] == "]":
-                section = l
+            m = re.match(r'\s*(\[[^\]]+\])', l)
+            if m:
+                section = m.group(1)
 
             if l[:1] == ";":  # comment
                 newfile.write("{}\n".format(l))

--- a/Utils/MigrateConfig.py
+++ b/Utils/MigrateConfig.py
@@ -88,7 +88,14 @@ def updateConfig(original_config_file, template_config_file, args, backup=True):
         sys.exit(1)
 
     if not os.path.exists(template_config_file):
-        logMessage("ERROR: Can't find template file {}".format(template_config_file))
+        logMessage(
+                "ERROR: Can't find template file {}\n"
+            "       No '.configTemplate' detected. Either:\n"
+            "       - run ./Scripts/RMS_Update.sh to create/update it, or\n"
+            "       - pass the template path explicitly with -t\n"
+            "         e.g.  python -m Utils.MigrateConfig -t /path/to/.configTemplate"
+            .format(template_config_file)
+        )
         sys.exit(1)
 
     logMessage("\nInput: {}".format(original_config_file))

--- a/Utils/MigrateConfig.py
+++ b/Utils/MigrateConfig.py
@@ -192,6 +192,7 @@ def updateConfig(original_config_file, template_config_file, args, backup=True):
             m = re.match(r'\s*(\[[^\]]+\])', l)
             if m:
                 section = m.group(1)
+                continue
 
             if l[:1] == ";":  # comment
                 newfile.write("{}\n".format(l))

--- a/Utils/MigrateConfig.py
+++ b/Utils/MigrateConfig.py
@@ -223,15 +223,15 @@ def updateConfig(original_config_file, template_config_file, args, backup=True):
                             "{}: {}\n".format(bits[0],original_value)
                         )  # write original attribute/value pair
                         logMessage(
-                            "  {}{}: {} carried forward over => {}"
-                                    .format(section,bits[0],original_value,new_default_value)
+                            "  {}{}: template default '{}' => kept '{}'"
+                                    .format(section, bits[0], new_default_value, original_value)
                         )
                         custom_cnt += 1
                         continue
 
                     logMessage(
-                        "  {}{}: {} RECENT template default applied => {}"
-                                .format(section,bits[0],original_value,new_default_value)
+                        "  {}{}: '{}' => RECENT template default '{}'"
+                                .format(section, bits[0], original_value, new_default_value)
                     )
 
             # if we don't need to update the template line write it out as is


### PR DESCRIPTION
Address issue #595, #596, #597 and #598.
Sections headers are recognized even if followed by inline comments.
Log messages are hopefully less confusing. E.g.:
```
Merging attributes...
  [System]stationID: template default 'XX0001' => kept 'US005B'
```

When no valid configTemplate is found, print the following error message:
```
ERROR: Can't find template file /home/ops/source/RMS/.configTemplate
       No '.configTemplate' detected. Either:
       - run ./Scripts/RMS_Update.sh to create/update it, or
       - pass the template path explicitly with -t
         e.g.  python -m Utils.MigrateConfig -t /path/to/.configTemplate
```