### PR TITLE
set pre-init logger to INFO

### DIFF
--- a/RMS/Logger.py
+++ b/RMS/Logger.py
@@ -110,7 +110,7 @@ _default_handler.setFormatter(_default_formatter)
 _default_handler.addFilter(PreInitNoiseFilter())
 _pre_init_logger = logging.getLogger()
 _pre_init_logger.addHandler(_default_handler)
-_pre_init_logger.setLevel(logging.DEBUG)
+_pre_init_logger.setLevel(logging.INFO)
 
 # This handler will be removed when proper logging is initialized
 

--- a/RMS/Logger.py
+++ b/RMS/Logger.py
@@ -65,7 +65,8 @@ except ImportError:
 # Set GStreamer debug level. Use '2' for warnings in production environments.
 # Level 4 and above are overwhelming the log
 # If higher verbosity is needed, disable in client scripts
-os.environ['GST_DEBUG'] = '2'
+if not os.getenv('GST_DEBUG', default=None):
+    os.environ['GST_DEBUG'] = '2'
 
 _rms_logging_queue = None
 _rms_listener_process = None


### PR DESCRIPTION
Set logging to INFO rather than DEBUG to reduce excessive logging from paramiko, matplot etc.  Hopefully no em-dashes in the file this time.