### PR TITLE
Fix missing SITE_DIR bug in scripts not calling the logger

### DIFF
--- a/RMS/Astrometry/ApplyRecalibrate.py
+++ b/RMS/Astrometry/ApplyRecalibrate.py
@@ -34,7 +34,7 @@ from RMS.Astrometry.FFTalign import alignPlatepar
 from RMS.Formats import CALSTARS, FFfile, FTPdetectinfo, Platepar, StarCatalog
 from RMS.Formats.FTPdetectinfo import findFTPdetectinfoFile, validDefaultFTPdetectinfo
 from RMS.Math import angularSeparation
-from RMS.Logger import initLogging, getLogger
+from RMS.Logger import LoggingManager, getLogger
 from RMS.Misc import RmsDateTime
 
 # Neighbourhood size around individual FFs with detections which will be takes for recalibration
@@ -1255,7 +1255,8 @@ if __name__ == "__main__":
     config = cr.loadConfigFromDirectory(cml_args.config, dir_path)
 
     # Initialize the logger
-    initLogging(config, 'recalibrate_', safedir=dir_path)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'recalibrate_', safedir=dir_path)
 
     # Get the logger handle
     log = getLogger("logger", level="INFO")

--- a/RMS/Astrometry/CheckFit.py
+++ b/RMS/Astrometry/CheckFit.py
@@ -24,7 +24,7 @@ from RMS.Astrometry.Conversions import date2JD, jd2Date, raDec2AltAz
 from RMS.Astrometry.FFTalign import alignPlatepar
 from RMS.Formats import CALSTARS, FFfile, Platepar, StarCatalog
 from RMS.Math import angularSeparation
-from RMS.Logger import initLogging, getLogger
+from RMS.Logger import LoggingManager, getLogger
 
 pyximport.install(setup_args={'include_dirs':[np.get_include()]})
 from RMS.Astrometry.CyFunctions import matchStars, subsetCatalog
@@ -719,7 +719,8 @@ if __name__ == "__main__":
     config = cr.loadConfigFromDirectory(cml_args.config, dir_path)
 
     # Initialize the logger
-    initLogging(config, 'checkfit_', safedir=dir_path)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'checkfit_', safedir=dir_path)
 
     # Get the logger handle
     log = getLogger("logger", level="INFO")

--- a/RMS/Astrometry/FFTalign.py
+++ b/RMS/Astrometry/FFTalign.py
@@ -28,7 +28,7 @@ from RMS.Formats.FFfile import getMiddleTimeFF
 from RMS.Formats import Platepar
 from RMS.Formats import StarCatalog
 from RMS.Math import rotatePoint
-from RMS.Logger import initLogging, getLogger
+from RMS.Logger import LoggingManager, getLogger
 
 # Import Cython functions
 import pyximport
@@ -384,7 +384,8 @@ if __name__ == "__main__":
     config = cr.loadConfigFromDirectory(cml_args.config, dir_path)
 
     # Initialize the logger
-    initLogging(config, 'fftalign_')
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'fftalign_')
 
     # Get the logger handle
     log = getLogger("logger", level="INFO")

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -42,7 +42,7 @@ from RMS.Formats.ObservationSummary import getObsDBConn, addObsParam
 from RMS.RawFrameSave import RawFrameSaver
 from RMS.Misc import RmsDateTime, mkdirP, UTCFromTimestamp
 from RMS.Formats import FTfile, FTStruct
-from RMS.Logger import getLogger, gstDebugLogger
+from RMS.Logger import LoggingManager, getLogger, gstDebugLogger
 from RMS.CaptureModeSwitcher import switchCameraMode
 import Utils.CameraControl as cc
 
@@ -2050,7 +2050,6 @@ if __name__ == "__main__":
     import multiprocessing
 
     import RMS.ConfigReader as cr
-    from RMS.Logger import initLogging
 
     ###
 
@@ -2072,7 +2071,8 @@ if __name__ == "__main__":
     config = cr.loadConfigFromDirectory(cml_args.config, os.path.abspath('.'))
 
     # Initialize the logger
-    initLogging(config)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config)
 
     # Get the logger handle
     log = getLogger("logger")

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -16,7 +16,7 @@ import ephem
 
 from RMS.CaptureDuration import captureDuration
 from RMS.ConfigReader import loadConfigFromDirectory
