### PR TITLE
Remove DOY in frame timelapse name

### DIFF
--- a/Utils/GenerateTimelapse.py
+++ b/Utils/GenerateTimelapse.py
@@ -202,7 +202,7 @@ def generateTimelapse(dir_path, keep_images=False, fps=None, output_file=None, h
 
 #  Output-naming helpers - one place to tweak naming scheme
 FNAME_TEMPLATE = (
-    "{station}_{doy_start:03d}_{start:%Y%m%d-%H%M%S}_to_{end:%Y%m%d-%H%M%S}_{suffix}"
+    "{station}_{start:%Y%m%d-%H%M%S}_to_{end:%Y%m%d-%H%M%S}_{suffix}"
 )
 
 MP4_SUFFIX = "frames_timelapse.mp4"


### PR DESCRIPTION
Remove DOY from frame timelapse filename to make it sortable chronologically.
```
US005C_156_20250605-032240_to_20250605-113024_frames_timelapse.*

to

US005C_20250605-032240_to_20250605-113024_frames_timelapse.*
```