### PR TITLE
Always force UTC time for all data products

### DIFF
--- a/RMS/Astrometry/Conversions.py
+++ b/RMS/Astrometry/Conversions.py
@@ -40,6 +40,7 @@ import numpy as np
 import scipy.optimize
 
 from RMS.Math import vectMag, vectNorm
+from RMS.Misc import UTCFromTimestamp
 
 # Import Cython functions
 import pyximport
@@ -114,7 +115,7 @@ def unixTime2Date(ts, tu, dt_obj=False):
     """
 
     # Convert the UNIX timestamp to datetime object
-    dt = datetime.utcfromtimestamp(float(ts) + float(tu)/1000000)
+    dt = UTCFromTimestamp.utcfromtimestamp(float(ts) + float(tu)/1000000)
 
     if dt_obj:
         return dt

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -40,7 +40,7 @@ from RMS.Misc import obfuscatePassword
 from RMS.Routines.GstreamerCapture import GstVideoFile
 from RMS.Formats.ObservationSummary import getObsDBConn, addObsParam
 from RMS.RawFrameSave import RawFrameSaver
-from RMS.Misc import RmsDateTime, mkdirP
+from RMS.Misc import RmsDateTime, mkdirP, UTCFromTimestamp
 from RMS.Formats import FTfile, FTStruct
 from RMS.Logger import getLogger, gstDebugLogger
 from RMS.CaptureModeSwitcher import switchCameraMode
@@ -779,7 +779,7 @@ class BufferedCapture(Process):
         """
 
         # Segment name is based on timestamp recorded during last segment save
-        segment_time = datetime.datetime.fromtimestamp(self.last_segment_savetime)
+        segment_time = UTCFromTimestamp.utcfromtimestamp(self.last_segment_savetime)
         self.last_segment_savetime = time.time()
         segment_filename = segment_time.strftime("{}_%Y%m%d_%H%M%S_video.mkv".format(self.config.stationID))
         segment_subpath = os.path.join(self.config.data_dir, self.config.video_dir, segment_time.strftime("%Y/%Y%m%d-%j/%Y%m%d-%j_%H"))
@@ -1019,7 +1019,7 @@ class BufferedCapture(Process):
                     self.start_timestamp = start_time - (self.config.camera_buffer/self.config.fps + self.config.camera_latency)
 
                 # Log start time
