### PR TITLE
Config secion: posibility to use old ML model

### DIFF
--- a/.config
+++ b/.config
@@ -648,6 +648,9 @@ min_patch_intensity_multiplier: 0.0
 ; the min_patch_intensity_multiplier filtering method.
 ml_filter: 0.85
 
+; use alternate model for ML filtering - file in share directory, default: hyper_model.tflite
+;ml_model_file = meteorml32.tflite
+
 ; All detection this close (in pixels) to the edge of the image or the mask
 ; will be removed
 detection_border: 5

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -1677,6 +1677,9 @@ def parseMeteorDetection(config, parser):
         if TFLITE_AVAILABLE and (config.ml_filter > 0):
             config.min_patch_intensity_multiplier = 0
 
+    if parser.has_option(section, "ml_model_file"):
+        config.ml_model_file = parser.get(section, "ml_model_file")
+        config.ml_model_path = os.path.join(config.rms_root_dir, "share", config.ml_model_file)
 
     if parser.has_option(section, "detection_border"):
         config.detection_border = parser.getint(section, "detection_border")


### PR DESCRIPTION
On CSI camera (non standard setup, no x264 compression) old ML model (meteorml32) has better results - up to 30% meteors are correctly detected.