### PR TITLE
fix: Improve platepar loading to prevent the default hardcoded platep…

### DIFF
--- a/Utils/Flux.py
+++ b/Utils/Flux.py
@@ -1247,6 +1247,7 @@ def detectClouds(config, dir_path, N=5, mask=None, show_plots=True, save_plots=F
             config.platepars_flux_recalibrated_name,
             ignore_distance_threshold=True,
             ignore_max_stars=True,
+            platepar=platepar
         )
 
     # Skip the rest if this flag is on. This is used on Python 2 systems, as the rest of the code doesn't play


### PR DESCRIPTION
Sometimes the platepar does not get properly loaded during the recalibration procedure. This improvement passes a platepar to the recalibration function instead of the recalibration function having to find it on its own.