### PR TITLE
Fix logger name typo in Logger.py

### DIFF
--- a/RMS/Logger.py
+++ b/RMS/Logger.py
@@ -612,7 +612,7 @@ def getLogger(name=None, level="DEBUG", stdout=False):
     Return:
         [Logger] Logger instance
     """
-    logger = logging.getLogger(name if name else "rmsogger")
+    logger = logging.getLogger(name if name else "rmslogger")
 
     level_map = {
         "DEBUG": logging.DEBUG,


### PR DESCRIPTION
Typo in Logger.py - logger name was misspelled as "rmsogger" without the ell. The error probably never got revealed as Logger.getLogger is always called with an argumemt.