### PR TITLE
Remove outdated comment from .config

### DIFF
--- a/.config
+++ b/.config
@@ -298,8 +298,6 @@ times_days_to_keep: 8
 
 
 ; the next settings configure the archive management by space used on disk
-; disabling quota management generates the reports, lists the files
-; that would be deleted but prevents any action from being taken
 quota_management_enabled: false
 
 ; Any one of the next five parameters missing or commented out disables


### PR DESCRIPTION
Config file in prerelease contains a comment which was made obsolete by pr #634.

This PR removes that comment