-                start_time_str = (datetime.datetime.fromtimestamp(self.start_timestamp)
+                start_time_str = (UTCFromTimestamp.utcfromtimestamp(self.start_timestamp)
                                     .strftime('%Y-%m-%d %H:%M:%S.%f'))
 
                 log.info("Start time is {:s}".format(start_time_str))
@@ -2012,7 +2012,7 @@ class BufferedCapture(Process):
                 # Clear the timestamp buffer list                
                 del self.timestamp_buffer[:]
 
-                base_time = datetime.datetime.fromtimestamp(first_frame_timestamp)
+                base_time = UTCFromTimestamp.utcfromtimestamp(first_frame_timestamp)
                 ft_filename = base_time.strftime("FT_{}_%Y%m%d_%H%M%S.bin".format(self.config.stationID))
                 ft_subpath = os.path.join(self.config.data_dir, self.config.times_dir, base_time.strftime("%Y/%Y%m%d-%j/%Y%m%d-%j_%H"))
 

--- a/RMS/Compression.py
+++ b/RMS/Compression.py
@@ -30,6 +30,7 @@ from RMS.VideoExtraction import Extractor
 from RMS.Formats import FFfile, FFStruct
 from RMS.Formats import FieldIntensities
 from RMS.Logger import getLogger
+from RMS.Misc import UTCFromTimestamp
 from RMS.Routines.Image import saveImage
 
 # Import Cython functions
@@ -142,12 +143,12 @@ class Compressor(multiprocessing.Process):
 
         if sys.version_info[0] == 2:
             # Python 2 code
-            dt = datetime.datetime.utcfromtimestamp(startTime)
+            dt = UTCFromTimestamp.utcfromtimestamp(startTime)
             ff.starttime = dt.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         else:
             # Python 3 code
-            dt = datetime.datetime.fromtimestamp(startTime, tz=datetime.timezone.utc)
+            dt = UTCFromTimestamp.utcfromtimestamp(startTime, tz=datetime.timezone.utc)
             ff.starttime = dt.isoformat(timespec='microseconds')
         
         # Write the FF file

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -17,7 +17,7 @@ import ephem
 from RMS.CaptureDuration import captureDuration
 from RMS.ConfigReader import loadConfigFromDirectory
 from RMS.Logger import initLogging, getLogger
-from RMS.Misc import RmsDateTime
+from RMS.Misc import RmsDateTime, UTCFromTimestamp
 
 # Get the logger from the main module
 log = getLogger("logger")
@@ -260,7 +260,7 @@ def objectsToDeleteByTime(top_level_dir, directories_list, quota_gb=0):
         if accumulated_size > quota_gb:
             accumulated_deletion_size += file_date_path_size[2] / (1024 ** 3)
             if not logged_deletion_start_time:
-                log.info("Deleting files before {}".format(datetime.datetime.fromtimestamp(file_date_path_size[0]).strftime('%Y%m%d_%H%M%S')))
+                log.info("Deleting files before {}".format(UTCFromTimestamp.utcfromtimestamp(file_date_path_size[0]).strftime('%Y%m%d_%H%M%S')))
                 logged_deletion_start_time = True
             objects_to_delete.append(file_date_path_size[1])
         pass

--- a/RMS/Formats/FTPdetectinfo.py
+++ b/RMS/Formats/FTPdetectinfo.py
@@ -21,7 +21,7 @@ import os
 import sys
 import git
 import numpy as np
-from RMS.Misc import RmsDateTime
+from RMS.Misc import RmsDateTime, UTCFromTimestamp
 
 # Map FileNotFoundError to IOError in Python 2 as it does not exist
 if sys.version_info[0] < 3:
@@ -74,7 +74,7 @@ def writeFTPdetectinfo(meteor_list, ff_directory, file_name, cal_directory, cam_
             repo = git.Repo(search_parent_directories=True)
             commit_unix_time = repo.head.object.committed_date
             sha = repo.head.object.hexsha
-            commit_time = datetime.datetime.fromtimestamp(commit_unix_time).strftime('%Y%m%d_%H%M%S')
+            commit_time = UTCFromTimestamp.utcfromtimestamp(commit_unix_time).strftime('%Y%m%d_%H%M%S')
 
         except:
             commit_time = ""

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -31,7 +31,7 @@ import os
 import subprocess
 
 
-from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir
+from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
 import re
 import sqlite3
 from RMS.ConfigReader import parse
@@ -171,7 +171,7 @@ def startObservationSummaryReport(config, duration, force_delete=False):
         repo = git.Repo(repo_path)
         if repo:
             addObsParam(conn, "commit_date",
-                        datetime.datetime.fromtimestamp(repo.head.object.committed_date).strftime('%Y%m%d_%H%M%S'))
+                        UTCFromTimestamp.utcfromtimestamp(repo.head.object.committed_date).strftime('%Y%m%d_%H%M%S'))
             addObsParam(conn, "commit_hash", repo.head.object.hexsha)
         else:
             print("RMS Git repository not found. Skipping Git-related information.")

--- a/RMS/Logger.py
+++ b/RMS/Logger.py
@@ -12,6 +12,7 @@ import threading
 import atexit
 import time
 
+import RMS.Misc
 
 try:
     from logging.handlers import QueueHandler  # Python 3.2+
@@ -134,78 +135,6 @@ class LoggerWriter:
         pass
 
 
-# Reproduced from RMS.Misc due to circular import issue
-def mkdirP(path):
-    """ Makes a directory and handles all errors.
-    
-    Arguments:
-        path: [str] Directory path to create
-        
-    Return:
-        [bool] True if successful, False otherwise
-    """
-    try:
-        os.makedirs(path)
-        return True
-    except OSError as exc:
-        if exc.errno == errno.EEXIST:
-            return True
-        else:
-            print("Error creating directory: " + str(exc))
-            return False
-    except Exception as e:
-        print("Error creating directory: " + str(e))
-        return False
-
-
-# Reproduced from RMS.Misc due to circular import issue
-class RmsDateTime:
-    """ Use Python-version-specific UTC retrieval.
-    """
-    if sys.version_info[0] < 3:
-        @staticmethod
-        def utcnow():
-            return datetime.datetime.utcnow()
-    else:
-        @staticmethod
-        def utcnow():
-            return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-
-
-# Reproduced from RMS.Misc due to circular import issue
-
-class UTCFromTimestamp:
-    """Cross-version helper to convert Unix timestamps to naive UTC datetime objects.
-
-    - Python 2.7–3.11: uses datetime.utcfromtimestamp()
-    - Python 3.12+: uses datetime.fromtimestamp(..., tz=timezone.utc).replace(tzinfo=None)
-    """
-
-    @staticmethod
-    def utcfromtimestamp(timestamp):
-        if sys.version_info >= (3, 12):
-            # Use aware datetime then strip tzinfo to make it naive
-            return datetime.datetime.fromtimestamp(
-                timestamp, tz=UTCFromTimestamp._get_utc_timezone()
-            ).replace(tzinfo=None)
-        else:
-            return datetime.datetime.utcfromtimestamp(timestamp)
-
-    @staticmethod
-    def _get_utc_timezone():
-        """Safely provide UTC tzinfo across Python versions."""
-        try:
-            # Python 3.2+
-            from datetime import timezone
-            return timezone.utc
-        except ImportError:
-            # Python 2: no timezone support
-            raise NotImplementedError(
-                "timezone-aware fromtimestamp() is not supported in Python < 3.2. "
-                "Use Python >= 3.12 or fallback to utcfromtimestamp()."
-            )
-
-
 
 def gstDebugLogger(category, level, file, function, line, obj, message, user_data):
     """ Maps GStreamer debug levels to Python logging levels and logs
@@ -251,7 +180,7 @@ class CustomHandler(logging.handlers.TimedRotatingFileHandler):
         
         # Calculate time range for the log file
         start_time = datetime.datetime.strptime(start_time_str, "%Y%m%d_%H%M%S")
-        end_time = UTCFromTimestamp.utcfromtimestamp(self.rolloverAt)
+        end_time = RMS.Misc.UTCFromTimestamp.utcfromtimestamp(self.rolloverAt)
         
         # Format the new filename with time range
         start_str = start_time.strftime("%d_%H%M")
@@ -291,10 +220,10 @@ def _listener_configurer(config, log_file_prefix, safedir):
 
     # Make directories
     print("Creating directory: " + config.data_dir)
-    data_dir_status = mkdirP(config.data_dir)
+    data_dir_status = RMS.Misc.mkdirP(config.data_dir)
     print("   Success: {}".format(data_dir_status))
     print("Creating directory: " + log_path)
-    log_path_status = mkdirP(log_path)
+    log_path_status = RMS.Misc.mkdirP(log_path)
     print("   Success: {}".format(log_path_status))
 
     # If the log directory doesn't exist or is not writable, use the safe directory
@@ -308,10 +237,10 @@ def _listener_configurer(config, log_file_prefix, safedir):
         if not os.path.exists(log_path) or not os.access(log_path, os.W_OK):
             root_logger.debug("Log directory not writable, using safedir: %s", safedir)
             log_path = safedir
-            mkdirP(log_path)
+            RMS.Misc.mkdirP(log_path)
 
     # Generate log filename with timestamp
-    start_time_str = RmsDateTime.utcnow().strftime("%Y%m%d_%H%M%S")
+    start_time_str = RMS.Misc.RmsDateTime.utcnow().strftime("%Y%m%d_%H%M%S")
     logfile_name = "{}log_{}_{}.log".format(log_file_prefix, config.stationID, start_time_str)
     full_path = os.path.join(log_path, logfile_name)
 

--- a/RMS/Logger.py
+++ b/RMS/Logger.py
@@ -11,6 +11,8 @@ import datetime
 import threading
 import atexit
 
+from RMS.Misc import UTCFromTimestamp
+
 
 try:
     from logging.handlers import QueueHandler  # Python 3.2+
@@ -215,7 +217,7 @@ class CustomHandler(logging.handlers.TimedRotatingFileHandler):
         
         # Calculate time range for the log file
         start_time = datetime.datetime.strptime(start_time_str, "%Y%m%d_%H%M%S")
-        end_time = datetime.datetime.fromtimestamp(self.rolloverAt)
+        end_time = UTCFromTimestamp.utcfromtimestamp(self.rolloverAt)
         
         # Format the new filename with time range
         start_str = start_time.strftime("%d_%H%M")

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -632,6 +632,37 @@ class RmsDateTime:
             return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 
 
+class UTCFromTimestamp:
+    """Cross-version helper to convert Unix timestamps to naive UTC datetime objects.
+
+    - Python 2.7–3.11: uses datetime.utcfromtimestamp()
+    - Python 3.12+: uses datetime.fromtimestamp(..., tz=timezone.utc).replace(tzinfo=None)
+    """
+
+    @staticmethod
+    def utcfromtimestamp(timestamp):
+        if sys.version_info >= (3, 12):
+            # Use aware datetime then strip tzinfo to make it naive
+            return datetime.datetime.fromtimestamp(
+                timestamp, tz=UTCFromTimestamp._get_utc_timezone()
+            ).replace(tzinfo=None)
+        else:
+            return datetime.datetime.utcfromtimestamp(timestamp)
+
+    @staticmethod
+    def _get_utc_timezone():
+        """Safely provide UTC tzinfo across Python versions."""
+        try:
+            # Python 3.2+
+            from datetime import timezone
+            return timezone.utc
+        except ImportError:
+            # Python 2: no timezone support
+            raise NotImplementedError(
+                "timezone-aware fromtimestamp() is not supported in Python < 3.2. "
+                "Use Python >= 3.12 or fallback to utcfromtimestamp()."
+            )
+
 def niceFormat(string, delim=":", extra_space=5):
 
     """

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -46,7 +46,7 @@ from RMS.Compression import Compressor
 from RMS.DeleteOldObservations import deleteOldObservations
 from RMS.DetectStarsAndMeteors import detectStarsAndMeteors
 from RMS.Formats.FFfile import validFFName
-from RMS.Misc import mkdirP, RmsDateTime
+from RMS.Misc import mkdirP, RmsDateTime, UTCFromTimestamp
 from RMS.QueuedPool import QueuedPool
 from RMS.Reprocess import getPlatepar, processNight, processFramesFiles
 from RMS.RunExternalScript import runExternalScript
@@ -931,7 +931,7 @@ if __name__ == "__main__":
         repo = git.Repo(search_parent_directories=True)
         commit_unix_time = repo.head.object.committed_date
         sha = repo.head.object.hexsha
-        commit_time = datetime.datetime.fromtimestamp(commit_unix_time).strftime('%Y%m%d_%H%M%S')
+        commit_time = UTCFromTimestamp.utcfromtimestamp(commit_unix_time).strftime('%Y%m%d_%H%M%S')
 
     except:
         commit_time = ""


### PR DESCRIPTION
The datetime.datetime.fromtimestamp function is not timezone aware and might produce data files with times set to localtime if the machine is not set to UTC.
The proposed change handles this on all python versions.