-from RMS.Logger import initLogging, getLogger
+from RMS.Logger import LoggingManager, getLogger
 from RMS.Misc import RmsDateTime, UTCFromTimestamp
 
 # Get the logger from the main module
@@ -1154,7 +1154,8 @@ if __name__ == '__main__':
     config = loadConfigFromDirectory(cfg_file, cfg_path)
 
     # Initialize the logger
-    initLogging(config)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config)
     log = getLogger("logger")
 
     if not os.path.isdir(config.data_dir):

--- a/RMS/DetectStarsAndMeteors.py
+++ b/RMS/DetectStarsAndMeteors.py
@@ -35,7 +35,7 @@ from RMS.ExtractStarsFrameInterface import extractStarsFrameInterface
 from RMS.Detection import detectMeteors
 from RMS.DetectionTools import loadImageCalibration
 from RMS.QueuedPool import QueuedPool
-from RMS.Logger import getLogger
+from RMS.Logger import LoggingManager, getLogger
 from RMS.Misc import RmsDateTime
 
 
@@ -489,9 +489,8 @@ if __name__ == "__main__":
 
 
     ### Init the logger
-
-    from RMS.Logger import initLogging
-    initLogging(config, 'detection_', safedir=cml_args.dir_path)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'detection_', safedir=cml_args.dir_path)
 
     log = getLogger("logger")
 

--- a/RMS/Detection.py
+++ b/RMS/Detection.py
@@ -43,7 +43,7 @@ from RMS.Formats import FFfile
 from RMS.Formats import FTPdetectinfo
 from RMS.Formats.FrameInterface import detectInputType
 from RMS.Formats.AST import loadAST
-from RMS.Logger import getLogger
+from RMS.Logger import LoggingManager, getLogger
 from RMS.Misc import mkdirP
 from RMS.Routines.Grouping3D import find3DLines, getAllPoints
 from RMS.Routines.CompareLines import compareLines
@@ -1739,8 +1739,8 @@ if __name__ == "__main__":
 
     ### Init the logger
 
-    from RMS.Logger import initLogging
-    initLogging(config, 'detection_', safedir=os.path.dirname(cml_args.dir_path[0]))
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'detection_', safedir=os.path.dirname(cml_args.dir_path[0]))
 
     log = getLogger("logger")
 

--- a/RMS/DownloadMask.py
+++ b/RMS/DownloadMask.py
@@ -19,20 +19,20 @@ These are the default settings hard coded into ConfigReader.py
 
 from __future__ import print_function, division, absolute_import
 
-import logging
 import os
 from os.path import exists as file_exists
 
 import paramiko
 
 
-from RMS.UploadManager import getSSHAndSFTP, existsRemoteDirectory, createRemoteDirectory
+from RMS.Logger import LoggingManager, getLogger
 from RMS.Misc import RmsDateTime
+from RMS.UploadManager import getSSHAndSFTP, existsRemoteDirectory, createRemoteDirectory
 
 
 
 # Get the logger from the main module
-log = logging.getLogger("logger")
+log = getLogger("logger")
 
 
 
@@ -175,7 +175,6 @@ def downloadNewMask(config):
 
 if __name__ == "__main__":
 
-    from RMS.Logger import initLogging
     import RMS.ConfigReader as cr
 
     import argparse
@@ -193,7 +192,8 @@ if __name__ == "__main__":
     config = cr.loadConfigFromDirectory(cml_args.config, os.path.abspath('.'))
 
     # Init the logger
-    initLogging(config)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config)
 
 
     # Test mask downloading

--- a/RMS/DownloadPlatepar.py
+++ b/RMS/DownloadPlatepar.py
@@ -2,18 +2,18 @@
 
 from __future__ import print_function, division, absolute_import
 
-import logging
 import os
 from os.path import exists as file_exists
 
 import paramiko
 
 
-from RMS.UploadManager import getSSHAndSFTP
+from RMS.Logger import LoggingManager, getLogger
 from RMS.Misc import RmsDateTime
+from RMS.UploadManager import getSSHAndSFTP
 
 # Get the logger from the main module
-log = logging.getLogger("logger")
+log = getLogger("logger")
 
 
 
@@ -98,8 +98,6 @@ def downloadNewPlatepar(config):
 
 if __name__ == "__main__":
 
