### PR TITLE
Save a frame every nth seconds from a reference epoch

### DIFF
--- a/.config
+++ b/.config
@@ -213,26 +213,10 @@ jpgs_quality: 90
 ; Set the saved framed PNG compression for png file type [0-9]
 png_compression: 3
 
-; Set the time interval in seconds for saving video frames.
-; CAUTION: Lower intervals can generate a large amount of data.
-; Example: An 8-hour run at 25 FPS will generate different data sizes
-;          depending on the interval and resolution selected.
-;
-;          | Inter|    Resolution     |
-;          |  (s) |   720p  |  1080p  |
-;          |------|---------|---------|
-;          | 0.2  |  ~20 GB |  ~50 GB |
-;          |   1  |   ~4 GB |  ~10 GB |
-;          |   2  |   ~2 GB |   ~5 GB |
-;          |   5  | ~800 MB |   ~2 GB |
-;          |  10  | ~400 MB |   ~1 GB |
-; Recommend 5 sec for single camera stations and 10 sec for multi-cam stations
-frame_save_interval: 5
-
 ; Run capture continuously, through day/night
 continuous_capture: false
 
-; Switch camera settings between day/night modes if continuous_capture is on,
+; Switch camera settings between day/night modes if continuous_capture is on
 ; using the settings in camera_settings.json "day" and "night" sections.
 switch_camera_modes: false
 

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1695,7 +1695,8 @@ class BufferedCapture(Process):
 
                     # Read the frame
                     log.info("Reading frame...")
-                    ret, _, _ = self.read()
+                    ret, frame, _ = self.read()
+                    self.convert_to_gray = self.isGrayscale(frame)
                     log.info("Frame read!")
 
                     # If the connection was made and the frame was retrieved, continue with the capture

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -868,9 +868,9 @@ class BufferedCapture(Process):
         Arguments:
             ts : [float]  epoch timestamp of current frame (seconds)
         """
-        dt   = self.config.frame_save_interval  # seconds
-        ref  = self.sync_tick_reference         # epoch offset
-        tol  = 0.5 / self.config.fps            # half-frame
+        dt   = self.config.frame_save_aligned_interval  # seconds
+        ref  = self.sync_tick_reference                 # epoch offset
+        tol  = 0.5 / self.config.fps                    # half-frame
 
         tick = int((ts - ref) / dt + 0.5)
         tick_time = ref + tick * dt

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1696,12 +1696,12 @@ class BufferedCapture(Process):
                     # Read the frame
                     log.info("Reading frame...")
                     ret, frame, _ = self.read()
-                    self.convert_to_gray = self.isGrayscale(frame)
                     log.info("Frame read!")
 
                     # If the connection was made and the frame was retrieved, continue with the capture
                     if ret:
                         log.info('Video device reconnected successfully!')
+                        self.convert_to_gray = self.isGrayscale(frame)
                         wait_for_reconnect = False
                         break
 
@@ -1742,6 +1742,13 @@ class BufferedCapture(Process):
                 ret, frame, frame_timestamp = self.read()
                 t_frame = time.time() - t1_frame
 
+                # If the video device was disconnected, wait for reconnection
+                if (self.video_file is None) and (not ret):
+                    log.info('Frame grabbing failed, video device is probably disconnected!')
+                    self.releaseResources()
+                    wait_for_reconnect = True
+                    break
+
                 # Set flag to save a raw frame
                 save_this_frame = (self.config.save_frames and
                                    self.video_file is None and
@@ -1755,13 +1762,6 @@ class BufferedCapture(Process):
                 # Handling for grayscale conversion
                 frame = self.handleGrayscaleConversion(frame)
 
-                # If the video device was disconnected, wait for reconnection
-                if (self.video_file is None) and (not ret):
-
-                    log.info('Frame grabbing failed, video device is probably disconnected!')
-                    self.releaseResources()
-                    wait_for_reconnect = True
-                    break
 
 
                 # If a video file is used, compute the time using the time from the file timestamp

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -700,7 +700,9 @@ class BufferedCapture(Process):
         Returns:
             bool: True if all sampled channels match (or frame is single-channel), otherwise False.
         """
-
+        if frame is None:
+            raise ValueError("isGrayscale() called with frame=None")
+        
         # We don't explicitly check frame.shape first; instead we rely on an IndexError
         # if 'frame' is single-channel (which is inherently grayscale).
         # This is faster than an extra dimension check for most BGR GMN stations 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -432,7 +432,7 @@ class Config:
         self.png_compression = 3
 
         # Set the time interval for saving video frames (s) aligned on reference epoch (not exposed in .config)
