### PR TITLE
Remove unwarranted precision from observation summary text file, add time error, catalog in use and other keys

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -589,7 +589,7 @@ def retrieveObservationData(conn, obs_start_time, ordering=None):
         # the two items into one.
 
         ordering = ['stationID',
-                    'commit_date', 'commit_hash','media_backend',
+                    'commit_date', 'commit_hash','media_backend','star_catalog_file',
                     'hardware_version',
                     'captured_directories',
                     'storage_used_gb', 'storage_free_gb', 'storage_total_gb',
@@ -597,12 +597,12 @@ def retrieveObservationData(conn, obs_start_time, ordering=None):
                     'camera_pointing_alt','camera_pointing_az',
                     'camera_information',
                     'clock_measurement_source', 'clock_synchronized', 'clock_ahead_ms', 'clock_error_uncertainty_ms',
-                    'start_time', 'duration', 'photometry_good',
+                    'start_time', 'duration', 'photometry_good', 'star_catalog_file',
                     'time_first_fits_file', 'time_last_fits_file', 'total_expected_fits','total_fits',
                     'fits_files_from_duration','fits_file_shortfall', 'fits_file_shortfall_as_time',
                     'capture_duration_from_fits',
                     'detections_after_ml',
-                    'media_backend','jitter_quality','dropped_frame_rate']
+                    'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate']
 
     # use this print call to check the ordering
     #print("Ordering {}".format(ordering))
@@ -834,6 +834,8 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     addObsParam(obs_db_conn, "total_fits", fits_count)
     addObsParam(obs_db_conn, "fits_file_shortfall", fits_file_shortfall)
     addObsParam(obs_db_conn, "fits_file_shortfall_as_time", fits_file_shortfall_as_time)
+    addObsParam(obs_db_conn, "protocol_in_use", config.protocol)
+    addObsParam(obs_db_conn, "star_catalog_file", config.star_catalog_file)
     obs_db_conn.close()
 
     writeToFile(config, getRMSStyleFileName(night_data_dir, "observation_summary.txt"))

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -794,7 +794,7 @@ def retrieveObservationData(conn, obs_start_time, ordering=None):
         # the two items into one.
 
         ordering = ['stationID',
-                    'commit_date', 'commit_hash', 'days_behind',
+                    'commit_date', 'commit_hash', 'repository_lag_remote_days',
                     'media_backend','star_catalog_file',
                     'hardware_version',
                     'captured_directories',
@@ -1043,9 +1043,9 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     addObsParam(obs_db_conn, "protocol_in_use", config.protocol)
     addObsParam(obs_db_conn, "star_catalog_file", config.star_catalog_file)
     try:
-        addObsParam(obs_db_conn, "repository_lag_days", daysBehind(config))
+        addObsParam(obs_db_conn, "repository_lag_remote_days", daysBehind(config))
     except:
-        addObsParam(obs_db_conn, "repository_lag_days", "Not determined")
+        addObsParam(obs_db_conn, "repository_lag_remote_days", "Not determined")
     obs_db_conn.close()
 
     writeToFile(config, getRMSStyleFileName(night_data_dir, "observation_summary.txt"))

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1,6 +1,6 @@
 # The MIT License
 
-# Copyright (c) 2024
+# Copyright (c) 2025
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -605,7 +605,7 @@ def retrieveObservationData(conn, obs_start_time, ordering=None):
                     'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate']
 
     # use this print call to check the ordering
-    #print("Ordering {}".format(ordering))
+    print("Ordering {}".format(ordering))
 
     sql_statement = ""
     sql_statement += "SELECT Key, Value from records \n"

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -71,7 +71,7 @@ def roundWithoutTrailingZero(value, no):
         value: [float] value.
         no: [integer] number of decimal places to round.
 
-    Returns:
+    Return:
         string: [string]: value rounded number of decimal places without trailing zero.
     """
 
@@ -85,7 +85,7 @@ def getTimeClient():
 
     This function is aware of systemd-timesyncd, chronyd, ntpd.
 
-    Returns:
+    Return:
         name: [string] Name of the time client.
 
     """
@@ -118,7 +118,7 @@ def timeSyncStatus(config, conn, force_client=None):
     Keyword arguments:
         force_client: [string] optional, string to force resolution by ntpd, chrony, or a query on a remote server.
 
-    Returns:
+    Return:
         ahead_ms: [float] time local clock ahead (+ve) milliseconds, or "Unknown" if delta cannot be determined.
     """
 
@@ -182,8 +182,8 @@ def getNTPStatistics():
     Argyments:
         None
 
-    Returns:
-        synchronized: [bool] true if reported as synchronised.
+    Return:
+        synchronized: [bool] true if reported as synchronized.
         uncertainty_ms: [float] uncertainty in milliseconds.
         time_error_ms: [str] always Unknown, unable to discern actual time error using ntp tools.
 
@@ -245,7 +245,7 @@ def getChronyUncertainty():
 
             None
 
-        Returns:
+        Return:
             synchronized: [bool] true if reported as synchronized.
             ahead_ms: [str] time in milliseconds that computer clock is reported to be ahead of superior reference.
             uncertainty_ms: [float] uncertainty in milliseconds.
@@ -302,7 +302,7 @@ def timestampFromNTP(addr='time.cloudflare.com'):
     Keyword arguments:
         addr: optional, address of ntp server to use.
 
-    Returns:
+    Return:
         adjusted_time: [float] time in seconds since epoch.
         estimated_network_delay: [float] estimated network delay (average of outgoing and return legs).
     """
@@ -570,7 +570,7 @@ def nightSummaryData(config, night_data_dir):
         night_data_dir: [path] the directory of captured files.
 
 
