### PR TITLE
[prerelease] Allow RMS_Update to work on remotes other than origin

### DIFF
--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -986,6 +986,9 @@ main() {
         else
             [[ -z "$RMS_BRANCH" ]] && RMS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+            # Get the remote which is actually in use
+            RMS_REMOTE=$(git for-each-ref --format='%(upstream:remotename)' $(git symbolic-ref -q HEAD))
+
             REMOTE_SHA=$(git ls-remote --quiet --heads \
                          "$RMS_REMOTE" "refs/heads/$RMS_BRANCH" | cut -f1)
             LOCAL_SHA=$(git rev-parse HEAD)


### PR DESCRIPTION
RMS_Update is a very complex piece of bash, this PR is submitted with best intents; but I don't claim to follow all the logic, or what is happening in all the code.

This pr is in reponse to issue #709 

When running RMS_Update

```
Creating recovery script RMS_Reset.sh...
Recovery script created: Scripts/RMS_Reset.sh
Use './Scripts/RMS_Reset.sh --switch' to return from old branches

====== Checking Git Configuration ======

Valid git repository found
Checking remote configuration...
Found remote 'g7gpr' pointing to: https://github.com/g7gpr/RMS
Found remote 'jt' pointing to: https://github.com/JustinD-T/RMS-ASTRA/
Found remote 'origin' pointing to: https://github.com/CroatianMeteorNetwork/RMS
Found RMS repository at remote 'origin'
Verifying connection to RMS remote...
Successfully connected to RMS repository through 'origin' remote
ERROR: Cannot query remote ref feature/em/radec_report
david@lap-deb-01:~/source/RMS$ Scripts/RMS_Update.sh 
Creating recovery script RMS_Reset.sh...
Recovery script created: Scripts/RMS_Reset.sh
Use './Scripts/RMS_Reset.sh --switch' to return from old branches

====== Checking Git Configuration ======

Valid git repository found
Checking remote configuration...
Found remote 'g7gpr' pointing to: https://github.com/g7gpr/RMS
Found remote 'jt' pointing to: https://github.com/JustinD-T/RMS-ASTRA/
Found remote 'origin' pointing to: https://github.com/CroatianMeteorNetwork/RMS
Found RMS repository at remote 'origin'
Verifying connection to RMS remote...
Successfully connected to RMS repository through 'origin' remote
ERROR: Cannot query remote ref feature/em/radec_report
david@lap-deb-01:~/source/RMS$ git remote -v
```

This pr detects the current remote in use, and allows RMS_Update to run to completion

```
Creating recovery script RMS_Reset.sh...
Recovery script created: Scripts/RMS_Reset.sh
Use './Scripts/RMS_Reset.sh --switch' to return from old branches

====== Checking Git Configuration ======

Valid git repository found
Checking remote configuration...
Found remote 'g7gpr' pointing to: https://github.com/g7gpr/RMS
Found remote 'jt' pointing to: https://github.com/JustinD-T/RMS-ASTRA/
Found remote 'origin' pointing to: https://github.com/CroatianMeteorNetwork/RMS
Found RMS repository at remote 'origin'
Verifying connection to RMS remote...
Successfully connected to RMS repository through 'origin' remote
ERROR: Cannot query remote ref g7gpr
david@lap-deb-01:~/source/RMS$ Scripts/RMS_Update.sh 
Creating recovery script RMS_Reset.sh...
Recovery script created: Scripts/RMS_Reset.sh
Use './Scripts/RMS_Reset.sh --switch' to return from old branches

====== Checking Git Configuration ======

Valid git repository found
Checking remote configuration...
Found remote 'g7gpr' pointing to: https://github.com/g7gpr/RMS
Found remote 'jt' pointing to: https://github.com/JustinD-T/RMS-ASTRA/
Found remote 'origin' pointing to: https://github.com/CroatianMeteorNetwork/RMS
Found RMS repository at remote 'origin'
Verifying connection to RMS remote...
Successfully connected to RMS repository through 'origin' remote
Nothing new on feature/em/radec_report and no tracked file modifications - exiting.
```
