### PR TITLE
Fix egg fragment syntax for pip 26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ cython>=0.27.3
 scipy>=1.0.0
 Pillow>=4.3.0
 astropy>=2.0.3
-imreg_dft @ git+https://github.com/matejak/imreg_dft@master#egg=imreg_dft>'2.0.0'
+imreg_dft @ git+https://github.com/matejak/imreg_dft@master
 configparser==4.0.2
 imageio==2.6.1
 python-dvr>=0.0.1 ; python_version >='3.6'


### PR DESCRIPTION
Apply fix from prerelease into master for pip 26 syntax error in requirements.