-    Returns:
+    Return:
         capture_duration_from_fits: [int] the duration from the start of first fits to the end of the last.
         fits_count: [int] the count of *.fits files in the directory.
         fits_file_shortfall: [int] the number of expected fits expected less the number actually found.
@@ -655,7 +655,7 @@ def getCommit(repo):
     Arguments:
         repo: [path] file location of a repository.
 
-    Returns:
+    Return:
         commit: [string] latest commit hash
     """
 
@@ -672,7 +672,7 @@ def getDateOfCommit(repo, commit):
         repo: [path] directory of repository.
         commit: [string] commit hash.
 
-    Returns:
+    Return:
         commit_time : [datetime object] python datetime object of the time and date of that commit
     """
 
@@ -712,7 +712,7 @@ def getBranchOfCommit(repo, commit):
         repo: [path] directory of repository.
         commit: [str] commit hash
 
-    Returns:
+    Return:
         local_branch: [str] A local branch where a commit exists.
     """
 
@@ -874,7 +874,7 @@ def serialize(config, format_nicely=True, as_json=False):
         as_json: [bool] optional, default false, return the data as a json.
 
     Return:
-        string of key value pairs committed to the database since the start of the previous observation session
+        string of key value pairs committed to the database since the start of the previous observation session.
     """
 
     conn = getObsDBConn(config)
@@ -960,13 +960,13 @@ def startObservationSummaryReport(config, duration, force_delete=False):
 
     Arguments:
             config: [config] config file.
-            duration: [int]the initially calculated duration seconds
+            duration: [int]the initially calculated duration seconds.
 
     Keyword arguments:
-            force_delete: [bool] forces deletion of the observation summary database, default False
+            force_delete: [bool] forces deletion of the observation summary database, default False.
 
     Return:
