### PR TITLE
Use flatten() instead of list comprehension to preserve scalar type in star coordinates with NumPy 1.26+

### DIFF
--- a/RMS/ExtractStars.py
+++ b/RMS/ExtractStars.py
@@ -136,8 +136,9 @@ def extractStars(img, img_median=None, mask=None, gamma=1.0, max_star_candidates
     y_init, x_init = np.hsplit(xy, 2)
 
     # Compensate for half-pixel shift caused by the 2x2 mean filter
-    x_init = [x + 0.5 for x in x_init]
-    y_init = [y + 0.5 for y in y_init]
+    # Flatten to get scalars - hsplit returns (n,1) column arrays
+    x_init = x_init.flatten() + 0.5
+    y_init = y_init.flatten() + 0.5
 
     # # Plot stars before the PSF fit
     # plotStars(ff, x, y)
@@ -547,13 +548,13 @@ def fitPSF(img, img_median, x_init, y_init, gamma=1.0, segment_radius=4, roundne
         x_max = x + segment_radius
 
         if y_min < 0:
-            y_min = np.array([0])
+            y_min = 0
         if y_max > nrows:
-            y_max = np.array([nrows])
+            y_max = nrows
         if x_min < 0:
-            x_min = np.array([0])
+            x_min = 0
         if x_max > ncols:
-            x_max = np.array([ncols])
+            x_max = ncols
 
         # Check if any of these values is NaN and skip the star
         if np.any(np.isnan([x_min, x_max, y_min, y_max])):


### PR DESCRIPTION
The March 2025 half-pixel shift compensation used a list comprehension that converted hsplit results into 1D arrays instead of scalars. This caused int() to fail on NumPy 1.26+ when boundary checks assigned np.array([0]).

 Fixed by using flatten() to preserve scalar types, and reverting boundary values to plain integers.