### PR TITLE
Fix Ctrl+C and SIGTERM handling during wait phase

### DIFF
--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -14,6 +14,8 @@ import string
 import inspect
 import datetime
 import tarfile
+import threading
+import signal
 
 # tkinter import that works on both Python 2 and 3
 if sys.version_info[0] < 3:
@@ -41,6 +43,51 @@ if sys.version_info[0] < 3:
 
 # Get the logger from the main module
 log = getLogger("rmslogger")
+
+
+def interruptibleWait(seconds):
+    """ Wait for the specified number of seconds, but allow interruption by Ctrl+C.
+
+    This replaces time.sleep() for long waits that should be interruptible.
+    Uses threading.Event to allow immediate response to SIGINT.
+
+    Arguments:
+        seconds: [float] Number of seconds to wait.
+
+    Returns:
+        bool: True if wait completed normally, False if interrupted by Ctrl+C.
+    """
+
+    # Create a local event for this wait
+    wait_event = threading.Event()
+
+    # Save the current SIGINT handler
+    original_handler = signal.signal(signal.SIGINT, signal.default_int_handler)
+
+    # Define a handler that sets the event
+    def interrupt_handler(signum, frame):
+        wait_event.set()
+
+    # Install our handler
+    signal.signal(signal.SIGINT, interrupt_handler)
+
+    try:
+        # Wait for the timeout or interruption
+        interrupted = wait_event.wait(timeout=seconds)
+
+        # Restore the original handler
+        signal.signal(signal.SIGINT, original_handler)
+
+        # If interrupted, raise KeyboardInterrupt to maintain compatibility
+        if interrupted:
+            raise KeyboardInterrupt()
+
+        return True
+
+    except Exception:
+        # Make sure we restore the handler even if something goes wrong
+        signal.signal(signal.SIGINT, original_handler)
+        raise
 
 
 def mkdirP(path):

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -1136,12 +1136,10 @@ if __name__ == "__main__":
 
             log.debug('Less than 15 minutes left to record, waiting for a new recording session tonight...')
 
-            # Reset the Ctrl+C to KeyboardInterrupt
-            resetSIGINT()
-
             try:
-                # Wait for 30 mins before checking again
-                time.sleep(30*60)
+                # Wait for 30 mins before checking again (interruptible)
+                from RMS.Misc import interruptibleWait
+                interruptibleWait(30*60)
 
             except KeyboardInterrupt:
 
@@ -1240,15 +1238,13 @@ if __name__ == "__main__":
                 log.info('Waiting {:s} to start recording for {:.3f} hrs'.format(str(waiting_time), \
                     duration/60/60))
 
-                # Reset the Ctrl+C to KeyboardInterrupt
-                resetSIGINT()
-
                 try:
 
-                    # Wait until sunset
+                    # Wait until sunset (interruptible)
                     waiting_time_seconds = int(waiting_time.total_seconds())
                     if waiting_time_seconds > 0:
-                        time.sleep(waiting_time_seconds)
+                        from RMS.Misc import interruptibleWait
+                        interruptibleWait(waiting_time_seconds)
 
                 except KeyboardInterrupt:
 


### PR DESCRIPTION
Ctrl+C and SIGTERM were not working during the "Waiting to start recording" phase. The time.sleep() call blocks without responding to signals. This is especially troublesome for the new GRMSUpdater as it attempts to shutdown StartCapture cleanly by sending a SIGTERM. In turn, this is needed for clean update in continuous mode.

Fix: Add interruptibleWait() function that uses threading.Event.wait() with a custom SIGINT handler, allowing immediate response to Ctrl+C. Replace time.sleep() with interruptibleWait() at both wait locations in StartCapture.