### PR TITLE
Fix for issue #742 in master

### DIFF
--- a/Utils/FRbinViewer.py
+++ b/Utils/FRbinViewer.py
@@ -78,6 +78,10 @@ def view(dir_path, ff_path, fr_path, config, save_frames=False, extract_format=N
 
         # Make the image square
         img_size = max(y_size, x_size)
+                
+        # ffmpeg requires dimensions to be divisible by two on some platforms see issue 742
+        if img_size % 2:
+            img_size +=1
 
         background = np.zeros((img_size, img_size), np.uint8)
         add_timestamp = False


### PR DESCRIPTION
Adjust image size to be divisible by two to ensure compatability with various platforms. 
FFMPEG uses a codec that on linux and macos requires the dimensions to be even.
Thanks to Alex Aitov for pointing me in the right direction for a quick fix. 

This PR applies the fix to Master. there's a second PR to apply it in prerelease as the codebases are significantly different