### PR TITLE
Plot sun, moon and arbitrary number of RaDEC defined objects on FOVSkyMap

### DIFF
--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -1,8 +1,6 @@
 import datetime
-
 import numpy as np
 import matplotlib.pyplot as plt
-
 import RMS.ConfigReader as cr
 
 from matplotlib.ticker import StrMethodFormatter
@@ -12,7 +10,7 @@ from RMS.Routines.FOVSkyArea import fovSkyArea
 from RMS.Astrometry.Conversions import latLonAlt2ECEF, ECEF2AltAz, raDec2AltAz, datetime2JD
 import ephem
 
-# Duration of a lunar month in seconds
+# Approximate duration of a lunar month in seconds
 LUNAR_MONTH_PERIOD_SECONDS = int(29.5 * 24 * 60 * 60)
 
 # Approximate duration of a day in seconds
@@ -23,8 +21,6 @@ YEAR_IN_SECONDS = int(365.25 * DAY_IN_SECONDS)
 
 # Astromical dusk, when centre of sun is 18 degrees below local horizon
 ASTRONOMICAL_DUSK = np.radians(-18)
-
-
 
 def plotMoon(ax, configs, show_moon, station_code, moon_plotted):
     """
@@ -127,7 +123,7 @@ def plotRaDec(ax, configs, show_radec, radec_list, radec_name_list, station_code
             radec_plotted: [bool] if True, radec will not be plotted again, if False, radec will be plotted
 
         Return:
-            radec_plotted: [bool] Generally returned true, unless the sun never sank below 0 elevation, or the object
+            radec_plotted: [bool] Generally returned true, unless the sun never set, or the object
             never rose
         """
 
@@ -199,7 +195,7 @@ def plotRaDec(ax, configs, show_radec, radec_list, radec_name_list, station_code
                                 object_rise, object_set = True, False
                             elif _el > 0.1 and el < 0.1:
                                 change_state = True
-                                object_ris, object_set = False, True
+                                object_rise, object_set = False, True
 
                     radec_azim_list.append(np.radians(az))
                     last_plotted_az = az
@@ -218,11 +214,11 @@ def plotRaDec(ax, configs, show_radec, radec_list, radec_name_list, station_code
             # Annotate the final point which was plotted, provided this has been initialised
             if last_plotted_initialized:
                 if last_plotted_sun_alt > _sun_alt:
-                    ax.annotate(" {}: UTC:{} (sunset)".format(radec_name, last_plotted_time_str),
+                    ax.annotate(" {}: UTC:{} (dusk)".format(radec_name, last_plotted_time_str),
                             xy=(np.radians(last_plotted_az),last_plotted_el), color="black", fontsize=8)
 
                 elif last_plotted_sun_alt < _sun_alt:
-                    ax.annotate(" {}: UTC:{} (sunrise)".format(radec_name, last_plotted_time_str),
+                    ax.annotate(" {}: UTC:{} (dawn)".format(radec_name, last_plotted_time_str),
                             xy=(np.radians(last_plotted_az),last_plotted_el), color="black", fontsize=8)
 
                 start, end = (np.radians(_last_plotted_az), _last_plotted_el), (np.radians(last_plotted_az), last_plotted_el)
@@ -464,7 +460,7 @@ if __name__ == "__main__":
 
 
     arg_parser.add_argument('-d', '--show_radec', dest='ra_dec', nargs=3, type=str, action="append",
-                            help="Show the path of a radec across the FoV, pass as ra, dec, name. The name passed will be used for annotation only.")
+                            help="Show the path of multiple radecs across the FoV, pass as ra, dec, name. The name passed will be used for annotation only.")
 
 
     ###

--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -3,9 +3,6 @@ import datetime
 import numpy as np
 import matplotlib.pyplot as plt
 import RMS.ConfigReader as cr
-import ephem
-from RMS.Misc import RmsDateTime
-from RMS.Astrometry.Conversions import raDec2AltAz, datetime2JD
 
 from matplotlib.ticker import StrMethodFormatter
 

--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -318,10 +318,10 @@ if __name__ == "__main__":
                             help="Show coordinates of the camera.")
 
     arg_parser.add_argument('-s', '--show_sun', dest='show_sun', default=False, action="store_true",
-                            help="Plot the position of the sun in each hour for the next year.")
+                            help="Plot the position of the sun in each hour for the next year as seen from one station.")
 
     arg_parser.add_argument('-m', '--show_moon', dest='show_moon', default=False, action="store_true",
-                            help="Plot the position of the moon every 300 seconds for the next 29.5 days.")
+                            help="Plot the position of the moon every 5 minutes for the next 29.5 days as seen from one station.")
 
 
     ###

