### PR TITLE
Update ai-edge-litert requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,7 @@ python-dvr>=0.0.1 ; python_version >='3.6'
 pyqtgraph>=0.12,<0.13 ; python_version >='3.6'
 pyyaml; python_version>='3.6'
 tflite-runtime; python_version >= '3.6' and python_version < '3.12' and sys_platform != 'darwin'
-ai-edge-litert>=1.3,<2.0 ; python_version >= '3.12' and python_version < '3.13' and platform_machine != "armv6l" and platform_machine != "armv7l"
-ai-edge-litert==2.1.0rc1 ; python_version >= '3.13' and platform_machine != "armv6l" and platform_machine != "armv7l"
+ai-edge-litert>=1.3 ; python_version >= '3.12' and platform_machine != "armv6l" and platform_machine != "armv7l"
 astrometry; python_version >= "3.8" and sys_platform != 'win32'
 astrometry==3.0.0; python_version >= "3.5" and python_version < "3.8" and sys_platform != 'win32'
 pyclean>=2.7.6; python_version >= "3.5"


### PR DESCRIPTION
Previously, we required a release candidate version to support Python 3.13 (Trixie). This is no longer necessary as the new ai-edge-litert 2.1.0 wheel supports Python 3.12 and 3.13.