### PR TITLE
reinstate console output in CameraControl

### DIFF
--- a/Utils/CameraControl.py
+++ b/Utils/CameraControl.py
@@ -80,7 +80,7 @@ else:
     import Utils.CameraControl27 as dvr
 
 # Get the logger from the main module
-log = getLogger("logger")
+log = getLogger("logger", stdout=True)
 
 
 def rebootCamera(cam):


### PR DESCRIPTION
By design this standalone module needs to send output to the console.  Unfortunately a change to the logger suppresses output unless stdout=True is added to the call to getLogger(). This PR adds that 

I'm unsure when this bug was introduced, and a check of the git logs doesn't help, However my stations were working correctly on 26/07 but broken by 28/07 so i would guess the issue was introduced between those dates, possibly by merging an older PR that had unintended side effects. I'll see if i can add an automated test of CameraControl to my test suite. 