--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -519,7 +519,7 @@ if __name__ == "__main__":
 
 
 
-    for entry in os.walk(os.path.expanduser(cml_args.dir_path), topdown=True):
+    for entry in sorted(os.walk(os.path.expanduser(cml_args.dir_path), topdown=True)):
 
         dir_path, dirs , file_list = entry
 

--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -294,6 +294,7 @@ def plotFOVSkyMap(platepars, configs, out_dir, north_up=False, show_pointing=Fal
     ref_ht = 100000 # m
     sun_plotted, moon_plotted, radec_plotted = False, False, False
 
+    print()
     for station_code in platepars:
 
         pp = platepars[station_code]

--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -5,16 +5,21 @@ import matplotlib.pyplot as plt
 import RMS.ConfigReader as cr
 
 from matplotlib.ticker import StrMethodFormatter
-
 from RMS.Routines.FOVArea import fovArea
 from RMS.Routines.FOVSkyArea import fovSkyArea
 
 from RMS.Astrometry.Conversions import latLonAlt2ECEF, ECEF2AltAz
 import ephem
 
+# Duration of a lunar month in seconds
+LUNAR_MONTH_PERIOD_SECONDS = int(29.5 * 24 * 60 * 60)
+
+# Approximate duration of a year in seconds
+YEAR_IN_SECONDS = int(365.25 * 24 * 60 * 60)
+
 def plotMoon(ax, configs, show_moon, station_code, moon_plotted):
     """
-    Plots the position of the moon every 5 minutes for the next 29.5 days
+    Plots the position of the moon every 5 minutes for the next lunar month
 
     Arguments:
         ax: [axis] axis on which to plot
@@ -34,11 +39,12 @@ def plotMoon(ax, configs, show_moon, station_code, moon_plotted):
         o.long = str(c.longitude)
         o.elevation = c.elevation
 
-        # If the current time is not given, use the current time
+
         current_time = datetime.datetime.now(datetime.timezone.utc)
 
         moon_azim_list, moon_elev_list = [], []
-        for elapsed_time in range(0, 59 * 12 * 60 * 60, 300):
+
+        for elapsed_time in range(0, LUNAR_MONTH_PERIOD_SECONDS, 300):
             time_to_evaluate = current_time + datetime.timedelta(seconds=elapsed_time)
             o.date = time_to_evaluate
             moon = ephem.Moon(o)
@@ -65,10 +71,10 @@ def plotSun(ax, configs, show_sun, station_code, sun_plotted):
             configs: [dict] dictionary of config files
             show_sun: [bool] whether to show sun
             station_code: [str] station code
-            sun_plotted: [bool] if True, moon will not be plotted again, if False, moon will be plotted
+            sun_plotted: [bool] if True, sun will not be plotted again, if False, sun will be plotted
 
         Return:
-            sun_plotted: [bool] Generally returned true, unless the sun  never rose above 0 elevation
+            sun_plotted: [bool] Generally returned true, unless the sun never rose above 0 elevation
         """
 
     if show_sun and station_code in configs and not sun_plotted:
@@ -82,11 +88,11 @@ def plotSun(ax, configs, show_sun, station_code, sun_plotted):
         current_time = datetime.datetime.now(datetime.timezone.utc)
 
         sun_azim_list, sun_elev_list = [], []
-        for elapsed_time in range(0, 365 * 24 * 60 * 60, 3600):
+
+        for elapsed_time in range(0, YEAR_IN_SECONDS, 3600):
             time_to_evaluate = current_time + datetime.timedelta(seconds=elapsed_time)
             o.date = time_to_evaluate
             sun = ephem.Sun(o)
-            sun.date = time_to_evaluate
             sun.compute(o)
 
             if sun.alt > 0:
@@ -121,7 +127,7 @@ def plotFOVSkyMap(platepars, configs, out_dir, north_up=False, show_pointing=Fal
         show_coordinates: [bool] If true, annotate plot with coordinates
         masks: [dict] A dictionary of mask objects where keys are station codes.
         output_file_name: [str] Name of output file default "fov_sky_map.png"
-        show_sun: [bool] If true, annotate plot with sun track  , default False
+        show_sun: [bool] If true, annotate plot with sun track, default False
 
     """
 

--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -143,6 +143,7 @@ def plotRaDec(ax, configs, show_radec, radec_list, radec_name_list, station_code
             ax.set_title(
                 "Plot of {} objects starting at {} ".format(len(radec_name_list), current_time.replace(microsecond=0)), fontsize=10)
 
+        object_rise, object_set = False, False
         for radec, radec_name in zip(radec_list, radec_name_list):
             radec_azim_list, radec_elev_list = [], []
             change_state, plot_arrow, plot_count, last_values_initialized = True, False, 1, False

--- a/Utils/FOVSkyMap.py
+++ b/Utils/FOVSkyMap.py
@@ -180,19 +180,19 @@ def plotRaDec(ax, configs, show_radec, radec_list, radec_name_list, station_code
                             change_state = False
 
                             if _sun_alt < ASTRONOMICAL_DUSK and sun.alt > ASTRONOMICAL_DUSK:
-                                ax.annotate(" {}: UTC:{} (dawn)".format(radec_name, time_str),
-                                            xy=(np.radians(az), el), color="black", fontsize=8)
+                                ax.annotate("{} (dawn)".format(time_str),
+                                            xy=(np.radians(az), el - 2), color="black", fontsize=8)
                                 plot_arrow = False
                             elif _sun_alt > ASTRONOMICAL_DUSK and sun.alt < ASTRONOMICAL_DUSK:
-                                ax.annotate(" {}: UTC:{} (dusk)".format(radec_name, time_str),
-                                            xy=(np.radians(az), el), color="black", fontsize=8)
+                                ax.annotate(" {}: UTC {} (dusk)".format(radec_name, time_str),
+                                            xy=(np.radians(az + 2), el + 4), color="black", fontsize=8)
                                 plot_arrow = True
                             elif object_set:
-                                ax.annotate(" {}: UTC:{} (setting)".format(radec_name, time_str),
-                                            xy=(np.radians(az), 0), color="black", fontsize=8)
+                                ax.annotate(" {} (setting)".format(time_str),
+                                            xy=(np.radians(az - 2), 0), color="black", fontsize=8)
                                 plot_arrow = False
                             elif object_rise:
-                                ax.annotate(" {}: UTC:{} (rising)".format(radec_name, time_str),
+                                ax.annotate(" {}: UTC {} (rising)".format(radec_name, time_str),
                                             xy=(np.radians(az), 0), color="black", fontsize=8)
                                 plot_arrow = True
 
@@ -228,12 +228,12 @@ def plotRaDec(ax, configs, show_radec, radec_list, radec_name_list, station_code
 
             if last_plotted_initialized:
                 if last_plotted_sun_alt > _sun_alt:
-                    ax.annotate(" {}: UTC:{} (dusk)".format(radec_name, last_plotted_time_str),
-                            xy=(np.radians(last_plotted_az),last_plotted_el), color="black", fontsize=8)
+                    ax.annotate(" {}: UTC {} (dusk)".format(radec_name, last_plotted_time_str),
+                            xy=(np.radians(last_plotted_az + 2),last_plotted_el + 4), color="black", fontsize=8)
 
                 elif last_plotted_sun_alt < _sun_alt:
-                    ax.annotate(" {}: UTC:{} (dawn)".format(radec_name, last_plotted_time_str),
-                            xy=(np.radians(last_plotted_az),last_plotted_el), color="black", fontsize=8)
+                    ax.annotate(" {} (dawn)".format(last_plotted_time_str),
+                            xy=(np.radians(last_plotted_az),last_plotted_el - 4), color="black", fontsize=8)
 
                 start, end = (np.radians(_last_plotted_az), _last_plotted_el), (np.radians(last_plotted_az), last_plotted_el)
                 ax.annotate('',
@@ -421,6 +421,7 @@ def plotFOVSkyMap(platepars, configs, out_dir, north_up=False, show_pointing=Fal
     if os.path.isdir(plot_path):
         plot_path = os.path.join(plot_path, "fov_sky_map.png")
     plt.savefig(plot_path, dpi=150)
+    print()
     print("FOV sky map saved to: {:s}".format(plot_path))
 
 


### PR DESCRIPTION
Adds option for a plot of the sun position as seen from one station for each hour over the next year. 
```
python -m Utils.FOVSkyMap -fircn /home/david/source/RMS/Tests/Stations/ -o /home/david/tmp -s
```

or

```
python -m Utils.FOVSkyMap -fircn /home/david/source/RMS/Tests/Stations/ -o /home/david/tmp --show_sun
```

<img width="1200" height="1200" alt="fov_sky_map" src="https://github.com/user-attachments/assets/1e0c4f3a-a6a8-411a-85fb-5106aafe329b" />


Also can show the moon position, every 5 minutes over the next 29.5 days.

```
python -m Utils.FOVSkyMap -fircn /home/david/source/RMS/Tests/Stations/ -o /home/david/tmp -m
```

or

```
python -m Utils.FOVSkyMap -fircn /home/david/source/RMS/Tests/Stations/ -o /home/david/tmp --show_moon
```



<img width="1200" height="1200" alt="fov_sky_map" src="https://github.com/user-attachments/assets/325c0bc1-11bf-4725-ab70-c01b78714f17" />

