### PR TITLE
Do not use config file settings for backup

### DIFF
--- a/Scripts/RMS_Backup.sh
+++ b/Scripts/RMS_Backup.sh
@@ -26,18 +26,14 @@ if [ ! -f $CONFIG_FILE ]; then
     exit 1
 fi
 
+MASK_FILE="${RMS_DIR}/mask.bmp"
+PLATEPAR_FILE="${RMS_DIR}/platepar_cmn2010.cal"
+
+STATIONS="${HOME}/source/Stations"
+
+RSA="${HOME}/.ssh"
+
 cd $(dirname $CONFIG_FILE)
-
-RSA_PRIV_FILE=$(read_property "rsa_private_key")
-RSA_PRIV_FILE="${RSA_PRIV_FILE/#\~/$HOME}"
-
-RSA_PUB_FILE=${RSA_PRIV_FILE}.pub
-
-PLATEPAR_FILE=$(read_property "platepar_name")
-PLATEPAR_FILE=$(realpath "${PLATEPAR_FILE/#\~/$HOME}")
-
-MASK_FILE=$(read_property "mask")
-MASK_FILE=$(realpath "${MASK_FILE/#\~/$HOME}")
 
 STATION_ID=$(read_property "stationID")
 TIMESTAMP=$(date +%Y-%m-%d)
@@ -48,15 +44,15 @@ echo "----------"
 echo
 echo "Station ID:....: " $STATION_ID
 echo "RMS config.....: " $CONFIG_FILE
-echo "RSA private key: " $RSA_PRIV_FILE
-echo "RSA public key.: " $RSA_PUB_FILE
-echo "Platepar.......: " $PLATEPAR_FILE
 echo "Mask...........: " $MASK_FILE
+echo "Platepar.......: " $PLATEPAR_FILE
+echo "RSA ...........: " $RSA
+echo "Stations.......: " $STATIONS
 echo
 echo "Compressing files..."
 
+zip -q -r $BACKUP_FILE $CONFIG_FILE $MASK_$PLATEPAR_FILE FILE $RSA $STATIONS
 
-zip -q --junk-paths $BACKUP_FILE $CONFIG_FILE $RSA_PRIV_FILE $RSA_PUB_FILE $PLATEPAR_FILE $MASK_FILE
 echo "Backup saved to: $BACKUP_FILE"
 
 exit 0


### PR DESCRIPTION
This PR relates to issue #644.

The mask and platepar files are no longer listed in the .config file, which is limiting the functionality of the RMS_Backup.sh script

This PR hard codes the names of the mask and platepar file into the backup script. It removes a flag --junk-paths, which may not have been functioning on some systems. This preserves the directory structure of a multicamera station, and stops files with the same name, but different paths clobbering each other. A consequence of this is that the whole .ssh directory is backed up, not just the key files. 

The old version of the file prints to terminal as below.

```
(vRMS) david@lap-deb-01:~/source/RMS$ Scripts/RMS_Backup.sh 
realpath: '': No such file or directory
realpath: '': No such file or directory
RMS Backup
----------

Station ID:....:  XX0001
RMS config.....:  /home/david/source/RMS/.config
RSA private key:  /home/david/.ssh/id_rsa
RSA public key.:  /home/david/.ssh/id_rsa.pub
Platepar.......: 
Mask...........: 

Compressing files...
Backup saved to: /home/david/RMS_Backup_XX0001_2025-06-15.zip
```
and yields the following output

[RMS_Backup_XX0001_2025-06-15.zip](https://github.com/user-attachments/files/20743170/RMS_Backup_XX0001_2025-06-15.zip)

The new version of the file prints to terminal as below.

```
(vRMS) david@lap-deb-01:~/source/RMS$ Scripts/RMS_Backup.sh 
RMS Backup
----------

Station ID:....:  XX0001
RMS config.....:  /home/david/source/RMS/.config
Mask...........:  /home/david/source/RMS/mask.bmp
Platepar.......:  /home/david/source/RMS/platepar_cmn2010.cal
RSA ...........:  /home/david/.ssh
Stations.......:  /home/david/source/Stations

Compressing files...
Backup saved to: /home/david/RMS_Backup_XX0001_2025-06-15.zip
```
and yields the following output

[RMS_Backup_XX0001_2025-06-15.zip](https://github.com/user-attachments/files/20743198/RMS_Backup_XX0001_2025-06-15.zip)