-    from RMS.Logger import initLogging
-
     # Set up a fake config file
     class FakeConf(object):
         def __init__(self):
@@ -125,7 +123,8 @@ if __name__ == "__main__":
     config = FakeConf()
 
     # Init the logger
-    initLogging(config)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config)
 
 
     # Test platepar downloading

--- a/RMS/Logger.py
+++ b/RMS/Logger.py
@@ -74,11 +74,6 @@ else:
 if not os.getenv('GST_DEBUG', default=None):
     os.environ['GST_DEBUG'] = '2'
 
-_rms_logging_queue = None
-_rms_listener_process = None
-_rms_init_lock = threading.Lock()
-_rms_logger_initialized = False
-
 # Add a default stderr handler for pre-initialization log messages
 _default_handler = logging.StreamHandler(sys.stderr)
 _default_formatter = logging.Formatter('%(message)s')
@@ -87,15 +82,18 @@ _pre_init_logger = logging.getLogger()
 _pre_init_logger.addHandler(_default_handler)
 _pre_init_logger.setLevel(logging.INFO)
 
-# Initialize set of directories to filter in
-ALLOWED_DIRS = set()
-
-# This handler will be removed when proper logging is initialized
-
-
 ##############################################################################
 # HELPERS
 ##############################################################################
+class LevelRespectingQueueListener(logging.handlers.QueueListener):
+    """QueueListener that respects individual handler levels."""
+    def handle(self, record):
+        """Override to check handler levels before handling."""
+        record = self.prepare(record)
+        for handler in self.handlers:
+            if record.levelno >= handler.level:  # Check handler level
+                handler.handle(record)
+
 
 class LoggerWriter:
     """ Used to redirect stdout/stderr to the log.
@@ -274,50 +272,181 @@ def gstDebugLogger(category, level, file, function, line, obj, message, user_dat
 ##############################################################################
 
 class CustomHandler(logging.handlers.TimedRotatingFileHandler):
-    """ Custom handler for rotating log files.
-    
-    The live file: log_XX0000_20241229_112347.log
-    On rollover: log_XX0000_20241229_112347-[29_1123-to-30_1123].log
     """
-    def __init__(self, station_id, start_time_str, *args, **kwargs):
+    Custom handler for rotating log files where the new file's name
+    reflects the start time of the new logging period, without renaming old files.
+    
+    On rollover, it closes the current log file and creates a new one with a
+    filename timestamped to the beginning of the new logging interval.
+    """
+    def __init__(self, station_id, log_file_prefix, filename, when='H', interval=24, utc=True, **kwargs):
+        """
+        Initializes the handler.
+        
+        Args:
+            station_id (str): The station ID to embed in the filename.
+            log_file_prefix (str): A prefix for the log filename.
+            filename (str): The initial full path to the log file.
+            when, interval, utc, **kwargs: Standard TimedRotatingFileHandler arguments.
+        """
         self.station_id = station_id
-        self.start_time_str = start_time_str
-        super(CustomHandler, self).__init__(*args, **kwargs)
-        self.suffix = "%Y%m%d_%H%M%S"
-        self.namer = self._rename_on_rollover
+        self.log_file_prefix = log_file_prefix
 
-    def _rename_on_rollover(self, default_name):
-        # Parse the default filename
-        base_dir, base_file = os.path.split(default_name)
-        base_noext, dot, start_time_str = base_file.rpartition('.')
+        # The namer/rotator attributes are not used since we override doRollover.
+        super(CustomHandler, self).__init__(
+            filename=filename, when=when, interval=interval, utc=utc, **kwargs
+        )
+
+    def doRollover(self):
+        """
+        Handles rollover by closing the current file and opening a new one with an
+        updated timestamp in its name.
+        """
+        # Close the current file stream
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        # The 'rolloverAt' time is the scheduled time for the rollover, which is
+        # the exact start time for the new log file.
+        rollover_time_s = self.rolloverAt
         
-        if base_noext.endswith('.log'):
-            base_noext = base_noext[:-4]
+        if self.utc:
+            time_tuple = time.gmtime(rollover_time_s)
+        else:
+            time_tuple = time.localtime(rollover_time_s)
         
