### PR TITLE
bugfix: specify type of config argument so that its handled properly …

### DIFF
--- a/RMS/Astrometry/AutoPlatepar.py
+++ b/RMS/Astrometry/AutoPlatepar.py
@@ -738,7 +738,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Auto-fit platepar from CALSTARS data")
     parser.add_argument("dir_path", help="Path to directory with CALSTARS file")
-    parser.add_argument("-c", "--config", help="Path to config file", default=None)
+    parser.add_argument("-c", "--config", nargs=1, metavar='CONFIG_PATH', type=str, help="Path to config file", default=None)
 
     # Fitting parameters (matching SkyFit2 defaults)
     parser.add_argument("--distortion", default=DEFAULT_DISTORTION_TYPE,
@@ -763,7 +763,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Load config
-    config = cr.loadConfigFromDirectory(args.config if args.config else '.', args.dir_path)
+    config = cr.loadConfigFromDirectory(args.config if args.config is not None else '.', args.dir_path)
 
     # Load star catalog
     catalog_stars = loadCatalogStars(config, config.catalog_mag_limit)


### PR DESCRIPTION
On windows, the -c argument was being misintepreted, if it contained a drive letter eg e:\
The fix is to specify the nargs and type arguments when adding to argparser. 

I also made the test of None explicit later on, probably not needed but this aligns with eg SkyFit2 so it adds some consistency.

Tested on Windows 11 and Ubuntu 24 (under WSL).
