### PR TITLE
Fix undefined variable calls in observation summary generation

### DIFF
--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -647,6 +647,10 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
     try:
         observation_summary_path_file_name, observation_summary_json_path_file_name = (
                 finalizeObservationSummary(config, night_data_dir))
+        
+        extra_files.append(observation_summary_path_file_name)
+        extra_files.append(observation_summary_json_path_file_name)
+        
         log.info("\n\nObservation Summary\n===================\n\n" + serialize(config) + "\n\n")
 
     except Exception as e:
@@ -654,8 +658,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
         log.debug(repr(traceback.format_exception(*sys.exc_info())))
 
 
-    extra_files.append(observation_summary_path_file_name)
-    extra_files.append(observation_summary_json_path_file_name)
+
     night_archive_dir = os.path.join(os.path.abspath(config.data_dir), config.archived_dir,
         night_data_dir_name)
 


### PR DESCRIPTION
Ensure that undefined variables are not referenced when generating the observation summary fails. This change improves error handling during the summary process.