### PR TITLE
Fix angular separation vector normalization

### DIFF
--- a/RMS/Math.py
+++ b/RMS/Math.py
@@ -88,8 +88,8 @@ def angularSeparationVect(vect1, vect2):
     # yield wildly wrong angles (and even NaNs if the product exceeds 1).  Ensure
     # both vectors are normalized before evaluating the inverse cosine and clip
     # the dot product into the valid range to avoid numerical issues.
-    vect1_norm = vect1 / np.linalg.norm(vect1)
-    vect2_norm = vect2 / np.linalg.norm(vect2)
+    vect1_norm = vect1/np.linalg.norm(vect1)
+    vect2_norm = vect2/np.linalg.norm(vect2)
 
     # Numerical precision can push the dot product slightly outside the range,
     # so clamp it to the closed interval [-1, 1].

--- a/RMS/Math.py
+++ b/RMS/Math.py
@@ -83,7 +83,19 @@ def angularSeparationDeg(ra1, dec1, ra2, dec2):
 def angularSeparationVect(vect1, vect2):
     """ Calculates angle between vectors in radians. """
 
-    return np.abs(np.arccos(np.dot(vect1, vect2)))
+    # The dot product gives |a||b|cos(theta). If the vectors are not normalized the
+    # magnitude term will incorrectly scale the value passed to arccos which can
+    # yield wildly wrong angles (and even NaNs if the product exceeds 1).  Ensure
+    # both vectors are normalized before evaluating the inverse cosine and clip
+    # the dot product into the valid range to avoid numerical issues.
+    vect1_norm = vect1 / np.linalg.norm(vect1)
+    vect2_norm = vect2 / np.linalg.norm(vect2)
+
+    # Numerical precision can push the dot product slightly outside the range,
+    # so clamp it to the closed interval [-1, 1].
+    dot_prod = np.clip(np.dot(vect1_norm, vect2_norm), -1.0, 1.0)
+
+    return np.abs(np.arccos(dot_prod))
 
 
 

--- a/Tests/test_math.py
+++ b/Tests/test_math.py
@@ -1,0 +1,14 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from RMS.Math import angularSeparationVect
+
+
+def test_angular_separation_vect_handles_non_unit_vectors():
+    vect1 = np.array([2.0, 0.0, 0.0])
+    vect2 = np.array([0.0, 3.0, 0.0])
+
+    angle = angularSeparationVect(vect1, vect2)
+
+    assert np.isclose(angle, np.pi / 2)


### PR DESCRIPTION
## Summary
- normalize vectors before computing the angular separation to avoid incorrect results for non-unit inputs
- clamp the dot product into the valid domain for arccos to prevent numeric issues
- add a regression test for the angular separation helper that demonstrates the failure when vectors are not normalized

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5890d3ce88329ac5c6ebe20850c6a