### PR TITLE
Start work on generating thumbnails during capture

### DIFF
--- a/RMS/Compression.py
+++ b/RMS/Compression.py
@@ -38,7 +38,6 @@ from RMS.Routines.Image import saveImage
 import pyximport
 pyximport.install(setup_args={'include_dirs':[np.get_include()]})
 from RMS.CompressionCy import compressFrames
-from Utils.GenerateThumbnails import Thumbnail
 
 # Get the logger from the main module
 log = getLogger("rmslogger")
@@ -84,7 +83,8 @@ class Compressor(multiprocessing.Process):
         self.exit = multiprocessing.Event()
 
         self.run_exited = multiprocessing.Event()
-        self.thumbnail = Thumbnail(config, 'captured')
+        self.thumbnail = RMS.Utils.GenerateThumbnails.Thumbnail
+
 
 
     def compress(self, frames):
@@ -242,16 +242,17 @@ class Compressor(multiprocessing.Process):
             self.join()
 
         # Return the detector and live viewer objects because they were updated in this namespace
-        return self.detector
+        return self.detector, self.thumbnail
     
 
 
-    def start(self):
+    def start(self, thumbnail):
         """ Start compression.
         """
         
         super(Compressor, self).start()
-    
+        self.thumbnail = thumbnail
+        pass
 
 
     def run(self):

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -55,6 +55,7 @@ from RMS.EventMonitor import EventMonitor
 from RMS.DownloadMask import downloadNewMask
 from RMS.Formats.ObservationSummary import startObservationSummaryReport
 from Utils.AuditConfig import compareConfigs
+from Utils.GenerateThumbnails import Thumbnail
 
 # Flag indicating that capturing should be stopped
 STOP_CAPTURE = False
@@ -616,7 +617,8 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
                 log.info(startObservationSummaryReport(config, duration, force_delete=False))
 
             # Start the compressor
-            compressor.start()
+            thumbnail = Thumbnail(config, "DETECTED", testing=True)
+            compressor.start(thumbnail)
 
             # Capture until Ctrl+C is pressed / camera switches modes
             if (daytime_mode is not None):
@@ -678,8 +680,10 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
 
             # Stop the compressor
             log.debug('Stopping compression...')
-            detector = compressor.stop()
+            detector, thumbnail  = compressor.stop()
             log.debug('Compression stopped')
+            thumbnail.add(None, None, final=True)
+            thumbnail.export(night_data_dir)
 
             if live_view is not None:
 

--- a/Utils/GenerateThumbnails.py
+++ b/Utils/GenerateThumbnails.py
@@ -118,6 +118,10 @@ class Thumbnail:
         """
 
         x, y, z = self.serialToCoordinates(self.img_index)
+        if final:
+            log.info(f"Finalising thumbnail of {self.img_index} images")
+
+        log.info(f"Adding image {self.img_index}")
         if z == 0 and ff is not None and ff_name is not None:
 
             # If it is the first image - this is a placeholder in case any work is required
@@ -185,8 +189,7 @@ class Thumbnail:
         log.info("Starting thumbnail export")
         # Build the body of the image
 
-        self.add(None, None, final=True)
-
+        log.info(f"Building mosaic of {self.img_index} images")
         log.info(f"Building thumbnail body from {len(self.row_list)} rows")
         thumbnail_mosaic = np.vstack(self.row_list)
 


### PR DESCRIPTION
This PR is in response to issue #822, and is a test of creating thumbnails, and possibly timelapse on the fly. 

It creates a class Thumbnail, to which images are added. The images are placed on a canvas in the same way as the original GenerateThumbanails process. The key difference is that the time taken to produce and save the Thumbnail at the end of capture is reduced by at least one order of magnitude. 

This is an example of a thumbnail produced 'on the fly'

![AU000A_20260204_115819_413028_CAPTURED_on_the_fly_thumbs](https://github.com/user-attachments/assets/1564d6f2-2953-4df6-8281-f4e993ecf366)

And by the conventional technique, which reads all the files in at the end.

![AU000A_20260204_115819_413028_CAPTURED_thumbs](https://github.com/user-attachments/assets/b771abc8-2085-4a55-95b7-3fc4d9971e4d)