-        # Calculate time range for the log file
-        start_time = datetime.datetime.strptime(start_time_str, "%Y%m%d_%H%M%S")
-        end_time = UTCFromTimestamp.utcfromtimestamp(self.rolloverAt)
+        # Format the time for the new filename
+        new_time_str = time.strftime("%Y%m%d_%H%M%S", time_tuple)
+
+        # Construct the new base filename in the same directory.
+        # This is the crucial step that changes the name of the NEXT log file.
+        self.baseFilename = os.path.join(
+            os.path.dirname(self.baseFilename),
+            "{}log_{}_{}.log".format(self.log_file_prefix, self.station_id, new_time_str)
+        )
         
-        # Format the new filename with time range
-        start_str = start_time.strftime("%d_%H%M")
-        end_str = end_time.strftime("%d_%H%M")
-        new_name = "{}-[{}-to-{}].log".format(base_noext, start_str, end_str)
+        # Open the new log file stream using the updated baseFilename.
+        self.stream = self._open()
+
+        # Calculate the time for the next rollover.
+        # This logic is adapted from the standard library to ensure correctness.
+        currentTime = int(time.time())
+        newRolloverAt = self.computeRollover(currentTime)
+        while newRolloverAt <= currentTime:
+            newRolloverAt = newRolloverAt + self.interval
+
+        # Handle potential Daylight Saving Time shifts for certain rollover schedules
+        if (self.when == 'MIDNIGHT' or self.when.startswith('W')) and not self.utc:
+            dstNow = time.localtime(currentTime)[-1]
+            dstAtRollover = time.localtime(newRolloverAt)[-1]
+            if dstNow != dstAtRollover:
+                if not dstNow:
+                    addend = -3600
+                else:
+                    addend = 3600
+                newRolloverAt += addend
         
-        return os.path.join(base_dir, new_name)
+        self.rolloverAt = newRolloverAt
+
+
+
+class LoggingManager:
+    """Manages the lifecycle of the multiprocessing logger."""
+    def __init__(self):
+        self.logging_queue = None
+        self.listener_process = None
+        self.is_initialized = False
+        self.init_lock = threading.Lock()
+
+    def initLogging(self, config, log_file_prefix="", safedir=None, 
+                    console_level=logging.INFO, file_level=logging.DEBUG):
+        """ 
+        Spawns the listener process and configures logging. This method is designed to be called once in 
+        the main process.
+        
+        Arguments:
+            config: [Config] Configuration object.
+
+        Keyword Arguments:
+            log_file_prefix: [str] Prefix for the log file name.
+            safedir: [str] Safe directory to use if the log directory is not writable.
+            console_level: [int] Logging level for the console output. E.g. logging.INFO
+            file_level: [int] Logging level for the file output. E.g. logging.DEBUG
+
+        """
+
+        with self.init_lock:
+            if self.is_initialized:
+                return
+
+            # Remove any default handlers from the root logger
+            main_logger = logging.getLogger()
+            for handler in main_logger.handlers[:]:
+                main_logger.removeHandler(handler)
+
+            # Spawn the listener process
+            self.logging_queue = multiprocessing.Queue(-1)
+            self.listener_process = multiprocessing.Process(
+                target=_listener_process,
+                args=(self.logging_queue, config, log_file_prefix, safedir, console_level, file_level)
+            )
+            self.listener_process.daemon = True
+            self.listener_process.start()
+            
+            # Configure the queue handler in the main process
+            qh = logging.handlers.QueueHandler(self.logging_queue)
+            qh.setFormatter(logging.Formatter('%(message)s'))
+            qh.addFilter(InRmsFilter(config))
+
+            # Replace root handlers with our queue handler
+            main_logger.handlers = [qh]
+            main_logger.setLevel(min(console_level, file_level)) # Keep root logger permissive
+            main_logger.propagate = False
+
+            # Redirect standard streams
+            sys.stderr = LoggerWriter(main_logger, logging.WARNING)
+            if config.log_stdout:
+                sys.stdout = LoggerWriter(main_logger, logging.INFO)
+
+            self.is_initialized = True
+            main_logger.debug("initLogging completed; queue listener started.")
+
+            # Register the instance's shutdown method for clean exit
+            atexit.register(self.shutdownLogging)
+
+    def shutdownLogging(self):
+        """
+        Handles cleanup of logging resources. Stops the listener process.
+        """
+        with self.init_lock:
+            if not self.is_initialized:
+                return
+            
+            # Stop the listener process
+            if self.listener_process and self.listener_process.is_alive():
+                print("Shutting down logging...") # Added for visibility during shutdown
+                self.logging_queue.put(None)  # Sentinel to stop the listener loop
+                self.listener_process.join(timeout=5)
+                if self.listener_process.is_alive():
+                    self.listener_process.terminate()
+            
+            self.is_initialized = False
+            print("Logging shutdown complete.")
 
 
 ##############################################################################
 # LISTENER SIDE
 ##############################################################################
 
