### PR TITLE
Fix unclear comment in ArchiveDetections

### DIFF
--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -295,6 +295,8 @@ def archiveDetections(captured_path, archived_path, ff_detected, config, extra_f
         imgdata_archived_path = f"{archived_path}_imgdata"
         imgdata_archive_name = f"{archive_base}_imgdata"
 
+        # In all cases create and retain the directory of detected files
+
         # Make the archive directory and compress into _detected.tar.bz2 if config.upload_split is False.
 
         create_detected_tar_bz2 = not config.upload_split


### PR DESCRIPTION
archiveDetections contains a comment which is confusing. This PR clarifies that comment.