### PR TITLE
update onscreen message

### DIFF
--- a/Scripts/RMS_FirstRun.sh
+++ b/Scripts/RMS_FirstRun.sh
@@ -3,7 +3,7 @@
 echo "Waiting 10 seconds to init the Pi..."
 echo ""
 echo "IMPORTANT: RMS will first update itself."
-echo "Do not touch any file during the update and do not close this window until RMS starts."
+echo "Do not touch any file during the update and do not close this window."
 sleep 12
 
 # Google DNS server IP


### PR DESCRIPTION
An onscreen message advises the user not to close the window "until RMS starts", but in fact RMS runs in the same window, so closing the window kills RMS. A few users have been known to do this and were then disappointed that RMS "didn't work". 

This PR changes the message a little to hopefully avoid that issue.