### PR TITLE
first_frame_timestamp can be referenced without first being created

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1696,6 +1696,7 @@ class BufferedCapture(Process):
             t_block = time.time()
             max_frame_interval_normalized = 0.0
             max_frame_age_seconds = 0.0
+            first_frame_timestamp = None
 
             # running totals for mean calculations
             sum_frame_interval_norm = 0.0
@@ -1980,7 +1981,9 @@ class BufferedCapture(Process):
                 break
 
 
-            if (not wait_for_reconnect) and (not self.daytime_mode.value):
+            if (not wait_for_reconnect
+                and not self.daytime_mode.value
+                and first_frame_timestamp is not None):
 
                 # Set the starting value of the frame block, which indicates to the compression that the
                 # block is ready for processing
@@ -2002,7 +2005,7 @@ class BufferedCapture(Process):
 
             # Save current timestamp buffer to ft file
             # Construct FTStruct, record timestamps, and reset the timestamp array in memory
-            if self.config.save_frame_times:
+            if (self.config.save_frame_times and first_frame_timestamp is not None):
                 ft = FTStruct.FTStruct()
                 ft.timestamps = copy.copy(self.timestamp_buffer)
 


### PR DESCRIPTION
If a camera disconnects after the main loop is entered but before the first frame is read, `first_frame_timestamp` is never created, yet the code that writes the FT file still runs and references it.

This PR guards against unset first_frame_timestamp.