-            [str] human readable message about session
+            [str] message about session.
 
     """
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -30,12 +30,12 @@ import sys
 import os
 import subprocess
 from time import strftime
-
+from datetime import datetime, timezone
 from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
 import re
 import sqlite3
 from RMS.ConfigReader import parse
-from datetime import datetime, timezone
+
 import platform
 import git
 import shutil
@@ -732,7 +732,9 @@ def startObservationSummaryReport(config, duration, force_delete=False):
 
 
     conn = getObsDBConn(config, force_delete=force_delete)
-    addObsParam(conn, "start_time", (datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=1)).replace(tzinfo=timezone.utc))
+    start_time_object = (datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=1)).replace(tzinfo=timezone.utc)
+    start_time_object_rounded = start_time_object.replace(microsecond=0)
+    addObsParam(conn, "start_time", start_time_object_rounded)
     addObsParam(conn, "duration", duration)
     addObsParam(conn, "stationID", sanitise(config.stationID, space_substitution=""))
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1043,9 +1043,9 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     addObsParam(obs_db_conn, "protocol_in_use", config.protocol)
     addObsParam(obs_db_conn, "star_catalog_file", config.star_catalog_file)
     try:
-        addObsParam(obs_db_conn, "repository_lagging_days", daysBehind(config))
+        addObsParam(obs_db_conn, "repository_lag_days", daysBehind(config))
     except:
-        addObsParam(obs_db_conn, "repository_lagging_days", "Not determined")
+        addObsParam(obs_db_conn, "repository_lag_days", "Not determined")
     obs_db_conn.close()
 
     writeToFile(config, getRMSStyleFileName(night_data_dir, "observation_summary.txt"))

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -29,19 +29,20 @@ from __future__ import print_function, division, absolute_import
 import sys
 import os
 import subprocess
-
+from time import strftime
 
 from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
 import re
 import sqlite3
 from RMS.ConfigReader import parse
-from datetime import datetime
+from datetime import datetime, timezone
 import platform
 import git
 import shutil
-import time
+
 import glob
 import json
+
 
 from RMS.Formats.FFfits import filenameToDatetimeStr
 import datetime
@@ -60,6 +61,285 @@ import struct
 import sys
 import time
 
+
+def roundWithoutTrailingZero(value, no):
+
+    """
+    Given a float, round to specified number of decimal places, then remove trailing zeroes
+
+    Args:
+        value: float value
+        no: number of decimal places to round to
+
+    Returns:
+        [string]: value rounded number of decimal places without trailing zero
+    """
+
+    value = round(value,no)
+    return str("{0:g}".format(value))
+
+def getTimeClient():
+
+    """
+    Attempt to identify which time service client, if any is providing sync service, or Not recognized.
+    Aware of systemd-timesyncd, chronyd, ntpd
+
+    Returns:
+        [string]: Name of the time client
+
+    """
+
+    clients = {
+        'systemd-timesyncd': ['systemctl', 'is-active', 'systemd-timesyncd'],
+        'chronyd': ['systemctl', 'is-active', 'chronyd'],
+        'ntpd': ['systemctl', 'is-active', 'ntp']
+    }
+
+    for name, cmd in clients.items():
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode().strip()
+            if output == 'active':
+                return name
+        except subprocess.CalledProcessError:
+            pass  # Not active or not installed
+    return "Not recognized"
+
+def timeSyncStatus(config, conn, force_client=None):
+
+    """
+    Add timeSyncStatus to the database, and return howe far the machine clock
+    is ahead of reference time in milliseconds
+
+    Args:
+        config:rms config file
+        conn: database connection
+        force_client: optional, string to force resolution by ntpd, chrony, or a query on a remote server
+
+    Returns:
+        time local clock ahead (+ve) milliseconds, or "Unknown" if delta cannot be determined
+    """
+
+    time_client = getTimeClient()
+
+    if force_client is None:
+        pass
+    else:
+        time_client = force_client
+
+    if time_client =="ntpd":
+        synchronized, uncertainty, ahead_ms = getNTPStatistics()
+        addObsParam(conn, "clock_measurement_source", "ntp")
+        addObsParam(conn, "clock_synchronized", synchronized)
+        addObsParam(conn, "clock_ahead_ms", ahead_ms)
+        addObsParam(conn, "clock_error_uncertainty_ms", uncertainty)
+
+    elif time_client == "chronyd":
+        synchronized, ahead_ms, uncertainty_ms = getChronyUncertainty()
+        addObsParam(conn, "clock_measurement_source", "chrony")
+        addObsParam(conn, "clock_synchronized", synchronized)
+        addObsParam(conn, "clock_ahead_ms", ahead_ms)
+        addObsParam(conn, "clock_error_uncertainty_ms", uncertainty_ms)
+
+    else:
+        addObsParam(conn, "clock_measurement_source", "Not detected")
+        remote_time_query, uncertainty = timestampFromNTP()
+        if remote_time_query is not None:
+            local_time_query = (datetime.datetime.now(timezone.utc) - datetime.datetime(1970, 1, 1).replace(tzinfo=timezone.utc)).total_seconds()
+            ahead_ms = (local_time_query - remote_time_query) * 1000
+            addObsParam(conn, "clock_error_uncertainty_ms", uncertainty * 1000)
+
+        else:
+            ahead_ms, uncertainty = "Unknown", "Unknown"
+            addObsParam(conn, "clock_error_uncertainty_ms", uncertainty)
+        addObsParam(conn, "clock_ahead_ms", ahead_ms)
+
+        result_list = subprocess.run(['timedatectl','status'], capture_output = True).stdout.splitlines()
+
+        for raw_result in result_list:
+            result = raw_result.decode('ascii')
+            if "synchronized" in result:
+                conn = getObsDBConn(config)
+                if result.split(":")[1].strip() == "no":
+                    addObsParam(conn, "clock_synchronized", False)
+                else:
+                    addObsParam(conn, "clock_synchronized", True)
+
+
+    return ahead_ms
+
+def getNTPStatistics():
+
+    """
+    Acquire the statistics of the ntp client.
+    Tries to use ntpstat, if not available, falls back to ntpq, if not available returns Unknown
+
+    Returns:
+        [bool]: true if reported as synchronised
+        [float]: uncertainty in milliseconds
+        [str]: always Unknown, unable to discern actual time error using ntp tools
+
+    """
+
+    try:
+        cmd = ["ntpstat"]
+        lines = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode().strip().splitlines()
+
+        # ntpstat uses the UK spelling of synchronised.
+        synchronized = False
+        if lines[0].startswith("synchronised"):
+            synchronized = True
+        else:
+            synchronized = False
+        # ntpstat return milliseconds rather than base units, do not multiply 1000
+        uncertainty_ms = float(lines[1].split()[4])
+        return synchronized, uncertainty_ms, "Unknown"
+    except:
+        pass
+
+    try:
+        cmd = ["ntpq", '-p']
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode().strip()
+        lines = output.splitlines()
+        for line in lines:
+            if line[0] == "*":
+                fields = line.split()
+                uncertainty =  float(fields[7]) + float(fields[8]) + float(fields[9])
+                return "True", uncertainty, "Unknown"
+    except:
+        pass
+
+    return "Unknown", "Unknown", "Unknown"
+
+
+
+def getChronyUncertainty():
+
+    """
+        Acquire the statistics of the ntp client.
+        Tries to use ntpstat, if not available, falls back to ntpq, if not available returns Unknown
+
+        uncertainty implementation is taken from
+        https://chrony-project.org/doc/3.3/chronyc.html
+
+        Root dispersion
+
+            This is the total dispersion accumulated through all the computers back to the
+            stratum-1 computer from which the computer is ultimately synchronised. Dispersion is due
+            to system clock resolution, statistical measurement variations, etc.
+
+            An absolute bound on the computers clock accuracy (assuming the stratum-1 computer is correct) is given by:
+            clock_error <= |system_time_offset| + root_dispersion + (0.5 * root_delay)
+
+            This is very high at initial synchronisation, as root dispersion dominates.
+
+
+        Returns:
+            [bool]: true if reported as synchronised
+            [float]: uncertainty in milliseconds
+            [str]: time in milliseconds that computer clock is reported to be ahead of superior reference
+
+        """
+
+    synchronized = False
+    system_time_offset, root_dispersion, root_delay = 0, 0, 0
+    try:
+        cmd = ["chronyc", "tracking"]
+        lines = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode().strip().splitlines()
+        ahead_ms = "Unknown"
+
+        for line in lines:
+            if line.startswith("Last offset"):
+                system_time_offset = float(line.split(":")[1].strip().split()[0])
+            if line.startswith("Root dispersion"):
+                root_dispersion = float(line.split(":")[1].strip().split()[0])
+            if line.startswith("Root delay"):
+                root_delay = float(line.split(":")[1].strip().split()[0])
+            if line.startswith("System time"):
+                if "slow" in line:
+                    ahead_ms = 0 - float(line.split(":")[1].strip().split()[0]) * 1000
+                else:
+                    ahead_ms = 0 + float(line.split(":")[1].strip().split()[0]) * 1000
+            if line.startswith("Leap status"):
+                if "Not synchronised" in line:
+                    synchronized = False
+                else:
+                    synchronized = True
+
+        if synchronized:
+            uncertainty_ms = (abs(system_time_offset) + root_dispersion + (0.5 * root_delay)) * 1000
+        else:
+            uncertainty_ms = "Unknown"
+            ahead_ms = "Unknown"
+
+        return synchronized, ahead_ms, uncertainty_ms
+
+    except:
+        return "False", "Unknown", "Unknown"
+
+def timestampFromNTP(addr='time.cloudflare.com'):
+
+    """
+    refer https://stackoverflow.com/questions/36500197/how-to-get-time-from-an-ntp-server
+    and also https://github.com/CroatianMeteorNetwork/RMS/issues/624
+
+
+    Args:
+        addr: optional, address of ntp server to use
+
+    Returns:
+        [float]: time in seconds since epoch
+        [float]: estimated network delay (average of outgoing and return legs)
+    """
+
+
+    REF_TIME_1970 = 2208988800  # Reference time
+    client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    client.settimeout(5)
+    data = b'\x1b' + 47 * b'\0'
+    try:
+        local_clock_transmit_timestamp = time.time()
+        client.sendto(data, (addr, 123))
+        data, address = client.recvfrom(1024)
+        local_clock_receive_timestamp = time.time()
+    except socket.timeout:
+        print("NTP request timed out")
+        return None, None
+    except Exception as e:
+        print("NTP request failed: {}".format(e))
+        return None, None
+    if data:
+
+        # for NTP the fractional seconds is a 32 bit counter
+        fractional_second_factor = ( 1 / 2 ** 32)
+
+
+        # unpack data
+        remote_clock_time_receive_timestamp_seconds = struct.unpack('!12I', data)[8] - REF_TIME_1970
+        remote_clock_time_receive_timestamp_fractional_seconds = struct.unpack('!12I', data)[9] * fractional_second_factor
+
+        remote_clock_time_transmit_timestamp_seconds = struct.unpack('!12I', data)[10] - REF_TIME_1970
+        remote_clock_time_transmit_timestamp_fractional_seconds = struct.unpack('!12I', data)[11] * fractional_second_factor
+
+        remote_clock_time_receive_timestamp = remote_clock_time_receive_timestamp_seconds + remote_clock_time_receive_timestamp_fractional_seconds
+        remote_clock_time_transmit_timestamp = remote_clock_time_transmit_timestamp_seconds + remote_clock_time_transmit_timestamp_fractional_seconds
+
+        local_clock_measured_response_time = (local_clock_receive_timestamp - local_clock_transmit_timestamp)
+        remote_clock_measured_processing_time = (remote_clock_time_transmit_timestamp - remote_clock_time_receive_timestamp)
+
+        # print("Rx Fractional {}, Tx fractional {}".format(remote_clock_time_receive_timestamp_fractional_seconds, remote_clock_time_transmit_timestamp_fractional_seconds))
+        # next calculation assumes that remote and local clock are running at identical rates
+        estimated_network_delay = local_clock_measured_response_time - remote_clock_measured_processing_time
+        if estimated_network_delay < 0:
+            return None, None
+
+        # now calculate estimated clock offsets
+        clock_offset_out_leg = remote_clock_time_receive_timestamp - local_clock_transmit_timestamp
+        clock_offset_return_leg = remote_clock_time_transmit_timestamp - local_clock_receive_timestamp
+        estimated_offset = (clock_offset_out_leg + clock_offset_return_leg) / 2
+        adjusted_time = remote_clock_time_transmit_timestamp + estimated_offset
+        return adjusted_time, estimated_network_delay
+    else:
+        return None, None
 
 def getObsDBConn(config, force_delete=False):
     """ Creates the Observation Summary database. Tries only once.
