### PR TITLE
Fix upload manager hang

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -367,7 +367,8 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
 
     # Initialize buffered capture
     bc = BufferedCapture(sharedArray, startTime, sharedArray2, start_time2, config, video_file=video_file,
-                         night_data_dir=night_data_dir, saved_frames_dir=saved_frames_dir, daytime_mode=daytime_mode, camera_mode_switch_trigger=camera_mode_switch_trigger)
+                         night_data_dir=night_data_dir, saved_frames_dir=saved_frames_dir, 
+                         daytime_mode=daytime_mode, camera_mode_switch_trigger=camera_mode_switch_trigger)
     bc.startCapture()
 
     # To track and make new directories every iteration
@@ -682,7 +683,7 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
                 log.info("File added.")
 
                 # optional delay (minutes in .config, converted to seconds)
-                upload_manager.delayNextUpload(delay=60 * config.upload_delay)
+                upload_manager.delayNextUpload(delay=60*config.upload_delay)
 
             # Delete detector backup files
             if detector is not None:

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -504,7 +504,6 @@ class UploadManager(multiprocessing.Process):
         self.upload_queue_file_path = os.path.join(self.config.data_dir, self.config.upload_queue_file)
 
         # Load the list of files to upload, and have not yet been uploaded
-        print("Loading upload queue from file: {:s}".format(self.upload_queue_file_path))
         self.loadQueue()
 
 
@@ -689,15 +688,12 @@ class UploadManager(multiprocessing.Process):
         self.upload_in_progress.value = True
 
         # Read the file list from disk
-        print("Loading upload queue from file: {:s}".format(self.upload_queue_file_path))
         self.loadQueue()
 
         tries = 0
 
         # Go through every file and upload it to server
         while True:
-
-            print("Trying to upload file, attempt {:d} of {:d}".format(tries + 1, retries))
 
             # Get a file from the queue
             with self.file_queue_lock:
@@ -784,7 +780,6 @@ class UploadManager(multiprocessing.Process):
                 self.last_runtime = RmsDateTime.utcnow()
 
             # Run the upload procedure
-            print("Running upload procedure at {:s}".format(str(self.last_runtime)))
             self.uploadData()
 
             time.sleep(0.1)

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -535,10 +535,12 @@ class UploadManager(multiprocessing.Process):
 
     def addFiles(self, file_list):
         """ Adds a list of files to be uploaded to the queue. """
+        
+        # Load the existing items in the queue (can't be under lock, as it would block the queue)
+        existing_items = set(self.getFileList())
 
         # Add new files to the queue
         with self.file_queue_lock:
-            existing_items = set(self.getFileList())
 
             new_files = [f for f in file_list if f not in existing_items]
 
@@ -591,10 +593,11 @@ class UploadManager(multiprocessing.Process):
             return None
 
 
-        # Read the queue file
+        # Load the existing items in the queue (can't be under lock, as it would block the queue)
+        existing_items = set(self.getFileList())
 
+        # Read the queue file
         with self.file_queue_lock:
-            existing_items = self.getFileList()
 
             with open(self.upload_queue_file_path) as f:
                 

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -558,6 +558,7 @@ class UploadManager(multiprocessing.Process):
 
     def getFileList(self):
         """ Safely get a snapshot of all items in the queue, preserving order, with thread/process lock. """
+
         items = []
 
         with self.file_queue_lock:
@@ -684,6 +685,7 @@ class UploadManager(multiprocessing.Process):
         self.upload_in_progress.value = True
 
         # Read the file list from disk
+        print("Loading upload queue from file: {:s}".format(self.upload_queue_file_path))
         self.loadQueue()
 
         tries = 0
@@ -691,7 +693,7 @@ class UploadManager(multiprocessing.Process):
         # Go through every file and upload it to server
         while True:
 
-            print("Trying to upload files...")
+            print("Trying to upload file, attempt {:d} of {:d}".format(tries + 1, retries))
 
             # Get a file from the queue
             with self.file_queue_lock:
@@ -778,6 +780,7 @@ class UploadManager(multiprocessing.Process):
                 self.last_runtime = RmsDateTime.utcnow()
 
             # Run the upload procedure
+            print("Running upload procedure at {:s}".format(str(self.last_runtime)))
             self.uploadData()
 
             time.sleep(0.1)

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -751,6 +751,9 @@ class UploadManager(multiprocessing.Process):
             if delay > 0:
                 # Log the delay
                 log.info("Upload delayed for {:.1f} min until {:s}".format(delay/60, str(self.next_runtime)))
+            else:
+                # Log that the upload will run immediately
+                log.info("Upload will run immediately at {:s}".format(str(self.next_runtime)))
 
 
 

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -504,6 +504,7 @@ class UploadManager(multiprocessing.Process):
         self.upload_queue_file_path = os.path.join(self.config.data_dir, self.config.upload_queue_file)
 
         # Load the list of files to upload, and have not yet been uploaded
+        print("Loading upload queue from file: {:s}".format(self.upload_queue_file_path))
         self.loadQueue()
 
 

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -17,14 +17,7 @@ import paramiko
 logging.getLogger("paramiko.transport").setLevel(logging.CRITICAL)
 logging.getLogger("paramiko.auth_handler").setLevel(logging.CRITICAL)
 
-try:
-    # Python 2
-    import Queue
-
-except:
-    # Python 3
-    import queue as Queue
-
+from multiprocessing import Queue
 
 
 from RMS.Misc import mkdirP, RmsDateTime

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -751,11 +751,6 @@ class UploadManager(multiprocessing.Process):
     def run(self):
         """ Try uploading the files every 15 minutes. """
 
-        # Initialize the logger inside the process
-        # This is necessary to avoid issues with logging in multiprocessing
-        from RMS.Logger import initLogging
-        initLogging(self.config)
-
         with self.last_runtime_lock:
             self.last_runtime = None
 

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -748,7 +748,9 @@ class UploadManager(multiprocessing.Process):
         with self.next_runtime_lock:
             self.next_runtime = RmsDateTime.utcnow() + datetime.timedelta(seconds=delay)
 
-            log.info("Upload delayed for {:.1f} min until {:s}".format(delay/60, str(self.next_runtime)))
+            if delay > 0:
+                # Log the delay
+                log.info("Upload delayed for {:.1f} min until {:s}".format(delay/60, str(self.next_runtime)))
 
 
 

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -691,6 +691,8 @@ class UploadManager(multiprocessing.Process):
         # Go through every file and upload it to server
         while True:
 
+            print("Trying to upload files...")
+
             # Get a file from the queue
             with self.file_queue_lock:
                 try:

--- a/Utils/CameraControl27.py
+++ b/Utils/CameraControl27.py
@@ -114,7 +114,7 @@ class DVRIPCam(object):
 
         # Skip printing keep-alive packets
         if "KeepAlive" not in data:
-            
+
             # Log the packet being received
             self.logger.debug("<= %s", data)
 
@@ -150,7 +150,7 @@ class DVRIPCam(object):
         if msg != 1006:
 
             # Log the packet being sent
-            self.logger.debug("=> %s", pkt)
+            self.logger.debug("=> %s", data)
 
 
         self.socket_send(pkt)


### PR DESCRIPTION
UploadManager would hang at the end in Python 2, preventing RMS from existing.
A major overhaul of the Queue system was done to prevent that and make everyting completely thread safe.