### PR TITLE
Change camera style from type1 to type2

### DIFF
--- a/Guides/imx291-config-maps.md
+++ b/Guides/imx291-config-maps.md
@@ -9,7 +9,7 @@ BLC		Param.[0].BLCMode			                '0x00000000'
 Auto Iris	Param.[0].ApertureMode			        '0x00000000'  
 White Balance	Param.[0].WhiteBalance			    '0x00000002'  
 AE Ref		Param.[0].ElecLevel			            100  
-Image Style	ParamEx.[0].Style 			            'type1'  
+Image Style	ParamEx.[0].Style 			            'type2'  
 DNC Thresh	Param.[0].DncThr			            50  
 DWDR		ParamEx.[0].BroadTrends.AutoGain	    0    
 DWDR Lim	ParamEx.[0].BroadTrends.Gain		    50  

--- a/Utils/setAllCameraParams.py
+++ b/Utils/setAllCameraParams.py
@@ -324,7 +324,7 @@ if __name__ == '__main__':
         params[0]['ExtraFormat']['AudioEnable']=0
         cam.set_info("Simplify.Encode", params)
 
-        setCameraParam(cam, ['','Style','type1'])
+        setCameraParam(cam, ['','Style','type2'])
         setCameraParam(cam, ['','AeSensitivity','1'])
         setCameraParam(cam, ['','ApertureMode','0'])
         setCameraParam(cam, ['','BLCMode','0'])

--- a/camera_settings.json
+++ b/camera_settings.json
@@ -21,7 +21,7 @@
 
     ["SetParam", "Camera", "ClearFog", "enable", "0"],
     ["SetParam", "Camera", "ClearFog", "level", "30"],
-    ["SetParam", "Camera", "Style", "type1"],
+    ["SetParam", "Camera", "Style", "type2"],
     ["SetParam", "Camera", "AeSensitivity", "1"],
     ["SetParam", "Camera", "ApertureMode", "0"],
     ["SetParam", "Camera", "BLCMode", "0"],


### PR DESCRIPTION
For as long as GitHub goes, the camera settings files have set the camera style to type1. However, type1 is gamma 0.45 encoded, whereas style type2 is linear. This PR changes the default value; however, camera settings do not change without operator action. We should consider forcefully changing style to type2 in the future.