### PR TITLE
Add protocol_in_use to ObservationSummary

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -318,6 +318,7 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     addObsParam(obs_db_conn, "total_fits", fits_count)
     addObsParam(obs_db_conn, "fits_file_shortfall", fits_file_shortfall)
     addObsParam(obs_db_conn, "fits_file_shortfall_as_time", fits_file_shortfall_as_time)
+    addObsParam(obs_db_conn, "protocol_in_use", config.protocol)
     obs_db_conn.close()
 
     writeToFile(config, getRMSStyleFileName(night_data_dir, "observation_summary.txt"))


### PR DESCRIPTION
This PR is related to Issue #625, and adds

```
protocol_in_use                 : tcp 
```

to the observation summary text file and 

```   
"protocol_in_use": "tcp"
```
 to the json file. 

When .config is set to UDP

```
protocol_in_use                 : udp 
```
and

```
"protocol_in_use": "udp"
```








