### PR TITLE
Fix for issue #742 in FRbinViewer in prerelease

### DIFF
--- a/Utils/FRbinViewer.py
+++ b/Utils/FRbinViewer.py
@@ -308,6 +308,7 @@ def view(dir_path, ff_path, fr_path, config, save_frames=False, extract_format=N
         # ffmpeg requires dimensions to be divisible by two on some platforms see issue 742
         if img_size % 2: 
             img_size +=1
+            
         background = np.zeros((img_size, img_size), np.uint8)
         add_timestamp = False
         add_shower_name = False


### PR DESCRIPTION
Fix for issue reported by Ventsi Bo where FRbinViewer fails to create mp4s on Linux platforms, if the dimensions of the RoI bin file are not even.  
This PR pulls the fix into Prerelease. There is a separate PR for the same fix in Master, as the two codebases (master and prerelease) are significantly different. 