-        self.frame_save_aligned_interval = 5
+        self.frame_save_aligned_interval = 5.0
 
         # Set whether to delete, archive, or leave saved frames after making timelapse ('delete', 'tar', 'none')
         self.frame_cleanup = 'delete'
@@ -1239,7 +1239,7 @@ def parseCapture(config, parser):
 
     # Load the interval for saving video frame
     if parser.has_option(section, "frame_save_aligned_interval"):
-        config.frame_save_aligned_interval = parser.getint(section, "frame_save_aligned_interval")
+        config.frame_save_aligned_interval = parser.getfloat(section, "frame_save_aligned_interval")
 
     # Set whether to delete, archive, or leave saved frames after making timelapse ('delete', 'tar', 'none')
     if parser.has_option(section, "frame_cleanup"):

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -434,9 +434,6 @@ class Config:
         # Set the time interval for saving video frames (s)
         self.frame_save_interval = 5
 
-        # Set the frame count interval for saving video frames (calculated from the time interval)
-        self.frame_save_interval_count = 256
-
         # Set whether to delete, archive, or leave saved frames after making timelapse ('delete', 'tar', 'none')
         self.frame_cleanup = 'delete'
 
@@ -1243,15 +1240,6 @@ def parseCapture(config, parser):
     # Load the interval for saving video frame
     if parser.has_option(section, "frame_save_interval"):
         config.frame_save_interval = parser.getint(section, "frame_save_interval")
-
-        # Calculate the interval frame count
-        config.frame_save_interval_count = int(round(float(config.frame_save_interval)*float(config.fps)))
-
-        # Must be greater than 5
-        if config.frame_save_interval_count < 5:
-            config.frame_save_interval_count = 256
-            print()
-            print("WARNING! The frame_save_interval must result in more than 5 frames interval. It has been reset to 256 frames!")
 
     # Set whether to delete, archive, or leave saved frames after making timelapse ('delete', 'tar', 'none')
     if parser.has_option(section, "frame_cleanup"):

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -431,8 +431,8 @@ class Config:
         # Set PNG compression for the saved frames for png file type
         self.png_compression = 3
 
-        # Set the time interval for saving video frames (s)
-        self.frame_save_interval = 5
+        # Set the time interval for saving video frames (s) aligned on reference epoch (not exposed in .config)
+        self.frame_save_aligned_interval = 5
 
         # Set whether to delete, archive, or leave saved frames after making timelapse ('delete', 'tar', 'none')
         self.frame_cleanup = 'delete'
@@ -1238,8 +1238,8 @@ def parseCapture(config, parser):
 
 
     # Load the interval for saving video frame
-    if parser.has_option(section, "frame_save_interval"):
-        config.frame_save_interval = parser.getint(section, "frame_save_interval")
+    if parser.has_option(section, "frame_save_aligned_interval"):
+        config.frame_save_aligned_interval = parser.getint(section, "frame_save_aligned_interval")
 
     # Set whether to delete, archive, or leave saved frames after making timelapse ('delete', 'tar', 'none')
     if parser.has_option(section, "frame_cleanup"):

--- a/Utils/AuditConfig.py
+++ b/Utils/AuditConfig.py
@@ -35,7 +35,7 @@ OMIT_FROM_CONFIG = {'lat',  # Deprecated DFNS Station
                     'mask_remote_name',  # Should not be exposed
                     'remote_mask_dir',  # Should not be exposed
                     'platepar_template_dir',  # Should not be exposed
-                    'frame_save_interval',  # Should not be exposed
+                    'frame_save_aligned_interval',  # Should not be exposed
                     }
 
 

--- a/Utils/AuditConfig.py
+++ b/Utils/AuditConfig.py
@@ -34,7 +34,8 @@ OMIT_FROM_CONFIG = {'lat',  # Deprecated DFNS Station
                     'use_dark',  # Deprecated
                     'mask_remote_name',  # Should not be exposed
                     'remote_mask_dir',  # Should not be exposed
-                    'platepar_template_dir'  # Should not be exposed
+                    'platepar_template_dir',  # Should not be exposed
+                    'frame_save_interval',  # Should not be exposed
                     }
 
 


### PR DESCRIPTION
Currently, frames are saved every nth frames from whenever the first frame is read. This PR save frames every nth seconds from a reference epoch. This allows synching frame capture across multiple cameras.
The interval is set to 5 seconds and is not exposed in .config. (ConfigReader only).
A frame is saved when its timestamp is within 0.5/fps seconds from a sync tick mark. 