### PR TITLE
Rollback changes ref circular dependencies

### DIFF
--- a/RMS/Logger.py
+++ b/RMS/Logger.py
@@ -411,7 +411,7 @@ def initLogging(config, log_file_prefix="", safedir=None, level=logging.DEBUG):
 
     # Set DEBUG on root logger in main process
     main_logger = logging.getLogger()
-    main_logger.setLevel(logging.DEBUG) # Keep root permissive
+    main_logger.setLevel(level=level) # Keep root permissive
 
     # Configure queue handler for main process
     qh = logging.handlers.QueueHandler(_rms_logging_queue)


### PR DESCRIPTION
This reverts a4bd454 "removed duplicated code while preventing circular imports" which unfortunately broke RMS.Reprocess and possibly some other standalone modules (see Issue #639 )  My google search did not find any workaround for this, so for now I think we'll have to live with the duplication until we cease support for Python 2.7 and can replace mkdirP and the utc-handling classes with generic Python 3.x code throughout the entire codebase.