### PR TITLE
Adjust nightly config lookup

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -573,7 +573,18 @@ def getEphemTimesFromCaptureDirectory(config, capture_directory):
     capture_directory_full_path = os.path.join(config.data_dir, config.captured_dir, capture_directory)
     if DEBUG_PRINT:
         print("Capture directory full path: {}".format(capture_directory_full_path))
-    night_config = parse(os.path.join(capture_directory_full_path,".config"))
+    config_file_name = getattr(config, "config_file_name", None)
+    if config_file_name:
+        nightly_config_filename = os.path.basename(config_file_name)
+        night_config_path = os.path.join(capture_directory_full_path, nightly_config_filename)
+    else:
+        night_config_path = os.path.join(capture_directory_full_path, ".config")
+
+    if not os.path.isfile(night_config_path):
+        # Fall back to the full config path if the nightly file is missing.
+        night_config_path = config_file_name or os.path.join(capture_directory_full_path, ".config")
+
+    night_config = parse(night_config_path)
     if DEBUG_PRINT:
         print("Making a time from {}".format(capture_directory))
     capture_directory_start_time = filenameToDatetimeStr(os.path.basename(capture_directory))


### PR DESCRIPTION
## Summary
- derive the nightly configuration path using the configured file name when available
- fall back to the main configuration file when the nightly copy is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efd604e4948329b9f9a780d489650e