-def _listener_configurer(config, log_file_prefix, safedir):
+def _listener_configurer(config, log_file_prefix, safedir, console_level=logging.INFO, file_level=logging.DEBUG):
     """ Set up the root logger with a TimedRotatingFileHandler. 
     This runs in the separate listener process.
     """
     # Set DEBUG on root logger - this is the master filter for all handlers
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
-
+    
     # Set up log directory
     log_path = os.path.join(config.data_dir, config.log_dir)
 
@@ -347,17 +476,28 @@ def _listener_configurer(config, log_file_prefix, safedir):
     logfile_name = "{}log_{}_{}.log".format(log_file_prefix, config.stationID, start_time_str)
     full_path = os.path.join(log_path, logfile_name)
 
+    # If RMS is to reboot daily, set the rollover time to 25 hours to prevent log fracturing before a new
+    # capture session starts
+    if config.reboot_after_processing:
+        rollover_interval = 30
+    else:
+        rollover_interval = 24
+
     # Initialize file and console handlers
     handler = CustomHandler(
         station_id=config.stationID,
-        start_time_str=start_time_str,
+        log_file_prefix=log_file_prefix,
         filename=full_path,
         when='H',
-        interval=24,
+        interval=rollover_interval,
         utc=True
     )
     console = logging.StreamHandler(sys.stdout)
 
+    # Set different levels for each handler
+    handler.setLevel(file_level)
+    console.setLevel(console_level)
+    
     # Add filters to both handlers
     handler.addFilter(InRmsFilter(config))
     console.addFilter(InRmsFilter(config))
@@ -378,7 +518,7 @@ def _listener_configurer(config, log_file_prefix, safedir):
     root_logger.debug("Log listener configured. Current file: %s", full_path)
 
 
-def _listener_process(queue, config, log_file_prefix, safedir):
+def _listener_process(queue, config, log_file_prefix, safedir, console_level=logging.INFO, file_level=logging.DEBUG):
     """ Target function for the logging listener process.
     Ignores SIGINT and runs QueueListener for async logging.
     """
@@ -387,11 +527,11 @@ def _listener_process(queue, config, log_file_prefix, safedir):
 
     # Configure the listener process
     logging.Formatter.converter = time.gmtime
-    _listener_configurer(config, log_file_prefix, safedir)
+    _listener_configurer(config, log_file_prefix, safedir, console_level, file_level)
 
-    # Start queue listener
+    # Start queue listener with our custom listener
     main_logger = logging.getLogger()
-    queue_listener = logging.handlers.QueueListener(queue, *main_logger.handlers)
+    queue_listener = LevelRespectingQueueListener(queue, *main_logger.handlers)
     queue_listener.start()
 
     # Keep the process alive
@@ -444,99 +584,6 @@ def getWhiteAndBlackLists(config):
     site_dirs.add(os.path.realpath(user_site))
 
     return allowed_dirs, site_dirs
