### PR TITLE
Replace walrus operator to preserve Python 3.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,10 +69,11 @@ cython_modules = [
 
 # Runtime requirements
 with open("requirements.txt") as fh:
-    requirements = [
-        stripped for line in fh
-        if (stripped := line.strip()) and not stripped.startswith("#") and not stripped.startswith("git+")
-    ]
+    requirements = []
+    for line in fh:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and not stripped.startswith("git+"):
+            requirements.append(stripped)
 
 # Data files
 base = Path(__file__).resolve().parent


### PR DESCRIPTION
Fix a syntax issue cause by a recently itroduced change which broke compatibility with Python 3.7.  The walrus operator := is not supported in Python 3.7.