### PR TITLE
Handle bad log names and reduce logging

### DIFF
--- a/Tests/SkeletonExternalScript.py
+++ b/Tests/SkeletonExternalScript.py
@@ -31,7 +31,7 @@ import RMS.ConfigReader as cr
 
 LOG_FILE_PREFIX = "EXTERNAL"
 
-log = getLogger("logger", stdout=False)
+log = getLogger("rmslogger", stdout=False)
 
 
 def createLock(config, log):

--- a/Utils/LogArchiver.py
+++ b/Utils/LogArchiver.py
@@ -29,7 +29,7 @@ from RMS.Logger import getLogger
 LATEST_LOG_UPLOADS_FILE_NAME = ".latestloguploads.json"
 ISO_DATE_2000 = datetime.datetime(int(2000), int(1), int(1), int(0), int(0), int(0)).isoformat()
 
-log = getLogger("logger")
+log = getLogger("rmslogger")
 
 
 def getTimeOfLastLogEntry(config, log_file):


### PR DESCRIPTION
This is a fix for issue #793.

When a badly formed log name appears in ~/RMS_data/logs/ this causes LogArchiver to fail. 

This PR removes any badly formed log names, and slightly reduces logging.

```
(vRMS) david@lap-deb-01:~/source/RMS$ python -m Utils.LogArchiver -t
Camera settings file: ./camera_settings.json
Loading the default config!
Log type SETI latest info uploaded was 2025-07-30T14:31:09
Log type camControl latest info uploaded was 2025-08-06T15:10:36
Log type log latest info uploaded was 2025-12-23T06:12:48
Log type reprocess latest info uploaded was 2025-12-20T11:02:20
                 : log
                 : camControl
                 : bad.log
                 : reprocess
                 : log
                 : camControl
                 : SETI
                 : bad.log
                 : reprocess
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/david/source/RMS/Utils/LogArchiver.py", line 300, in <module>
    archive_file_name = makeLogArchives(config, latest_captured_directory_full_path, update_tracker=cml_args.tracker)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/source/RMS/Utils/LogArchiver.py", line 219, in makeLogArchives
    date_for_this_log_type = datetime.datetime.fromisoformat(latest_log_uploads_dict[log_file_type])
                                                             ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'bad.log'
```

However, with this PR

```
(vRMS) david@lap-deb-01:~/source/RMS$ python -m Utils.LogArchiver -t
Camera settings file: ./camera_settings.json
Loading the default config!
Log type camControl latest info uploaded was 2025-08-06T15:10:36
Log type log latest info uploaded was 2025-12-23T06:12:48
Log type reprocess latest info uploaded was 2025-12-20T11:02:20
Adding camControl_log_AU000A_20250806_151036.log to log upload archive to ensure overlap with last upload
Adding log_AU000A_20251223_061248_001.log to log upload archive to ensure overlap with last upload
Adding reprocess_log_AU000A_20251220_110220_001.log to log upload archive to ensure overlap with last upload
Log directory structure created at /tmp/tmphtalpifh
For log file type camControl the newest file is camControl_log_AU000A_20250806_151036.log, last entry is 2025-08-06 15:10:36
For log file type log the newest file is log_AU000A_20251223_061248_001.log, last entry is 2025-12-24 02:48:25
For log file type reprocess the newest file is reprocess_log_AU000A_20251220_110220_001.log, last entry is 2025-12-20 11:03:00
Logs archived at /home/david/RMS_data/CapturedFiles/AU000A_20250809_102552_318266/AU000A_20250809_102552_318266_logs.tar.bz2
```



