### PR TITLE
Safeguard releaseResources and add diagnostics

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -149,6 +149,12 @@ class BufferedCapture(Process):
         self.start_time2.value = 0
 
         # Initialize shared values for raw frame saving (these are designed for multiprocessing)
+
+        # Raw-frame infrastructure: always create, even if save_frames=False
+        self.raw_frame_saver = None    # avoids AttributeError in releaseRawArrays
+        self.shared_raw_array = None   # primary raw-frame buffer
+        self.shared_raw_array2 = None  # secondary raw-frame buffer
+
         if self.config.save_frames:
 
             # Frame saving block size - these many raw frames are written to buffer before saving to disk

--- a/RMS/RawFrameSave.py
+++ b/RMS/RawFrameSave.py
@@ -163,6 +163,16 @@ class RawFrameSaver(multiprocessing.Process):
         self.exit.set()
         log.debug('Raw frame saver exit flag set')
 
+        # flush any frames whose TS array still has data
+        leftovers = []
+        for frame, ts in zip(self.array1, self.timeStamps1):
+            if ts: leftovers.append((frame.copy(), float(ts)))
+        for frame, ts in zip(self.array2, self.timeStamps2):
+            if ts: leftovers.append((frame.copy(), float(ts)))
+        if leftovers:
+            log.info("Flushing %d tail-end raw frames before shutdown", len(leftovers))
+            self.saveFramesToDisk(leftovers, self.daytime_mode)
+
         # Free shared memory after the raw frame saver is done
         try:
             log.debug('Freeing frame buffers in raw frame saver...')

--- a/RMS/RawFrameSave.py
+++ b/RMS/RawFrameSave.py
@@ -173,6 +173,12 @@ class RawFrameSaver(multiprocessing.Process):
             log.info("Flushing %d tail-end raw frames before shutdown", len(leftovers))
             self.saveFramesToDisk(leftovers, self.daytime_mode)
 
+            # mark buffers consumed so run() won’t resave them
+            self.timeStamps1.fill(0)
+            self.timeStamps2.fill(0)
+            self.start_time1.value = 0
+            self.start_time2.value = 0
+
         # Free shared memory after the raw frame saver is done
         try:
             log.debug('Freeing frame buffers in raw frame saver...')


### PR DESCRIPTION
Fix hang on backend mismatch.  Cleanup now checks the actual object (hasattr(device, "release") vs set_state) instead of trusting the video_device_type flag, so a GstAppSink is never routed through cap.release().
- Timeout-protected OpenCV release: cap.release() runs in a daemon thread with a 2 s join; if it stalls we drop the FD and log a warning rather than block forever.
- Unified teardown: always sets device to None and handles Gst to NULL, making multiple calls to releaseResources() idempotent.
- Extra DEBUG logs: added around state transitions, cleanup branches, and timeout paths to pinpoint future stalls.

Python has no safe built-in way to abort a running C call in another thread, so there is a bit of trial and error on my part to see what works and what doesn't. The number of debug log messages may seem overkill, but until we have a good handle on this, I think it's necessary.