### PR TITLE
Reduce precision of reporting in observation summary .txt file

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -245,8 +245,8 @@ def getChronyUncertainty():
     try:
         cmd = ["chronyc", "tracking"]
         lines = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode().strip().splitlines()
-        print(lines)
         ahead_ms = "Unknown"
+
         for line in lines:
             if line.startswith("Last offset"):
                 system_time_offset = float(line.split(":")[1].strip().split()[0])
@@ -264,11 +264,13 @@ def getChronyUncertainty():
                     synchronized = False
                 else:
                     synchronized = True
+
         if synchronized:
             uncertainty_ms = (abs(system_time_offset) + root_dispersion + (0.5 * root_delay)) * 1000
         else:
             uncertainty_ms = "Unknown"
             ahead_ms = "Unknown"
+
         return synchronized, ahead_ms, uncertainty_ms
 
     except:
@@ -406,7 +408,7 @@ def addObsParam(conn, key, value):
 
             """
 
-    print(key,value)
+
     sql_statement = ""
     sql_statement += "INSERT INTO records \n"
     sql_statement += "(\n"
@@ -847,7 +849,6 @@ if __name__ == "__main__":
     config = parse(os.path.expanduser("~/source/RMS/.config"))
 
     obs_db_conn = getObsDBConn(config)
-    print(timeSyncStatus(config, obs_db_conn))
     startObservationSummaryReport(config, 100, force_delete=False)
     pp = Platepar()
     pp.read(os.path.expanduser(os.path.join(config.rms_root_dir, "platepar_cmn2010.cal")))


### PR DESCRIPTION
This PR is in response to issue #624, and reduces the level of precision in the .txt file of the observation summary, and lists the values in a more logical order. 


```
stationID                       : AU002C 
commit_date                     : 20250610_214720 
commit_hash                     : 27250b572be589b3dc2c2a5ab2c334ec047813f8 
hardware_version                : x86_64 
captured_directories            : 23 
storage_used_gb                 : 2442.75 
storage_free_gb                 : 1036.03 
storage_total_gb                : 3665.02 
camera_lens                     : 6mm 
camera_fov_h                    : 53.69 
camera_fov_v                    : 29.978 
camera_pointing_alt             : 40.72 degrees 
camera_pointing_az              : 108.33 degrees 
camera_information              : 50H20L 
clock_error_seconds             : 0.4 
clock_synchronized              : yes 
start_time                      : 2025-06-10 21:47:31 
duration                        : 100 
time_first_fits_file            : 2025-05-27 10:20:14 
time_last_fits_file             : 2025-05-27 12:24:24 
total_expected_fits             : 728 
total_fits                      : 720 
fits_files_from_duration        : 9.759 
fits_file_shortfall             : 8 
fits_file_shortfall_as_time     : 00:01:21 
capture_duration_from_fits      : 7459.98 
```
