### PR TITLE
Calculate the shortfall in fits files with reference to ephemeris calculations

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -29,23 +29,23 @@ from __future__ import print_function, division, absolute_import
 import sys
 import os
 import subprocess
-import time
-import datetime
-from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
-import re
-import sqlite3
-from RMS.ConfigReader import parse
-
 import platform
 import git
 import shutil
-
 import glob
 import json
-
-
-from RMS.Formats.FFfits import filenameToDatetimeStr
+import re
+import sqlite3
 import datetime
+import socket
+import struct
+import sys
+import time
+import tempfile
+
+from RMS.ConfigReader import parse
+from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
+from RMS.Formats.FFfits import filenameToDatetimeStr
 from RMS.Formats.Platepar import Platepar
 
 if sys.version_info.major > 2:
@@ -56,11 +56,6 @@ else:
 
 EM_RAISE = True
 
-import socket
-import struct
-import sys
-import time
-import tempfile
 
 def roundWithoutTrailingZero(value, no):
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -26,10 +26,13 @@
 from __future__ import print_function, division, absolute_import
 
 
-import sys
+
 import os
+import sys
+import socket
 import subprocess
 import platform
+
 import git
 import shutil
 import glob
@@ -37,9 +40,8 @@ import json
 import re
 import sqlite3
 import datetime
-import socket
+
 import struct
-import sys
 import time
 import tempfile
 

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -812,7 +812,7 @@ if __name__ == "__main__":
             log.info("Using all available cores for detection.")
 
 
-    duration, _,_,_,_,_,_, = nightSummaryData(config, cml_args.dir_path[0])
+    duration, _,_,_,_,_,_,_,_,_,_ = nightSummaryData(config, cml_args.dir_path[0])
     log.info(startObservationSummaryReport(config, duration, force_delete=False))
     # Process the night
     _, archive_name, detector = processNight(cml_args.dir_path[0], config)


### PR DESCRIPTION
This PR addresses issue #659 

Expected numbers of fits are calculated on the basis of the ephemeris calculations for either night time only, or approximated for continuous capture. 