### PR TITLE
Fix video recording

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -967,6 +967,7 @@ class BufferedCapture(Process):
             # queue2 smooths out the writes, but doesn't wait until the buffers fill up for writing
             storage_branch = (
                 "t. ! queue2 max-size-buffers=150 max-size-bytes=2097152 max-size-time=5000000000 ! "
+                "h264parse ! "
                 "splitmuxsink name=splitmuxsink0 max-size-time={:d} muxer-factory=matroskamux"
                 ).format(int(segment_duration_sec*1e9))
 


### PR DESCRIPTION
The current video recording pipeline was broken, making RMS revert to OpenCV. Another h264 parse string had to be added to make it work.