### PR TITLE
Fix: Reset stream counters and backend on mode transitions

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -2113,6 +2113,9 @@ class BufferedCapture(Process):
                             transition_type = "Day→Night" if not current_daytime else "Night→Day"
                             log.info(f"{transition_type} transition detected, resetting counters and media backend")
 
+                            # Update last_daytime_mode BEFORE breaking to prevent detecting same transition again
+                            self.last_daytime_mode = current_daytime
+
                             # Reset dropped frames counter for new session
                             self.dropped_frames.value = 0
                             self.dropped_frames_timestamps.clear()


### PR DESCRIPTION
When running capture continuously without rebooting, the dropped frames counter is not being reset. After a day or two, this causes capture to switch and remain in cv2 mode until reboot.
   - Resets dropped frames counter and reset_count at day/night transitions to provide accurate per-session metrics
   - Resets media_backend_override at mode transitions to allow GStreamer retry
   - Fixes infinite reconnection loop by properly updating last_daytime_mode before breaking