-
-def initLogging(config, log_file_prefix="", safedir=None, level=logging.DEBUG):
-    """ Called once in the MAIN process (e.g. StartCapture.py).
-    Spawns the listener process and configures logging.
-
-    Arguments:
-        config: [object] RMS config object
-        log_file_prefix: [str] Optional prefix for log filenames
-        safedir: [str] Fallback directory if normal log_path is unwritable
-        level: [int] Logging level for the main logger (defaults to DEBUG)
-    """
-    global _rms_logging_queue, _rms_listener_process, _rms_logger_initialized
-    global RMS_ROOT, SITE_DIRS, ALLOWED_DIRS
-
-    # Whitelist RMS root and external script directories
-    RMS_ROOT = os.path.realpath(getRmsRootDir())
-    ALLOWED_DIRS, SITE_DIRS = getWhiteAndBlackLists(config)
-
-    # Ensure we only init once
-    with _rms_init_lock:
-        if _rms_logger_initialized:
-            return
-
-    # Remove any default handlers
-    main_logger = logging.getLogger()
-    for handler in main_logger.handlers[:]:
-        main_logger.removeHandler(handler)
-
-    # Spawn listener process
-    _rms_logging_queue = multiprocessing.Queue(-1)
-    _rms_listener_process = multiprocessing.Process(
-        target=_listener_process,
-        args=(_rms_logging_queue, config, log_file_prefix, safedir)
-    )
-    _rms_listener_process.daemon = True
-    _rms_listener_process.start()
-
-    # Keep root logger permissive
-    main_logger.setLevel(level)
-
-    # Configure queue handler (backport for Py2)
-    try:
-        QueueHandler = logging.handlers.QueueHandler
-    except AttributeError:
-        class QueueHandler(logging.Handler):
-            """Minimal backport of Python3's QueueHandler."""
-            def __init__(self, queue):
-                super(QueueHandler, self).__init__()
-                self.queue = queue
-            def emit(self, record):
-                try:
-                    self.queue.put(record)
-                except Exception:
-                    self.handleError(record)
-
-    qh = QueueHandler(_rms_logging_queue)
-    qh.setFormatter(logging.Formatter('%(message)s'))
-    qh.addFilter(InRmsFilter(config))
-
-    # Replace root handlers with our queue handler
-    main_logger.handlers = [qh]
-
-    # Redirect standard streams into the logger
-    sys.stderr = LoggerWriter(main_logger, logging.WARNING)
-    if config.log_stdout:
-        sys.stdout = LoggerWriter(main_logger, logging.INFO)
-
-    main_logger.propagate = False
-    _rms_logger_initialized = True
-    main_logger.debug("initLogging completed; queue listener started.")
-
-    # Ensure clean shutdown
-    atexit.register(shutdownLogging)
-
-
-
-def shutdownLogging():
-    """ Handles cleanup of logging resources.
-    Stops the listener process and resets the logging state.
-    """
-    global _rms_logging_queue, _rms_listener_process, _rms_logger_initialized
-    with _rms_init_lock:
-        if not _rms_logger_initialized:
-            return
-        
-        # Stop the listener process
-        if _rms_listener_process and _rms_listener_process.is_alive():
-            _rms_logging_queue.put(None)  # Sentinel
-            _rms_listener_process.join(timeout=5)
-            if _rms_listener_process.is_alive():
-                _rms_listener_process.terminate()
-        
-        _rms_logger_initialized = False
 
 
 def getLogger(name=None, level="DEBUG", stdout=False):

--- a/RMS/MLFilter.py
+++ b/RMS/MLFilter.py
@@ -35,7 +35,7 @@ except ImportError:
 
 from RMS.Formats import FFfile
 from RMS.Formats import FTPdetectinfo
-from RMS.Logger import initLogging, getLogger
+from RMS.Logger import LoggingManager, getLogger
 import RMS.ConfigReader as cr
 
 # Get the logger from the main module
@@ -610,7 +610,8 @@ if __name__ == "__main__":
     config = cr.loadConfigFromDirectory(cml_args.config, dir_path)
 
     ### Init the logger
-    initLogging(config, 'reprocess_')
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'reprocess_')
     log = getLogger("logger")
 
     #########################

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -24,7 +24,7 @@ from RMS.Formats.FFfile import validFFName
 from RMS.Formats.FTPdetectinfo import readFTPdetectinfo, writeFTPdetectinfo
 from RMS.Formats.Platepar import Platepar
 from RMS.Formats import CALSTARS
-from RMS.Logger import getLogger
+from RMS.Logger import LoggingManager, getLogger
 from RMS.MLFilter import filterFTPdetectinfoML
 from RMS.UploadManager import UploadManager
 from RMS.Routines.Image import saveImage
@@ -793,9 +793,8 @@ if __name__ == "__main__":
 
     
     ### Init the logger
-
-    from RMS.Logger import initLogging
-    initLogging(config, 'reprocess_')
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'reprocess_')
 
     log = getLogger("logger")
 

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -38,7 +38,7 @@ import numpy as np
 from Utils.LiveViewer import LiveViewer
 
 import RMS.ConfigReader as cr
