### PR TITLE
Add platepar pixel to sky example script

### DIFF
--- a/Tests/PlateparXY2SkyExample.py
+++ b/Tests/PlateparXY2SkyExample.py
@@ -25,7 +25,7 @@ from RMS.Astrometry.CyFunctions import equatorialCoordPrecession
 from RMS.Formats.Platepar import Platepar
 
 
-def parse_time(value: str) -> datetime:
+def parseTime(value: str) -> datetime:
     """Parse an ISO 8601 timestamp.
 
     The value is interpreted as UTC. Time zone aware values are converted to UTC and
@@ -52,8 +52,8 @@ def main() -> None:
         "--time",
         dest="timestamp",
         required=True,
-        type=parse_time,
-        help="Observation time in ISO 8601 format (UTC)",
+        type=parseTime,
+        help="Observation time in ISO 8601 format (UTC). For example: 2023-01-15T12:34:56.789",
     )
     parser.add_argument(
         "--height",
@@ -72,13 +72,15 @@ def main() -> None:
     # Convert the observation time to Julian Date using the station UT correction.
     jd = datetime2JD(args.timestamp, UT_corr=platepar.UT_corr)
 
+    # Convert the pixel coordinates to J2000 RA/Dec using the platepar.
     # xyToRaDecPP expects iterables of equal length. Provide a single-sample input.
     _, ra_j2000, dec_j2000, _ = xyToRaDecPP(
-        [args.timestamp],
+        [jd],
         [args.x],
         [args.y],
         [1],
         platepar,
+        jd_time=True,
         extinction_correction=False,
         precompute_pointing_corr=True,
     )
@@ -96,10 +98,12 @@ def main() -> None:
     ra_epoch = np.degrees(ra_epoch_rad)
     dec_epoch = np.degrees(dec_epoch_rad)
 
-    # Convert to topocentric alt/az without refraction using the epoch-of-date coordinates.
+    # Convert to topocentric alt/az without refraction (relevant for in-atmosphere objects) using the 
+    # epoch-of-date coordinates.
     az_no_ref, alt_no_ref = raDec2AltAz(ra_epoch, dec_epoch, jd, platepar.lat, platepar.lon)
 
-    # Compute the apparent alt/az including refraction from the J2000 coordinates.
+    # Compute the apparent alt/az including refraction from the J2000 coordinates (relevant for 
+    # exo-atmosphere objects).
     az_with_ref, alt_with_ref = trueRaDec2ApparentAltAz(
         ra_j2000,
         dec_j2000,


### PR DESCRIPTION
## Summary
- add a command-line example in Tests that loads a platepar and converts pixel coordinates into RA/Dec and Alt/Az
- demonstrate both refraction-corrected and uncorrected conversions and a geodetic projection using AEGeoidH2LatLonAlt

## Testing
- python -m Tests.PlateparXY2SkyExample share/platepar_templates/template_generic_720p_6mm.cal 640 360 --time 2020-01-01T00:00:00 *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_69021f1c8970832981aa028b0204ab3c