### PR TITLE
Cython missing from install on trixie

### DIFF
--- a/Scripts/RMS_Installer.sh
+++ b/Scripts/RMS_Installer.sh
@@ -69,6 +69,7 @@ python3 -m venv --system-site-packages vRMS
 source ~/vRMS/bin/activate
 
 # Install Python packages
+python -m pip install cython
 python -m pip install --upgrade pip setuptools wheel
 python -m pip install -r ~/source/RMS/requirements.txt
 


### PR DESCRIPTION
Installing on trixie, imreg_dft fails to build as cython package missing. Added this into the install script. 
