### PR TITLE
Correct message in FirstRun

### DIFF
--- a/Scripts/RMS_FirstRun.sh
+++ b/Scripts/RMS_FirstRun.sh
@@ -3,7 +3,7 @@
 echo "Waiting 10 seconds to init the Pi..."
 echo ""
 echo "IMPORTANT: RMS will first update itself."
-echo "Do not touch any file during the update and do not close this window until RMS starts."
+echo "Do not touch any file during the update and do not close this window even after RMS starts"
 sleep 12
 
 # Google DNS server IP


### PR DESCRIPTION
Update message in RMS_FirstRun to state that the window must not be closed even after RMS starts. Currently it says until, implying you can close the window once RMS starts, and this sometimes causes users to inadvertently close the window. Of course, closing it will in fact kill RMS. 