### PR TITLE
Skip authentication

### DIFF
--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -50,7 +50,7 @@ log = getLogger("logger")
 
 
 
-def getPlatepar(config, night_data_dir):
+def getPlatepar(config, night_data_dir, skip_authentications = False):
     """ Downloads a new platepar from the server or uses an existing one.
     
     Arguments:  
@@ -63,7 +63,8 @@ def getPlatepar(config, night_data_dir):
 
 
     # Download a new platepar from the server, if present  
-    downloadNewPlatepar(config)
+    if not skip_authentications:
+        downloadNewPlatepar(config)
 
 
     # Construct path to the platepar in the night directory

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -326,11 +326,11 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         log.debug('Could not generate config audit report:' + repr(e))
 
     # Check for and get an updated mask
-    if config.mask_download_permissive:
+    if config.mask_download_permissive and not skip_authentications:
         downloadNewMask(config)
 
     # Get the platepar file
-    platepar, platepar_path, platepar_fmt = getPlatepar(config, night_data_dir)
+    platepar, platepar_path, platepar_fmt = getPlatepar(config, night_data_dir, skip_authentications)
 
     # If the platepar is not none, set the FOV from it
     if platepar is not None:
@@ -896,6 +896,10 @@ if __name__ == "__main__":
     arg_parser.add_argument('-e', '--detectend', action="store_true", help="""Detect stars and meteors at the
         end of the night, after capture finishes. """)
 
+    arg_parser.add_argument('-s', '--skip_authentications', action="store_true",
+        help="""Skip any actions requiring authentication """)
+
+
     arg_parser.add_argument('-r', '--resume', action="store_true", \
         help="""Resume capture into the last night directory in CapturedFiles. """)
     
@@ -939,6 +943,13 @@ if __name__ == "__main__":
 
     log.info("Program version: {:s}, {:s}".format(commit_time, sha))
 
+    # Check to see if we should be skipping actions requiring authentication
+
+    if cml_args.skip_authentications:
+        skip_authentications = True
+        log.info("Skipping any actions requiring authentication")
+    else:
+        skip_authentications = False
 
     # Set the number of cores to use if given
     if cml_args.num_cores is not None:
@@ -960,8 +971,10 @@ if __name__ == "__main__":
     mkdirP(os.path.join(root_dir, config.captured_dir))
     mkdirP(os.path.join(root_dir, config.archived_dir))
 
+
+
     # Check for and get an updated mask
-    if config.mask_download_permissive:
+    if config.mask_download_permissive and not skip_authentications:
         downloadNewMask(config)
 
     # If the duration of capture was given, capture right away for a specified time
@@ -1035,7 +1048,7 @@ if __name__ == "__main__":
         sys.exit()
 
     upload_manager = None
-    if config.upload_enabled:
+    if config.upload_enabled and not skip_authentications:
 
         # Init the upload manager
         log.info('Starting the upload manager...')


### PR DESCRIPTION
To assist with testing, a new command line switch is added

```
python -m RMS.StartCapture -s
```

or

```
python -m RMS.StartCapture --skip_authentication
```

will run capture, however any activities requiring authentication will be skipped.

This is in response to issue #362.

Additionally stationID XX0001 will also cause any activites requiring authentication to be skipped.