### PR TITLE
Remove double space

### DIFF
--- a/RMS/VideoExtraction.py
+++ b/RMS/VideoExtraction.py
@@ -286,7 +286,7 @@ class Extractor(Process):
         
         # Skip the event if not points where found
         if len(event_points) == 0:
-            log.info("Nothing found, not extracting anything  from {}".format(self.filename))
+            log.info("Nothing found, not extracting anything from {}".format(self.filename))
             return
         
         t = time.time()


### PR DESCRIPTION
```
2025/07/31 11:59:27-INFO-VideoExtraction-line:289 - Nothing found, not extracting anything  from AU000A_20250731_115909_211_0143872
```

Contains a double space. This PR removes the double space addressing #693 

```
2025/07/31 13:42:32-INFO-VideoExtraction-line:289 - Nothing found, not extracting anything from AU000A_20250731_134210_456_0018176
```