@@ -114,6 +394,119 @@ def getObsDBConn(config, force_delete=False):
 
     return conn
 
+def addObsParam(conn, key, value):
+
+    """ Add a single key value pair into the database
+
+            arguments:
+                conn: the connection to the database
+                key: the key for the value to be added
+                value: the value to be added
+
+            returns:
+                conn: [connection] connection to database if success else None
+
+            """
+
+
+    sql_statement = ""
+    sql_statement += "INSERT INTO records \n"
+    sql_statement += "(\n"
+    sql_statement += "TimeStamp, Key, Value \n"
+    sql_statement += ")\n\n"
+
+    sql_statement += "VALUES "
+    sql_statement += "(                            \n"
+    sql_statement += "CURRENT_TIMESTAMP,'{}','{}'   \n".format(key, value)
+    sql_statement += ")"
+
+    try:
+        cursor = conn.cursor()
+        cursor.execute(sql_statement)
+        conn.commit()
+
+    except:
+
+        if EM_RAISE:
+            raise
+
+def estimateLens(fov_h):
+
+    """ Estimate the focal length of the lens in use
+
+        arguments:
+                fov_h: horizontal field of view
+
+        returns:
+                an estimate of the focal length of the lens
+
+    """
+
+    lens_types = ["25mm", "16mm", "8mm", "6mm", "4mm"]
+    lens_fov_h = [15, 30, 45, 60, 90]
+    for type, fov in zip(lens_types, lens_fov_h):
+        if fov_h < fov:
+            return type
+    return None
+
+def getLastStartTime(conn):
+    """ Query the database to discover the previous start time
+        arguments:
+                conn: connection to database
+
+        returns:
+                the previous start time
+
+    """
+
+
+    sql_statement = ""
+    sql_statement += "SELECT Value from records \n"
+    sql_statement += "      WHERE Key = 'start_time' \n"
+    sql_statement += "      ORDER BY TimeStamp desc \n"
+
+    result = conn.cursor().execute(sql_statement).fetchone()
+
+    if result is None:
+        sql_statement = ""
+        sql_statement += "SELECT Timestamp from records \n"
+        sql_statement += "  ORDER BY Timestamp asc \n"
+
+        result =  conn.cursor().execute(sql_statement).fetchone()
+
+    return result[0]
+
+def gatherCameraInformation(config, attempts=6, delay=10, sock_timeout=3):
+
+    """ Gather information about the sensor in use
+        Retry the DVRIP handshake until it works, or we exhaust attempts.
+
+                arguments:
+                    config: config object
+                    attempts: optional, default 6, number of attempts to connect
+                    delay: optional, default 10, delay between attempts
+                    sock_timeout: optional, default 3, socket timeout in seconds
+
+                returns:
+                    sensor type string
+
+                """
+
+    ip = re.search(r'(?:\d{1,3}\.){3}\d{1,3}', config.deviceID).group()
+    for _ in range(attempts):
+        try:
+            cam = dvr.DVRIPCam(ip, timeout=sock_timeout)
+            if cam.login():
+                sensor = cam.get_upgrade_info()['Hardware']
+                cam.close()
+                return sensor
+        except (socket.timeout, OSError, ConnectionError):
+            # Camera may still be rebooting - ignore and retry
+            pass
+        time.sleep(delay)
+
+    return "Unavailable"
+
 def captureDirectories(captured_dir, stationID):
     """ Counts the captured directories
 
@@ -139,6 +532,191 @@ def captureDirectories(captured_dir, stationID):
 
     return capture_directories
 
+def nightSummaryData(config, night_data_dir):
+    """ Calculate the summary data for the night. This is based on work by others
+        and translated from the original source code
+
+                arguments:
+                    config: config file
+                    night_data_dir: the directory of captured files
+
+
+                returns:
+                    capture_duration_from_fits: the duration from the start of first fits to the end of the last
+                    fits_count: the count of *.fits files in the directory
+                    fits_file_shortfall: the number of expected fits expected vs the number actually found
+                    fits_file_shortfall_as_time: this shortfall expressed in seconds, never negative
+                    time_first_fits_file: the time of the first fits file
+                    time_last_fits_file: the time of the last fits file
+                    total_expected_fits: the number of fits files expected
+
+                """
+
+    duration_one_fits_file = 256 / config.fps
+    fits_files_list = glob.glob(os.path.join(night_data_dir, "*.fits"))
+    fits_files_list.sort()
+    fits_count = len(fits_files_list)
+    if fits_count < 1:
+        return 0,0,0,0,0,0,0
+
+    time_first_fits_file = datetime.datetime.strptime(filenameToDatetimeStr(os.path.basename(fits_files_list[0])),
+                                                      "%Y-%m-%d %H:%M:%S.%f")
+    time_last_fits_file = datetime.datetime.strptime(filenameToDatetimeStr(
+        os.path.basename(fits_files_list[-1])), "%Y-%m-%d %H:%M:%S.%f")
+    capture_duration_from_fits = (time_last_fits_file - time_first_fits_file).total_seconds() + duration_one_fits_file
+    total_expected_fits = round(capture_duration_from_fits / duration_one_fits_file)
+    fits_file_shortfall = total_expected_fits - fits_count
+    fits_file_shortfall = 0 if fits_file_shortfall < 1 else fits_file_shortfall
+    fits_file_shortfall_as_time = str(datetime.timedelta(seconds=fits_file_shortfall * duration_one_fits_file))
+    return capture_duration_from_fits, fits_count, fits_file_shortfall, fits_file_shortfall_as_time, \
+                        time_first_fits_file, time_last_fits_file, total_expected_fits
+
+def retrieveObservationData(conn, obs_start_time, ordering=None):
+    """ Query the database to get the data more recent than the time passed in.
+        Usually this will be the start of the most recent observation session
+        If no ordering is passed, then a default ordering is returned
+
+            arguments:
+                    conn: connection to database
+                    ordering: optional, default None, sequence to order the keys.
+
+            returns:
+                    key value pairs committed to the database since the obs_start_time
+    """
+
+    if ordering is None:
+        # Be sure to add a comma after each list entry, IDE will not pick up this error as Python will concatenate
+        # the two items into one.
+
+        ordering = ['stationID',
+                    'commit_date', 'commit_hash','media_backend',
+                    'hardware_version',
+                    'captured_directories',
+                    'storage_used_gb', 'storage_free_gb', 'storage_total_gb',
+                    'camera_lens','camera_fov_h','camera_fov_v',
+                    'camera_pointing_alt','camera_pointing_az',
+                    'camera_information',
+                    'clock_measurement_source', 'clock_synchronized', 'clock_ahead_ms', 'clock_error_uncertainty_ms',
+                    'start_time', 'duration', 'photometry_good',
+                    'time_first_fits_file', 'time_last_fits_file', 'total_expected_fits','total_fits',
+                    'fits_files_from_duration','fits_file_shortfall', 'fits_file_shortfall_as_time',
+                    'capture_duration_from_fits',
+                    'detections_after_ml',
+                    'media_backend','jitter_quality','dropped_frame_rate']
+
+    # use this print call to check the ordering
+    #print("Ordering {}".format(ordering))
+
+    sql_statement = ""
+    sql_statement += "SELECT Key, Value from records \n"
+    sql_statement += "           WHERE TimeStamp >= '{}' \n".format(obs_start_time)
+    sql_statement += "           GROUP BY KEY \n"
+    sql_statement += "           ORDER BY \n"
+    sql_statement += "              CASE Key \n"
+
+    # This SQL applies an ordering to all the keys in the ordering list. Any extra keys will be at the end.
+    count = 1
+    for ordering_key in ordering:
+        sql_statement += "                  WHEN '{:s}' THEN {:03d} \n".format(ordering_key,count)
+        count += 1
+
+    sql_statement += "                  ELSE {:03d} \n".format(count)
+    sql_statement += "              END"
+
+    #print(sql_statement)
+
+    return conn.cursor().execute(sql_statement).fetchall()
+
+def serialize(config, format_nicely=True, as_json=False):
+    """ Returns the data from the most recent observation session as either colon
+        delimited text file, ar as a json
+                arguments:
+                        config: station config file
+                        format_nicely: optional, default true, present the data with
+                                        delimiter characters aligned
+                        as_json: optional, default false, return the data as a json
+
+                returns:
+                        string of key value pairs committed to the database since the
+                        start of the previous observation session
+        """
+
+    conn = getObsDBConn(config)
+    data = retrieveObservationData(conn, getLastStartTime(conn))
+    conn.close()
+
+    if as_json:
+        return json.dumps(dict(data), default=lambda o: o.__dict__, indent=4, sort_keys=True)
+
+    output = ""
+    for key,value in data:
+        #does this look like a float
+        if not re.match(r'^-?\d+(?:\.\d+)$', value) is None:
+            # handle as float
+            try:
+                value_as_float = float(value)
+                output += "{}:{:s} \n".format(key, roundWithoutTrailingZero(value_as_float, 3))
+            except:
+                pass
+        else:
+            try:
+                # convert to a time
+                time_object = time.strptime(value, "%Y-%m-%d %H:%M:%S.%f")
+                value_as_time = strftime("%Y-%m-%d %H:%M:%S", time_object)
+                output += "{}:{:s} \n".format(key, value_as_time)
+
+            except:
+                try:
+                # convert to a time
+                    time_object = time.strptime(value, "%H:%M:%S.%f")
+                    value_as_time = strftime("%H:%M:%S", time_object)
+                    output += "{}:{:s} \n".format(key, value_as_time)
+                    # if it didn't work, then handle as a string
+                except:
+                    pass
+                    try:
+                        output += "{}:{:s} \n".format(key, value)
+                    except:
+                        # if we can't output as a string, then move on
+                        pass
+
+    if format_nicely:
+        return niceFormat(output)
+
+
+    return output
+
+def writeToFile(config, file_path_and_name):
+    """Write colon delimited text to file
+                arguments:
+                        config: station config file
+                        file_path_and_name: full path to the target file
+
+                returns:
+                        string of key value pairs committed to the database since the
+                        start of the previous observation session
+        """
+
+
+    with open(file_path_and_name, "w") as summary_file_handle:
+        as_ascii = serialize(config).encode("ascii", errors="ignore").decode("ascii")
+        summary_file_handle.write(as_ascii)
+
+
+def writeToJSON(config, file_path_and_name):
+    """Write as a json
+                    arguments:
+                            config: station config file
+                            file_path_and_name: full path to the target file
+
+                    returns:
+                            string of key value pairs committed to the database since the
+                            start of the previous observation session
+            """
+    with open(file_path_and_name, "w") as summary_file_handle:
+        as_ascii = serialize(config, as_json=True).encode("ascii", errors="ignore").decode("ascii")
+        summary_file_handle.write(as_ascii)
+
 def startObservationSummaryReport(config, duration, force_delete=False):
     """ Enters the parameters known at the start of observation into the database
 
