### PR TITLE
Fix platform detection misclassifying macOS as Windows

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -53,7 +53,10 @@ def choosePlatform(win_conf, rpi_conf, linux_pc_conf):
     """ Choose the setting depending on if this is running on the RPi or a Linux PC. """
 
     # Check if running on Windows
-    if 'win' in sys.platform:
+    # ``sys.platform`` contains ``darwin`` on macOS, which previously triggered the
+    # Windows branch because it contains the substring ``"win"``.  Use ``startswith``
+    # to avoid mis-detecting macOS as Windows.
+    if sys.platform.startswith('win'):
         return win_conf
 
     else:

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -52,10 +52,9 @@ except ImportError:
 def choosePlatform(win_conf, rpi_conf, linux_pc_conf):
     """ Choose the setting depending on if this is running on the RPi or a Linux PC. """
 
-    # Check if running on Windows
-    # ``sys.platform`` contains ``darwin`` on macOS, which previously triggered the
-    # Windows branch because it contains the substring ``"win"``.  Use ``startswith``
-    # to avoid mis-detecting macOS as Windows.
+    # Check if running on Windows.
+    # ``startswith`` ensures the platform string actually begins with ``"win"``
+    # instead of matching other identifiers that merely contain that substring.
     if sys.platform.startswith('win'):
         return win_conf
 


### PR DESCRIPTION
## Summary
- avoid matching the substring "win" in sys.platform when selecting platform-specific configs
- ensure macOS is no longer misdetected as Windows by using sys.platform.startswith("win")

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5abd2a0608329952ae9691b614d1c