### PR TITLE
Network outage caused RMS_Update.sh to reclone after 5 failed git attempts, but the clone also failed (no network), leaving the station with no RMS directory.

### DIFF
--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -470,8 +470,9 @@ is_git_repo_corrupted() {
         local lsfiles_status
         lsfiles_err=$(git ls-files 2>&1) && lsfiles_status=0 || lsfiles_status=$?
         if [ $lsfiles_status -ne 0 ]; then
-            if echo "$lsfiles_err" | grep -qiE "(corrupt|bad signature|index file .* is corrupt)"; then
-                print_status "info" "Corruption check: index file corrupted"
+            # Check for various index corruption error messages
+            if echo "$lsfiles_err" | grep -qiE "(corrupt|bad signature|index file|smaller than expected|invalid)"; then
+                print_status "info" "Corruption check: index file corrupted: $lsfiles_err"
                 return 0  # corrupted
             fi
         fi


### PR DESCRIPTION
Normally, if a network outage is detected, RMS_Update does not proceed. However, if the network connection is initially established but subsequently fails during RMS_Update, it can cause RMS_Update.sh to reclone after 5 failed git attempts, but the clone also fails (no network), leaving the station with no RMS directory.

  Fix:
  1. Added is_git_repo_corrupted() function that checks for actual git corruption (missing .git, broken HEAD, corrupted index, etc.)
  2. Attempt 5 now only reclones if corruption is detected - network failures exit gracefully with "Repository is intact"
  3. If reclone is attempted but fails, the original directory is restored from backup
  4. Added error handling for edge cases (mv failures, etc.)

  Tested all failure git repo failure mode and network connection issue I could think of. 