### PR TITLE
Update device URL in configuration

### DIFF
--- a/.config
+++ b/.config
@@ -93,7 +93,7 @@ reboot_lock_file: .reboot_lock
 [Capture]
 
 ; device URL
-device: rtsp://192.168.1.25:554/user=admin&password=&channel=1&stream=0.sdp
+device: rtsp://192.168.42.10:554/user=admin&password=&channel=1&stream=0.sdp
 
 ; Transport Layer Protocol: 'tcp' or 'udp'. Defaults to tcp. UDP typically
 ; provides more stable connectivity, but TCP has a longer track record.


### PR DESCRIPTION
Correct default ip address in config file
This should not actually be an issue as the address baked-into the current image is correct and any self-builder would need to check it anyway. However if RMS_update crashes then this incorrect version can get left behind and sometimes stashed by mistake. 
This was reported by Chuck, who noted that several of his managed cameras had the wrong address.  However, oddly, it seems they had the correct camera ID and other parameters. Does RMS now have some code to attempt to patch teh config file with missing or "incorrect" values? That would be high risk. 
