### PR TITLE
Avoid crash when no fits in CapturedFiles

### DIFF
--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -222,33 +222,36 @@ def archiveDetections(captured_path, archived_path, ff_detected, config, extra_f
         log.error('Generating captured stack failed with error:' + repr(e))
         log.error("".join(traceback.format_exception(*sys.exc_info())))
 
+    if ff_detected is not None:
+        log.info('Generating a stack of {:d} detections...'.format(len(ff_detected)))
 
-    log.info('Generating a stack of {:d} detections...'.format(len(ff_detected)))
 
-    try:
+        try:
 
-        # Make a co-added image of all detections. Filter out possible clouds
-        detected_stack_path, _ = stackFFs(captured_path, 'jpg', deinterlace=(config.deinterlace_order > 0), 
-            subavg=True, filter_bright=True, file_list=sorted(ff_detected), mask=mask)
+            # Make a co-added image of all detections. Filter out possible clouds
+            detected_stack_path, _ = stackFFs(captured_path, 'jpg', deinterlace=(config.deinterlace_order > 0),
+                subavg=True, filter_bright=True, file_list=sorted(ff_detected), mask=mask)
 
-        if detected_stack_path is not None:
+            if detected_stack_path is not None:
 
-            log.info("Detected stack saved to: {:s}".format(detected_stack_path))
+                log.info("Detected stack saved to: {:s}".format(detected_stack_path))
 
-            # Extract the name of the stack image
-            stack_file = os.path.basename(detected_stack_path)
+                # Extract the name of the stack image
+                stack_file = os.path.basename(detected_stack_path)
             
-            # Add the stack path to the list of files to put in the archive
-            file_list.append(stack_file)
+                # Add the stack path to the list of files to put in the archive
+                file_list.append(stack_file)
 
-        else:
-            log.info("Detected stack could not be saved!")
+            else:
+                log.info("Detected stack could not be saved!")
 
 
-    except Exception as e:
-        log.error('Generating stack failed with error:' + repr(e))
-        log.error("".join(traceback.format_exception(*sys.exc_info())))
+        except Exception as e:
+            log.error('Generating stack failed with error:' + repr(e))
+            log.error("".join(traceback.format_exception(*sys.exc_info())))
 
+    else:
+        log.info('No detections to stack')
 
 
     if file_list:

--- a/RMS/Formats/FTPdetectinfo.py
+++ b/RMS/Formats/FTPdetectinfo.py
@@ -302,6 +302,8 @@ def readFTPdetectinfo(ff_directory, file_name, ret_input_format=False):
         [tuple]: Two options, see ret_input_format.
     """
 
+    if file_name is None:
+        return []
     ff_name = ''
 
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -706,23 +706,33 @@ def nightSummaryData(config, night_data_dir):
     fits_files_list = glob.glob(os.path.join(night_data_dir, "*.fits"))
     fits_files_list.sort()
     fits_count = len(fits_files_list)
-    if fits_count < 1:
-        return 0,0,0,0,0,0,0,0,0,0,0
 
-    time_first_fits_file = datetime.datetime.strptime(filenameToDatetimeStr(os.path.basename(fits_files_list[0])),
+    if fits_count != 0:
+        time_first_fits_file = datetime.datetime.strptime(filenameToDatetimeStr(os.path.basename(fits_files_list[0])),
                                                       "%Y-%m-%d %H:%M:%S.%f")
-    time_last_fits_file = datetime.datetime.strptime(filenameToDatetimeStr(
-        os.path.basename(fits_files_list[-1])), "%Y-%m-%d %H:%M:%S.%f")
+        time_last_fits_file = datetime.datetime.strptime(filenameToDatetimeStr(
+            os.path.basename(fits_files_list[-1])), "%Y-%m-%d %H:%M:%S.%f")
 
     # Compute key values using the first and last fits files to mark the start and end of observations
-    capture_duration_from_fits = (time_last_fits_file - time_first_fits_file).total_seconds() + duration_one_fits_file
-    total_expected_fits = round(capture_duration_from_fits / duration_one_fits_file)
-    fits_file_shortfall = total_expected_fits - fits_count
-    fits_file_shortfall = 0 if fits_file_shortfall < 1 else fits_file_shortfall
-    fits_file_shortfall_as_time = str(datetime.timedelta(seconds=fits_file_shortfall * duration_one_fits_file))
+        capture_duration_from_fits = (time_last_fits_file - time_first_fits_file).total_seconds() + duration_one_fits_file
+        total_expected_fits = round(capture_duration_from_fits / duration_one_fits_file)
+        fits_file_shortfall = total_expected_fits - fits_count
+        fits_file_shortfall = 0 if fits_file_shortfall < 1 else fits_file_shortfall
+        fits_file_shortfall_as_time = str(datetime.timedelta(seconds=fits_file_shortfall * duration_one_fits_file))
+
+    else:
+        print(night_data_dir)
+        dir_name = os.path.basename(night_data_dir)
+        dir_d, dir_t = dir_name.split("_")[1], dir_name.split("_")[2]
+        y, m, d = int(dir_d[0:4]), int(dir_d[4:6]), int(dir_d[6:8])
+        hr, min, sec = int(dir_t[0:2]), int(dir_t[2:4]), int(dir_t[4:6])
+        time_first_fits_file = datetime.datetime(year = y, month = m, day = d, hour = hr, minute = min, second = sec)
+        time_first_fits_file += datetime.timedelta(seconds = 10)
+        capture_duration_from_fits, total_expected_fits = 0, 0
+        fits_file_shortfall, fits_file_shortfall_as_time, time_last_fits_file = 0, 0, 0
+
 
     # Compute key values from the ephemeris values
-
     start_ephem, duration_ephem, end_ephem = getObservationDuration(config, time_first_fits_file)
     total_expected_fits_ephemeris = round(duration_ephem / duration_one_fits_file)
     fits_file_shortfall_ephemeris = total_expected_fits_ephemeris - fits_count

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -206,7 +206,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
         obs_db_conn = getObsDBConn(config)
         # Filter out detections using machine learning
-        if config.ml_filter > 0:
+        if config.ml_filter > 0 and ftpdetectinfo_name is not None:
 
             log.info("Filtering out detections using machine learning...")
 
@@ -644,18 +644,18 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
                     night_data_dir, cams_code_formatted, fps, calibration=cal_file_name, \
                     celestial_coords_given=(platepar is not None))
 
+
     try:
         observation_summary_path_file_name, observation_summary_json_path_file_name = (
                 finalizeObservationSummary(config, night_data_dir))
         log.info("\n\nObservation Summary\n===================\n\n" + serialize(config) + "\n\n")
+        extra_files.append(observation_summary_path_file_name)
+        extra_files.append(observation_summary_json_path_file_name)
 
     except Exception as e:
         log.debug('Generating Observation Summary failed with message:\n' + repr(e))
         log.debug(repr(traceback.format_exception(*sys.exc_info())))
 
-
-    extra_files.append(observation_summary_path_file_name)
-    extra_files.append(observation_summary_json_path_file_name)
     night_archive_dir = os.path.join(os.path.abspath(config.data_dir), config.archived_dir,
         night_data_dir_name)
 


### PR DESCRIPTION
If capture fails and there are no fits files, then RMS crashes.

This PR addresses issue #672


