### PR TITLE
Restore original output location if no output destination specified

### DIFF
--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -162,6 +162,11 @@ def plotFOVSkyMap(platepars, configs, out_dir, north_up=False, show_pointing=Fal
     else:
         output_file_name = os.path.join(os.path.abspath('.'), os.path.expanduser(output_file_name))
 
+    if os.path.isdir(output_file_name):
+        output_file_name = os.path.join(output_file_name, "fov_sky_map.png")
+
+
+
     # Save the plot to disk
     plot_path = os.path.expanduser(output_file_name)
     if os.path.isdir(plot_path):
@@ -229,6 +234,22 @@ if __name__ == "__main__":
     masks = {}
     configs = {}
 
+    cml_args.dir_path = os.path.expanduser(cml_args.dir_path)
+    if not os.path.isdir(cml_args.dir_path):
+        print("Input directory {:s} does not exist, quitting.".format(cml_args.dir_path))
+        quit()
+
+    if cml_args.output_file_name is None:
+        output_file_name = cml_args.dir_path
+    else:
+        output_file_name = cml_args.output_file_name[0]
+
+    if not os.path.isdir(output_file_name) and not os.path.isdir(os.path.dirname(output_file_name)):
+        print("Output directory {:s} does not exist, quitting.".format(os.path.dirname(output_file_name)))
+        quit()
+
+
+
     for entry in os.walk(os.path.expanduser(cml_args.dir_path), topdown=True):
 
         dir_path, dirs , file_list = entry
@@ -270,7 +291,7 @@ if __name__ == "__main__":
     plotFOVSkyMap(platepars, configs, cml_args.dir_path, north_up=cml_args.north_up,
                   show_pointing=cml_args.pointing, show_fov=cml_args.fov,
                   rotate_text=cml_args.rotate, masks=masks,
-                  flip_text=cml_args.flip_text, output_file_name=cml_args.output_file_name[0],
+                  flip_text=cml_args.flip_text, output_file_name=output_file_name,
                   show_ip=cml_args.show_ip, show_coordinates=cml_args.show_coordinates)
 
 

--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -16,12 +16,24 @@ def plotFOVSkyMap(platepars, configs, out_dir, north_up=False, show_pointing=Fal
 
     Arguments:
         platepars: [dict] A dictionary of Platepar objects where keys are station codes.
+        configs: [dics] A dictionary of RMS config objects where keys are station codes.
         out_dir: [str] Path to where the graph will be saved.
+
+    Keyword arguments:
+        north_up: [bool] If true, plot the north upward.
+        show_pointing: [bool] If true, annotate plot with azimuth and elevation per camera
+        show_fov: [bool] If true, annotate plot with field of view per camera
+        rotate_text: [bool] If true, rotate text so that is normal to the camera
+        flip_text: [bool] If true, flip text so that it is never upside down
+        show_ip: [bool] If true, annotate plot with address of camera
+        show_coordinates: [bool] If true, annotate plot with coordinates
+        masks:
 
     Keyword arguments:
         masks: [dict] A dictionary of mask objects where keys are station codes.
 
     """
+
 
     # Change plotting style
     plt.style.use('ggplot')
@@ -145,6 +157,11 @@ def plotFOVSkyMap(platepars, configs, out_dir, north_up=False, show_pointing=Fal
     plt.tight_layout()
 
 
+    if output_file_name is None:
+        output_file_name = os.path.join(out_dir, "fov_sky_map.png")
+    else:
+        output_file_name = os.path.join(os.path.abspath('.'), os.path.expanduser(output_file_name))
+
     # Save the plot to disk
     plot_path = os.path.expanduser(output_file_name)
     if os.path.isdir(plot_path):
@@ -248,15 +265,12 @@ if __name__ == "__main__":
                 print("Loaded mask for     {:s}: {:s}".format(pp.station_code, pp_path))
 
 
-    if cml_args.output_file_name is None:
-        output_file_name = os.path.join(cml_args.dir_path, "fov_sky_map.png")
-    else:
-        output_file_name = os.path.join(os.path.abspath('.'), os.path.expanduser(cml_args.output_file_name[0]))
+
     # Plot all platepars on an alt/az sky map
     plotFOVSkyMap(platepars, configs, cml_args.dir_path, north_up=cml_args.north_up,
                   show_pointing=cml_args.pointing, show_fov=cml_args.fov,
                   rotate_text=cml_args.rotate, masks=masks,
-                  flip_text=cml_args.flip_text, output_file_name=output_file_name,
+                  flip_text=cml_args.flip_text, output_file_name=cml_args.output_file_name[0],
                   show_ip=cml_args.show_ip, show_coordinates=cml_args.show_coordinates)
 
 


### PR DESCRIPTION
Original behavior was for FOVSkyMap to write output to same directory as files were brought from. This PR restores that functionality. 

```
(vRMS) david@lap-deb-01:~/source/RMS$ python -m Utils.FOVSkyMap ~/source/RMS/Tests/Stations
FOV sky map saved to: /home/david/source/RMS/Tests/Stations/fov_sky_map.png
```

If a path is given with no filename, at appends default of fov_sky_map.png

```
(vRMS) david@lap-deb-01:~/source/RMS$ python -m Utils.FOVSkyMap ~/source/RMS/Tests/Stations -rl -o ~/tmp
FOV sky map saved to: /home/david/tmp/fov_sky_map.png
```

If a path and filename is given then that path and filename is used

```
(vRMS) david@lap-deb-01:~/source/RMS$ python -m Utils.FOVSkyMap ~/source/RMS/Tests/Stations -rl -o ~/tmp/Station.png
FOV sky map saved to: /home/david/tmp/Station.png

```



It also adds showing the ip address
```
python -m Utils.FOVSkyMap ~/source/RMS/Tests/Stations -ir
```
![fov_sky_map](https://github.com/user-attachments/assets/35c0887c-8e06-4fb8-b707-1ff4f088edaf)

and the station coordinates

```
python -m Utils.FOVSkyMap ~/source/RMS/Tests/Stations -irc
```

![fov_sky_map](https://github.com/user-attachments/assets/481c1990-fe24-4b74-8602-da54b0b1c3f7)
