### PR TITLE
Update requirements.txt for bcrypt and cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 gitpython>=2.1.8
 # Use versions 2.4.0 due to compatibility issues with OpenSSL on Pi3/Jessie
 paramiko>=2.9.0; python_version>='3.6'
+# Cap bcrypt and cryptography for Python 3.7 (no prebuilt armv7l wheels for newer versions)
+bcrypt<4.0; python_version<'3.8'
+cryptography<4.0; python_version<'3.8'
 numpy>=1.19.0,<1.21.0 ; python_version=='3.6'
 numpy>=1.21.0,<1.24.0 ; python_version>='3.7' and python_version<'3.10'
 numpy>=1.26.0,<2.0.0 ; python_version>='3.10'


### PR DESCRIPTION
When rebuilding a new vRMS venv on Buster, pip install fails because newer versions of bcrypt and cryptography require a Rust compiler, which is not available on most Pi setups. This PR caps bcrypt and cryptography versions for Python 3.7 compatibility. 