### PR TITLE
Refresh current time before computing time to wait

### DIFF
--- a/RMS/CaptureModeSwitcher.py
+++ b/RMS/CaptureModeSwitcher.py
@@ -105,7 +105,10 @@ def captureModeSwitcher(config, daytime_mode, camera_mode_switch_trigger):
                         camera_mode_switch_trigger.value = True
 
                     daytime_mode.value = True
-                    time_to_wait = (next_set - current_time).total_seconds()
+
+                    # Refresh the current time after the stagger wait
+                    now = RmsDateTime.utcnow()
+                    time_to_wait = max(0, (next_set - now).total_seconds())
 
                 else:
                     log.info("Next event is a sunrise ({}), switching to nighttime mode".format(next_rise))
@@ -119,7 +122,10 @@ def captureModeSwitcher(config, daytime_mode, camera_mode_switch_trigger):
                         camera_mode_switch_trigger.value = True
 
                     daytime_mode.value = False
-                    time_to_wait = (next_rise - current_time).total_seconds()
+                    
+                    # Refresh the current time after the stagger wait
+                    now = RmsDateTime.utcnow()
+                    time_to_wait = max(0, (next_set - now).total_seconds())
 
 
             # If the day last more than 24 hours, continue daytime capture for the whole day


### PR DESCRIPTION
Currently, there is an error when computing the time_to_wait before switching mode if capture_wait_seconds is not zero (used to stagger switching in a multi-camera setup). The time_to_wait uses a current_time that is no longer current by the time of the calculation. 

This PR uses a fresh current time.