-from RMS.Logger import initLogging, getLogger
+from RMS.Logger import LoggingManager, getLogger
 from RMS.BufferedCapture import BufferedCapture
 from RMS.CaptureDuration import captureDuration
 from RMS.CaptureModeSwitcher import captureModeSwitcher
@@ -916,7 +916,8 @@ if __name__ == "__main__":
 
 
     # Initialize the logger
-    initLogging(config)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config)
 
     # Get the logger handle
     log = getLogger("logger")

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -2,20 +2,21 @@
 
 from __future__ import print_function, division, absolute_import
 
+import logging
 import sys
 import os
 import ctypes
 import multiprocessing
 import time
 import datetime
-import logging
-
 import binascii
 import paramiko
 
+from RMS.Logger import LoggingManager, getLogger
+
 # Suppress Paramiko internal errors before they appear in logs
-logging.getLogger("paramiko.transport").setLevel(logging.CRITICAL)
-logging.getLogger("paramiko.auth_handler").setLevel(logging.CRITICAL)
+getLogger("paramiko.transport").setLevel(logging.CRITICAL)
+getLogger("paramiko.auth_handler").setLevel(logging.CRITICAL)
 
 from multiprocessing import Manager
 
@@ -816,8 +817,6 @@ class UploadManager(multiprocessing.Process):
 
 if __name__ == "__main__":
 
-    from RMS.Logger import initLogging
-
     # Set up a fake config file
     class FakeConf(object):
         def __init__(self):
@@ -866,7 +865,8 @@ if __name__ == "__main__":
     ### Test the upload manager ###
 
     # Init the logger
-    initLogging(config)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config)
 
     up = UploadManager(config)
     up.start()

--- a/Utils/CameraControl.py
+++ b/Utils/CameraControl.py
@@ -67,7 +67,7 @@ import pprint
 import re
 
 import RMS.ConfigReader as cr
-from RMS.Logger import getLogger, initLogging
+from RMS.Logger import LoggingManager, getLogger
 from time import sleep
 import datetime
 
@@ -918,8 +918,11 @@ if __name__ == '__main__':
     # Load the config file
     config = cr.loadConfigFromDirectory(cml_args.config, 'notused')
     # initialise a logger, when running in standalone mode, to avoid DVRip's excessive debug messages
-    logger = initLogging(config, log_file_prefix='camControl_')
-    
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, log_file_prefix='camControl_')
+    log = getLogger("logger")
+
+
     if cmd not in cmd_list:
         log.info('Error: command "%s" not supported', cmd)
         exit(1)

--- a/Utils/Flux.py
+++ b/Utils/Flux.py
@@ -25,7 +25,7 @@ from matplotlib import scale as mscale
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.stats
-from RMS.Logger import getLogger
+from RMS.Logger import LoggingManager, getLogger
 
 
 # Get the logger from the main module
@@ -3819,8 +3819,8 @@ if __name__ == "__main__":
     # Load the config file
     config = cr.loadConfigFromDirectory(cml_args.config, dir_path)
 
-    from RMS.Logger import initLogging
-    initLogging(config, 'flux_')
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'flux_')
 
     if not os.path.isfile(ftpdetectinfo_path):
         log.warning("The FTPdetectinfo file does not exist:", ftpdetectinfo_path)

--- a/iStream/iStream.py
+++ b/iStream/iStream.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 import subprocess
 from RMS.CaptureDuration import captureDuration
-from RMS.Logger import initLogging, getLogger
+from RMS.Logger import LoggingManager, getLogger
 from RMS.Misc import isRaspberryPi, RmsDateTime
 
 
@@ -20,7 +20,8 @@ def rmsExternal(captured_night_dir, archived_night_dir, config):
 
 
     # Initialize the logger
-    initLogging(config, 'iStream_')
+    log_manager = LoggingManager()
+    log_manager.initLogging(config, 'iStream_')
     log = getLogger("logger")
     log.info('iStream external script started')
 


### PR DESCRIPTION
RMS.Astrometry.ApplyRecalibrate didn't run as a standalone script as it failed to find the SITE_DIR global variable. I completely removed the use of globals, but left them initialized in case they're used outside of RMS.
