### PR TITLE
Fix environment marker field in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 gitpython>=2.1.8
 # Use versions 2.4.0 due to compatibility issues with OpenSSL on Pi3/Jessie
-paramiko==2.4.0; python_version=='2.7'
 paramiko>=2.9.0; python_version>='3.6'
-numpy>=1.13.3,<1.22.0 ; python_version=='2.7'
-numpy>=1.21.0,<1.24.0 ; python_version>='3.6' and python_version<='3.9.2'
-numpy>=1.26.0,<2.0.0 ; python_version>'3.9.2'
+numpy>=1.19.0,<1.21.0 ; python_version=='3.6'
+numpy>=1.21.0,<1.24.0 ; python_version>='3.7' and python_version<'3.10'
+numpy>=1.26.0,<2.0.0 ; python_version>='3.10'
 matplotlib>=2.1.1
 pyephem>=3.7.6.0
 cython>=0.27.3
@@ -15,7 +14,6 @@ imreg_dft @ git+https://github.com/matejak/imreg_dft@master#egg=imreg_dft>'2.0.0
 configparser==4.0.2
 imageio==2.6.1
 python-dvr>=0.0.1 ; python_version >='3.6'
-pyqtgraph @ git+https://github.com/pyqtgraph/pyqtgraph@develop#egg=pyqtgraph ; python_version=='2.7'
 pyqtgraph>=0.12,<0.13 ; python_version >='3.6'
 pyyaml; python_version>='3.6'
 tflite-runtime; python_version >= '3.6' and python_version < '3.12' and sys_platform != 'darwin'


### PR DESCRIPTION
Remove minor version in the environment marker fields as this is not supported. Also, remove obsolete Python 2-related requirements.