### PR TITLE
Remove platepar to FTPdetectinfo time check

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -792,27 +792,12 @@ def processIncompleteCaptures(config, upload_manager):
         #   processed
         FTPdetectinfo_files = glob.glob('{:s}/FTPdetectinfo_*.txt'.format(captured_dir_path))
         any_ftpdetectinfo_files = False
-        newest_FTPfile_older_than_platepar = False
         if len(FTPdetectinfo_files) > 0:
             any_ftpdetectinfo_files = True
-
-            # Is the platepar in the captured_dir_path newer than latest FTP file?
-            # i.e. has the operator replaced the platepar because of bad calibration?
-            newest_FTPfile_older_than_platepar = True
-            for FTPfile in FTPdetectinfo_files:
-                capture_platepar = os.path.join(captured_dir_path,config.platepar_name)
-                if os.path.exists(capture_platepar):
-                    # Any FTPfile newer than platepar - no need to reprocess
-                    if os.path.getmtime(FTPfile) > os.path.getmtime(capture_platepar):
-                        newest_FTPfile_older_than_platepar = False
-                else:
-                    # if there is no platepar in the captured_dir_path
-                    newest_FTPfile_older_than_platepar = False
 
         # Auto reprocess criteria:
         #   - Any backup pickle files
         #   - No pickle and no FTPdetectinfo files
-        #   - Newest FTP file older than platepar in capture directory
 
         run_reprocess = False
         if any_pickle_files:
@@ -820,9 +805,6 @@ def processIncompleteCaptures(config, upload_manager):
         else:
             if not any_ftpdetectinfo_files:
                 run_reprocess = True
-        if newest_FTPfile_older_than_platepar:
-                run_reprocess = True
-                log.info("Reprocessing because newest FTPDetect file older than platepar file")
 
         # Skip the folder if it doesn't need to be reprocessed
         if not run_reprocess:


### PR DESCRIPTION
Remove 'Newest FTP file older than platepar in capture directory' auto reprocess criteria as it causes infinite reprocessing of capture directories with no meteor detection. If a newer pp is added, manual reprocessing can be performed.