### PR TITLE
eventmonitor recovers raw video files and, where available frames files

### DIFF
--- a/RMS/EventMonitor.py
+++ b/RMS/EventMonitor.py
@@ -1655,7 +1655,10 @@ class EventMonitor(multiprocessing.Process):
 
         """
 
+        # Create a set which will hold all the candidate files
         time_matched_path_and_file_set = set()
+
+        # Initialise the keyword variables
         if search_from_list is None:
             search_from_list = [self.config.video_dir, self.config.frame_dir]
 
@@ -1665,7 +1668,7 @@ class EventMonitor(multiprocessing.Process):
         if duration_list is None:
             duration_list = [self.config.raw_video_duration, self.config.frame_save_aligned_interval]
 
-
+        # Populate the candidate file set with al the files from the list of starting search points
         for search_from, suffix, duration in zip(search_from_list, suffix_list, duration_list):
             candidate_file_set = set()
             search_from = os.path.join(self.config.data_dir, search_from)
@@ -1694,7 +1697,10 @@ class EventMonitor(multiprocessing.Process):
                 times_list = [file_start_time, file_end_time]
                 event_time = convertGMNTimeToPOSIX(event.dt)
 
+                # Sort the times list, so that the first element is before the second
                 times_list.sort()
+
+                # Now check the times
                 for time_point in times_list:
                     time_delta = abs(time_point - event_time).total_seconds()
                     # Is the event_time point within tolerance of the start and end, or between the start and end


### PR DESCRIPTION
This PR is in response to issue #811 

New features in RMS allow the capture of accurately timestamped image files and also high quality mkv video files. 

This PR adds the ability for eventmonitor to recover these images files and video files. 
The mkv files are concatenated into a single file, for compatibility and ease of viewing - this feature was removed to reduce upload size.

For example

```# Testing raw video and frames files
EventTime                : 20260201_095500
TimeTolerance (s)        : 40
EventLat (deg +N)        : -32.343
EventLon (deg +E)        : 116.257
EventHt (km)             : 100
CloseRadius(km)          : 100
FarRadius (km)           : 600
RequireFR                : 0
END
```

Returns the files 40 seconds either side of 20260201_095500. The returned archive is named

```-rw-r--r--  1 david david 3.7M Feb  1 10:15 AU000A_20260201_095500_event.tar.bz2```

And when extracted contains 

```
total 4.0M
drwxr-xr-x 2 david david 4.0K Feb  1 10:13 .
drwxr-xr-x 3 david david 4.0K Feb  1 10:13 ..
-rw-r--r-- 1 david david 1.5M Feb  1 10:13 20260201_095500_raw_files.mkv
-rw-r--r-- 1 david david 1.5M Feb  1 10:13 20260201_095500_raw_files.mp4
-rw-r--r-- 1 david david 203K Feb  1 10:13 AU000A_20260201_095358_213537_video.mkv
-rw-r--r-- 1 david david  20K Feb  1 10:13 AU000A_20260201_095420_000_d.jpg
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095425_000_d.jpg
-rw-r--r-- 1 david david 205K Feb  1 10:13 AU000A_20260201_095428_218112_video.mkv
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095430_000_d.jpg
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095435_000_d.jpg
-rw-r--r-- 1 david david  20K Feb  1 10:13 AU000A_20260201_095440_000_d.jpg
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095445_000_d.jpg
-rw-r--r-- 1 david david  20K Feb  1 10:13 AU000A_20260201_095450_000_d.jpg
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095455_000_d.jpg
-rw-r--r-- 1 david david 211K Feb  1 10:13 AU000A_20260201_095458_204464_video.mkv
-rw-r--r-- 1 david david  20K Feb  1 10:13 AU000A_20260201_095500_000_d.jpg
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095505_000_d.jpg
-rw-r--r-- 1 david david  20K Feb  1 10:13 AU000A_20260201_095510_000_d.jpg
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095515_000_d.jpg
-rw-r--r-- 1 david david  20K Feb  1 10:13 AU000A_20260201_095520_000_d.jpg
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095525_000_d.jpg
-rw-r--r-- 1 david david 199K Feb  1 10:13 AU000A_20260201_095528_173892_video.mkv
-rw-r--r-- 1 david david  20K Feb  1 10:13 AU000A_20260201_095530_000_d.jpg
-rw-r--r-- 1 david david  19K Feb  1 10:13 AU000A_20260201_095535_000_d.jpg
-rw-r--r-- 1 david david 1.5K Feb  1 10:13 event_report.txt
-rw-r--r-- 1 david david  188 Feb  1 10:13 mkv_list.txt
```

The small bright fleck in this jpg file is NWK1733, flying south-south-west towards a north facing station, AU000A at Perth Observatory.

![AU000A_20260201_095455_000_d](https://github.com/user-attachments/assets/2759b27c-692d-4e00-a543-d7a3475495e7)

The video file shows the aircraft, starting from about 00:55.

https://github.com/user-attachments/assets/d9cebe44-5db5-4765-9299-06f3ebb1ba38

For meteor work, 

```EventTime                : 20260131_183727
TimeTolerance (s)        : 20
EventLat (deg +N)        : -32.343
EventLon (deg +E)        : 116.257
EventHt (km)             : 100
CloseRadius(km)          : 100
FarRadius (km)           : 600
RequireFR                : 0
END
```

The archive was created as 

```
-rw-r--r--  1 david david  55M Feb  1 10:35 AU000A_20260131_183727_event.tar.bz2
```

When extracted, it contains,

```-rw-r--r-- 1 david david  11M Feb  1 10:30 20260131_183727_raw_files.mkv
-rw-r--r-- 1 david david  11M Feb  1 10:30 20260131_183727_raw_files.mp4
-rw-r--r-- 1 david david  14M Feb  1 10:29 AU000A_20260131_183703_733958_video.mkv
-rw-r--r-- 1 david david  14M Feb  1 10:29 AU000A_20260131_183733_721059_video.mkv
-rw-r--r-- 1 david david  93K Feb  1 10:29 AU000A_captured_stack.jpg
-rw-r--r-- 1 david david  25K Feb  1 10:29 .config
-rw-r--r-- 1 david david 1.5K Feb  1 10:30 event_report.txt
-rw-r--r-- 1 david david 3.6M Feb  1 10:29 FF_AU000A_20260131_183716_858_0590336.fits
-rw-r--r-- 1 david david  54K Feb  1 10:29 FF_AU000A_20260131_183716_858_0590336.jpg
-rw-r--r-- 1 david david 3.6M Feb  1 10:29 FF_AU000A_20260131_183727_098_0590592.fits
-rw-r--r-- 1 david david  55K Feb  1 10:29 FF_AU000A_20260131_183727_098_0590592.jpg
-rw-r--r-- 1 david david 3.6M Feb  1 10:29 FF_AU000A_20260131_183737_338_0590848.fits
-rw-r--r-- 1 david david  56K Feb  1 10:29 FF_AU000A_20260131_183737_338_0590848.jpg
-rw-r--r-- 1 david david 245K Feb  1 10:29 FR_AU000A_20260131_183727_098_0590592.bin
-rw-r--r-- 1 david david 102K Feb  1 10:29 FR_AU000A_20260131_183727_098_0590592_line_00.mp4
-rw-r--r-- 1 david david   94 Feb  1 10:29 mkv_list.txt
-rw-r--r-- 1 david david  20K Feb  1 10:29 platepar_cmn2010.cal
```

And contains an MP4, showing the meteor around 30 seconds into the video.

The frames file had already been deleted, so these were not uploaded.