### PR TITLE
splitmuxsink: add async-finalize=true so muxer-factory is honoured

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -992,7 +992,7 @@ class BufferedCapture(Process):
             storage_branch = (
                 "t. ! queue2 max-size-buffers=150 max-size-bytes=2097152 max-size-time=5000000000 ! "
                 "h264parse ! "
-                "splitmuxsink name=splitmuxsink0 max-size-time={:d} muxer-factory=matroskamux"
+                "splitmuxsink name=splitmuxsink0 async-finalize=true max-size-time={:d} muxer-factory=matroskamux"
                 ).format(int(segment_duration_sec*1e9))
 
         # Otherwise, skip saving the raw stream to disk


### PR DESCRIPTION
This PR addresses a bug when raw_video_save is enabled on older GStreamer (e.g. GStreamer 1.16 on Ubuntu 20.04).

On older GStreamer versions, splitmuxsink ignores muxer-factory=matroskamux and uses qtmux instead, causing:

- Memory leak: qtmux keeps growing frame tables in RAM (stts/stco)
- Shutdown hangs: Large files block pipeline teardown indefinitely on very long runs
- Log spam: "reserved-moov-update-period" warnings every 30 seconds

Adding `async-finalize=true` enables the muxer-factory setting. This makes splitmuxsink actually use matroskamux, which streams headers incrementally.

Tested on Ubuntu 20.04 and 24.04.