### PR TITLE
Handle SFTP connection drops gracefully in platepar and mask downloads 

### DIFF
--- a/RMS/DownloadMask.py
+++ b/RMS/DownloadMask.py
@@ -160,6 +160,10 @@ def downloadNewMask(config):
 
         log.info('Remote mask renamed to: ' + dl_mask_name)
 
+    except (paramiko.SSHException, EOFError, OSError) as e:
+        log.warning('Connection error during mask download: {}'.format(e))
+        return False
+
     finally:
         if sftp:
             log.debug("Closing SFTP channel")

--- a/RMS/DownloadPlatepar.py
+++ b/RMS/DownloadPlatepar.py
@@ -83,6 +83,10 @@ def downloadNewPlatepar(config):
 
         log.info('Remote platepar renamed to: ' + dl_pp_name)
 
+    except (paramiko.SSHException, EOFError, OSError) as e:
+        log.warning('Connection error during platepar download: {}'.format(e))
+        return False
+
     finally:
         if sftp:
             log.debug("Closing SFTP channel")


### PR DESCRIPTION
Address issue #721 by adding except (paramiko.SSHException, EOFError, OSError) to DownloadPlatepar.py and DownloadMask.py so stale/dropped SFTP connections return False instead of crashing StartCapture.