@@ -154,7 +732,7 @@ def startObservationSummaryReport(config, duration, force_delete=False):
 
 
     conn = getObsDBConn(config, force_delete=force_delete)
-    addObsParam(conn, "start_time", datetime.datetime.utcnow() - datetime.timedelta(seconds=1))
+    addObsParam(conn, "start_time", (datetime.datetime.now(timezone.utc) - datetime.timedelta(seconds=1)).replace(tzinfo=timezone.utc))
     addObsParam(conn, "duration", duration)
     addObsParam(conn, "stationID", sanitise(config.stationID, space_substitution=""))
 
@@ -210,73 +788,6 @@ def startObservationSummaryReport(config, duration, force_delete=False):
 
     return "Opening a new observations summary for duration {} seconds".format(duration)
 
-def timestampFromNTP(addr='0.us.pool.ntp.org'):
-
-    """
-    refer https://stackoverflow.com/questions/36500197/how-to-get-time-from-an-ntp-server
-
-    Args:
-        addr: optional, address of ntp server to use
-
-    Returns:
-        [int]: time in seconds since epoch
-    """
-
-
-    REF_TIME_1970 = 2208988800  # Reference time
-    client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    client.settimeout(5)
-    data = b'\x1b' + 47 * b'\0'
-    try:
-        client.sendto(data, (addr, 123))
-        data, address = client.recvfrom(1024)
-    except socket.timeout:
-        print("NTP request timed out")
-        return None
-    except Exception as e:
-        print("NTP request failed: {}".format(e))
-        return None
-    if data:
-        t = struct.unpack('!12I', data)[10]
-        t -= REF_TIME_1970
-        return t
-    else:
-        return None
-
-def timeSyncStatus(config):
-
-    """
-
-    Determine approximate time sync error and report on status. Any error of fewer than ten seconds
-    may be caused by imprecision in the remote time query
-
-    Args:
-        config: configuration object
-
-    Returns:
-        Approximate time error in seconds
-    """
-
-    remote_time_query = timestampFromNTP()
-    if remote_time_query is not None:
-        local_time_query = (datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds()
-        time_error_seconds = round(abs(local_time_query - remote_time_query),1)
-        print("Approximate time error is {}".format(time_error_seconds))
-    else:
-        time_error_seconds = "Unknown"
-
-    result_list = subprocess.run(['timedatectl','status'], capture_output = True).stdout.splitlines()
-    #print(result_list)
-    for raw_result in result_list:
-        result = raw_result.decode('ascii')
-        if "synchronized" in result:
-            conn = getObsDBConn(config)
-            addObsParam(conn, "clock_synchronized", result.split(":")[1].strip())
-            addObsParam(conn, "clock_error_seconds", time_error_seconds)
-            conn.close()
-
-    return time_error_seconds
-
 def finalizeObservationSummary(config, night_data_dir, platepar=None):
 
     """ Enters the parameters known at the end of observation into the database
@@ -294,12 +805,15 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     capture_duration_from_fits, fits_count, fits_file_shortfall, fits_file_shortfall_as_time, time_first_fits_file, \
         time_last_fits_file, total_expected_fits = nightSummaryData(config, night_data_dir)
 
+
+
+    obs_db_conn = getObsDBConn(config)
+
     try:
-        timeSyncStatus(config)
+        timeSyncStatus(config, obs_db_conn)
     except Exception as e:
         print(repr(e))
 
-    obs_db_conn = getObsDBConn(config)
     platepar_path = os.path.join(config.config_file_path, config.platepar_name)
     if os.path.exists(platepar_path):
         platepar = Platepar()
@@ -330,261 +844,10 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
 
 
 
-def nightSummaryData(config, night_data_dir):
-    """ Calculate the summary data for the night. This is based on work by others
-        and translated from the original source code
-
-                arguments:
-                    config: config file
-                    night_data_dir: the directory of captured files
-
-
-                returns:
-                    capture_duration_from_fits: the duration from the start of first fits to the end of the last
-                    fits_count: the count of *.fits files in the directory
-                    fits_file_shortfall: the number of expected fits expected vs the number actually found
-                    fits_file_shortfall_as_time: this shortfall expressed in seconds, never negative
-                    time_first_fits_file: the time of the first fits file
-                    time_last_fits_file: the time of the last fits file
-                    total_expected_fits: the number of fits files expected
-
-                """
-
-    duration_one_fits_file = 256 / config.fps
-    fits_files_list = glob.glob(os.path.join(night_data_dir, "*.fits"))
-    fits_files_list.sort()
-    fits_count = len(fits_files_list)
-    if fits_count < 1:
-        return 0,0,0,0,0,0,0
-
-    time_first_fits_file = datetime.datetime.strptime(filenameToDatetimeStr(os.path.basename(fits_files_list[0])),
-                                                      "%Y-%m-%d %H:%M:%S.%f")
-    time_last_fits_file = datetime.datetime.strptime(filenameToDatetimeStr(
-        os.path.basename(fits_files_list[-1])), "%Y-%m-%d %H:%M:%S.%f")
-    capture_duration_from_fits = (time_last_fits_file - time_first_fits_file).total_seconds() + duration_one_fits_file
-    total_expected_fits = round(capture_duration_from_fits / duration_one_fits_file)
-    fits_file_shortfall = total_expected_fits - fits_count
-    fits_file_shortfall = 0 if fits_file_shortfall < 1 else fits_file_shortfall
-    fits_file_shortfall_as_time = str(datetime.timedelta(seconds=fits_file_shortfall * duration_one_fits_file))
-    return capture_duration_from_fits, fits_count, fits_file_shortfall, fits_file_shortfall_as_time, \
-                        time_first_fits_file, time_last_fits_file, total_expected_fits
-
-
-def addObsParam(conn, key, value):
-
-    """ Add a single key value pair into the database
-
-            arguments:
-                conn: the connection to the database
-                key: the key for the value to be added
-                value: the value to be added
-
-            returns:
-                conn: [connection] connection to database if success else None
-
-            """
-
-
-    sql_statement = ""
-    sql_statement += "INSERT INTO records \n"
-    sql_statement += "(\n"
-    sql_statement += "TimeStamp, Key, Value \n"
-    sql_statement += ")\n\n"
-
-    sql_statement += "VALUES "
-    sql_statement += "(                            \n"
-    sql_statement += "CURRENT_TIMESTAMP,'{}','{}'   \n".format(key, value)
-    sql_statement += ")"
-
-    try:
-        cursor = conn.cursor()
-        cursor.execute(sql_statement)
-        conn.commit()
-
-    except:
-
-        if EM_RAISE:
-            raise
-
-
-
-def gatherCameraInformation(config, attempts=6, delay=10, sock_timeout=3):
-
-    """ Gather information about the sensor in use
-        Retry the DVRIP handshake until it works or we exhaust attempts.
-
-                arguments:
-                    config: config object
-                    attempts: optional, default 6, number of attempts to connect
-                    delay: optional, default 10, delay between attempts
-                    sock_timeout: optional, default 3, socket timeout in seconds
-
-                returns:
-                    sensor type string
-
-                """
-
-    ip = re.search(r'(?:\d{1,3}\.){3}\d{1,3}', config.deviceID).group()
-    for _ in range(attempts):
-        try:
-            cam = dvr.DVRIPCam(ip, timeout=sock_timeout)
-            if cam.login():
-                sensor = cam.get_upgrade_info()['Hardware']
-                cam.close()
-                return sensor
-        except (socket.timeout, OSError, ConnectionError):
-            # Camera may still rebooting - ignore and retry
-            pass
-        time.sleep(delay)
-
-    return "Unavailable"
-
-def estimateLens(fov_h):
-
-    """ Estimate the focal length of the lens in use
-
-        arguments:
-                fov_h: horizontal field of view
-
-        returns:
-                an estimate of the focal length of the lens
-
-    """
-
-    lens_types = ["25mm", "16mm", "8mm", "6mm", "4mm"]
-    lens_fov_h = [15, 30, 45, 60, 90]
-    for type, fov in zip(lens_types, lens_fov_h):
-        if fov_h < fov:
-            return type
-    return None
-
-def getLastStartTime(conn):
-    """ Query the database to discover the previous start time
-        arguments:
-                conn: connection to database
-
-        returns:
-                the previous start time
-
-    """
-
-
-    sql_statement = ""
-    sql_statement += "SELECT Value from records \n"
-    sql_statement += "      WHERE Key = 'start_time' \n"
-    sql_statement += "      ORDER BY TimeStamp desc \n"
-
-    result = conn.cursor().execute(sql_statement).fetchone()
-
-    if result is None:
-        sql_statement = ""
-        sql_statement += "SELECT Timestamp from records \n"
-        sql_statement += "  ORDER BY Timestamp asc \n"
-
-        result =  conn.cursor().execute(sql_statement).fetchone()
-
-    return result[0]
-
-def retrieveObservationData(conn, obs_start_time):
-    """ Query the database to get the data more recent than the time passed in.
-        Usually this will be the start of the most recent observation session
-            arguments:
-                    conn: connection to database
-
-            returns:
-                    key value pairs committed to the database since the obs_start_time
-    """
-
-    sql_statement = ""
-    sql_statement += "SELECT Key, Value from records \n"
-    sql_statement += "           WHERE TimeStamp >= '{}' \n".format(obs_start_time)
-    sql_statement += "           GROUP BY Key \n"
-
-    return conn.cursor().execute(sql_statement).fetchall()
-
-
-def serialize(config, format_nicely=True, as_json=False):
-    """ Returns the data from the most recent observation session as either colon
-        delimited text file, ar as a json
-                arguments:
-                        config: station config file
-                        format_nicely: optional, default true, present the data with
-                                        delimeter characters aligned
-                        as_json: optional, default false, return the data as a json
-
-                returns:
-                        string of key value pairs committed to the database since the
-                        start of the previous observation session
-        """
-
-    conn = getObsDBConn(config)
-    data = retrieveObservationData(conn, getLastStartTime(conn))
-    conn.close()
-
-    if as_json:
-        return json.dumps(dict(data), default=lambda o: o.__dict__, indent=4, sort_keys=True)
-
-    output = ""
-    for key,value in data:
-        output += "{}:{} \n".format(key,value)
-
-    if format_nicely:
-        return niceFormat(output)
-
-
-    return output
-
-
-def writeToFile(config, file_path_and_name):
-    """Write colon delimited text to file
-                arguments:
-                        config: station config file
-                        file_path_and_name: full path to the target file
-
-                returns:
-                        string of key value pairs committed to the database since the
-                        start of the previous observation session
-        """
-
-
-    with open(file_path_and_name, "w") as summary_file_handle:
-        as_ascii = serialize(config).encode("ascii", errors="ignore").decode("ascii")
-        summary_file_handle.write(as_ascii)
-
-
-def writeToJSON(config, file_path_and_name):
-    """Write colon delimited text to file as a json
-                    arguments:
-                            config: station config file
-                            file_path_and_name: full path to the target file
-
-                    returns:
-                            string of key value pairs committed to the database since the
-                            start of the previous observation session
-            """
-    with open(file_path_and_name, "w") as summary_file_handle:
-        as_ascii = serialize(config, as_json=True).encode("ascii", errors="ignore").decode("ascii")
-        summary_file_handle.write(as_ascii)
-
-
-
-
-def readFromFile(self, file_path_and_name):
-    # todo: this is required at server end
-    string = ""
-    return string
-
-
-def unserialize(self):
-    # todo: this is required at server end
-    return self
-
-
 if __name__ == "__main__":
 
     config = parse(os.path.expanduser("~/source/RMS/.config"))
 
-    timeSyncStatus(config)
     obs_db_conn = getObsDBConn(config)
     startObservationSummaryReport(config, 100, force_delete=False)
     pp = Platepar()

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -605,7 +605,7 @@ def retrieveObservationData(conn, obs_start_time, ordering=None):
                     'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate']
 
     # use this print call to check the ordering
-    print("Ordering {}".format(ordering))
+    #print("Ordering {}".format(ordering))
 
     sql_statement = ""
     sql_statement += "SELECT Key, Value from records \n"


### PR DESCRIPTION
This PR relates to issue #641 and reduces the precision of the observation summary file, and uses the features of chrony, ntpstat, ntpq, or a fallback to a direct query on a remote time server to estimate time error and uncertainty. 

The values added are 

```
clock_measurement_source        : chrony 
clock_synchronized              : True 
clock_ahead_ms                  : 1.817 
clock_error_uncertainty_ms      : 47.129 
```

The keys are ordered to improve readability.

```
stationID                       : AU002C 
commit_date                     : 20250615_071249 
commit_hash                     : 115ff0e8985978044a7fa3415dd4867c59757c0f 
hardware_version                : x86_64 
captured_directories            : 24 
storage_used_gb                 : 2405.52 
storage_free_gb                 : 1073.25 
storage_total_gb                : 3665.02 
camera_lens                     : 6mm 
camera_fov_h                    : 53.69 
camera_fov_v                    : 29.978 
camera_pointing_alt             : 40.72 degrees 
camera_pointing_az              : 108.33 degrees 
camera_information              : 50H20L 
clock_measurement_source        : chrony 
clock_synchronized              : True 
clock_ahead_ms                  : 1.817 
clock_error_uncertainty_ms      : 47.129 
start_time                      : 2025-06-15 07:14:32.220349+00:00 
duration                        : 100 
time_first_fits_file            : 2025-05-27 10:20:14 
time_last_fits_file             : 2025-05-27 12:24:24 
total_expected_fits             : 728 
total_fits                      : 720 
fits_files_from_duration        : 9.759 
fits_file_shortfall             : 8 
fits_file_shortfall_as_time     : 00:01:21 
capture_duration_from_fits      : 7459.98 
```