### PR TITLE
Class supporting queries for GMN catalog

### DIFF
--- a/RMS/Formats/StarCatalog.py
+++ b/RMS/Formats/StarCatalog.py
@@ -6,6 +6,7 @@ import os
 import zlib
 import sys
 import argparse
+import time
 
 from RMS.Math import angularSeparationDeg
 from RMS.Logger import LoggingManager, getLogger
@@ -94,7 +95,7 @@ class Catalog:
 
     def queryRaDec(self, ra_deg, dec_deg, radius_deg=0.1, n_brightest=1):
         """
-
+        Tree search for ra dec coordinates, search is in a wrapped Euclidean space
 
         Arguments:
             ra_deg: [float] right ascension degrees
@@ -806,7 +807,7 @@ def testCatQueryRaDec():
     ])
 
     cat = Catalog(config, lim_mag=6)
-    print(serializeQueryResults(cat.queryRaDec(test_star_ra_deg, test_star_dec_deg, radius_deg=2, n_brightest=3), test_star_names, test_star_mag))
+    log.info(serializeQueryResults(cat.queryRaDec(test_star_ra_deg, test_star_dec_deg, radius_deg=2, n_brightest=3), test_star_names, test_star_mag))
 
 
 def serializeQueryResults(results, star_names=None, star_mag=None):
@@ -848,7 +849,7 @@ if __name__ == "__main__":
     arg_parser.add_argument('-c', '--config', nargs=1, metavar='CONFIG_PATH', type=str, \
         help="Path to a config file which will be used instead of the default one.")
 
-    arg_parser.add_argument('--radec', metavar='radec', nargs=3, help="""Search in radec space (degrees) RA DEC Radius""")
+    arg_parser.add_argument('--radec', metavar='radec', nargs=4, help="""Search in radec space (degrees) RA DEC Radius Lim Mag""")
 
     arg_parser.add_argument('-t', '--test', action="store_true", help="""Run tests""")
 
@@ -859,19 +860,23 @@ if __name__ == "__main__":
     config = cr.loadConfigFromDirectory(cml_args.config, os.path.abspath('.'))
 
     #Initialize the logger
-    #log_manager = LoggingManager()
-    #log_manager.initLogging(config)
+    log_manager = LoggingManager()
+    log_manager.initLogging(config)
 
 
     #Get the logger handle
-    #log = getLogger("rmslogger")
+    log = getLogger("rmslogger")
 
     if cml_args.test:
         test = testCatQueryRaDec()
 
 
     if cml_args.radec is not None:
-        print(f"Querying RA={cml_args.radec[0]} DEC={cml_args.radec[1]} degrees")
-        cat = Catalog(config, lim_mag=10)
-        results = cat.queryRaDec(float(cml_args.radec[0]), float(cml_args.radec[1]), float(cml_args.radec[2]))
-        print(serializeQueryResults(results))
+        ra, dec, radius = float(cml_args.radec[0]), float(cml_args.radec[1]), float(cml_args.radec[2])
+        lim_mag = float(cml_args.radec[3])
+        log.info(f"Querying RA={ra:.3f} DEC={dec:.3f} Radius={radius:.3f} degrees Limiting mag={lim_mag:.1f}")
+        cat = Catalog(config, lim_mag=float(cml_args.radec[2]))
+        results = cat.queryRaDec(ra, dec, lim_mag)
+        log.info(serializeQueryResults(results))
+        # Allow logger time to write
+        time.sleep(1)


### PR DESCRIPTION
Adds a Catalog class which on initialization reads in the GMN catalog, and exposes a query interface which can receive scalars or arrays for a tree search in a Euclidean space. Once the catalog is loaded, multiple queries can be executed very quickly. 

Return is a list of arrays of results, one item for scalar inputs, multiple for array inputs. Results are ordered by increasing magnitude.

e.g.

```
cat = Catalog(config, lim_mag=10)
results = cat.queryRaDec(ra, dec, radius)
```


Also adds a command line interface. 

```
(vRMS) :~/source/RMS$ python -m RMS.Formats.StarCatalog --radec 0.1 55.7537 1 6
2026/03/20 04:21:32-INFO-StarCatalog-line:877 - Querying RA=0.100 DEC=55.754 Radius=1.000 degrees Limiting mag=6.0
2026/03/20 04:21:38-INFO-StarCatalog-line:880 - 		Returned name: HD 3712              RA=  10.127  Dec=  56.537  Mag= 1.94  Sep= 5.636

```
Queries wrap around all edges

And a test routine. 

```
(vRMS) :~/source/RMS$ python -m RMS.Formats.StarCatalog --test

2026/03/20 04:25:32-INFO-StarCatalog-line:810 - 
	New search for Sirius               of magnitude -1.46
		Returned name: HD 48915             RA= 101.281  Dec= -16.730  Mag=-1.44  Sep= 0.042
		Returned name: HD 49980             RA= 102.591  Dec= -17.085  Mag= 5.27  Sep= 1.339
		Returned name: HD 49048             RA= 101.497  Dec= -14.796  Mag= 5.27  Sep= 1.919

	New search for Canopus              of magnitude -0.74
		Returned name: HD 45348             RA=  95.988  Dec= -52.695  Mag=-0.63  Sep= 0.008
		Returned name: HD 47306             RA=  98.744  Dec= -52.976  Mag= 4.33  Sep= 1.680
		Returned name: HD 46569             RA=  97.828  Dec= -51.825  Mag= 5.45  Sep= 1.420

	New search for Alpha Centauri       of magnitude -0.27
		Returned name: HD 128621            RA= 219.843  Dec= -60.831  Mag= 1.35  Sep= 0.083
		Returned name: HD 127631            RA= 218.705  Dec= -60.964  Mag= 5.50  Sep= 0.651
		Returned name: HD 130206            RA= 222.312  Dec= -59.407  Mag= 5.93  Sep= 1.807

	New search for Arcturus             of magnitude -0.05
		Returned name: HD 124897            RA= 213.912  Dec=  19.177  Mag=-0.44  Sep= 0.086
		Returned name: HD 124897            RA= 213.944  Dec=  19.229  Mag= 0.88  Sep= 0.060
		Returned name: HD 124953            RA= 214.018  Dec=  18.912  Mag= 5.92  Sep= 0.289

	New search for Vega                 of magnitude 0.03
		Returned name: HD 172167            RA= 279.237  Dec=  38.786  Mag= 0.03  Sep= 0.018
		Returned name: HD 172380            RA= 279.527  Dec=  39.668  Mag= 4.23  Sep= 0.895
		Returned name: HD 173648            RA= 281.193  Dec=  37.605  Mag= 4.32  Sep= 1.939

	New search for Capella              of magnitude 0.08
		Returned name: HD 33167             RA=  77.679  Dec=  46.961  Mag= 5.56  Sep= 1.398
		Returned name: HD 34903             RA=  80.803  Dec=  47.022  Mag= 6.05  Sep= 1.673
		Returned name: HD 34498             RA=  80.010  Dec=  44.425  Mag= 6.05  Sep= 1.638

	New search for Rigel                of magnitude 0.18
		Returned name: HD 34085             RA=  78.634  Dec=  -8.202  Mag= 0.28  Sep= 0.114
		Returned name: HD 34503             RA=  79.401  Dec=  -6.844  Mag= 3.59  Sep= 1.502
		Returned name: HD 33328             RA=  77.287  Dec=  -8.754  Mag= 4.24  Sep= 1.550

	New search for Procyon              of magnitude 0.38
		Returned name: HD 61421             RA= 114.820  Dec=   5.218  Mag= 0.40  Sep= 0.072
		Returned name: HD 60803             RA= 114.144  Dec=   5.862  Mag= 5.75  Sep= 0.896
		Returned name: HD 61887             RA= 115.396  Dec=   3.625  Mag= 5.94  Sep= 1.702

	New search for Achernar             of magnitude 0.46
		Returned name: HD 10144             RA=  24.429  Dec= -57.237  Mag= 0.06  Sep= 0.053
		Returned name: HD 10052             RA=  24.187  Dec= -58.271  Mag= 5.19  Sep= 1.084
		Returned name: HD 10360             RA=  24.953  Dec= -56.193  Mag= 5.51  Sep= 1.037

	New search for Betelgeuse           of magnitude 0.50
		Returned name: HD 39801             RA=  88.793  Dec=   7.407  Mag= 0.57  Sep= 0.043
		Returned name: HD 38710             RA=  87.001  Dec=   6.454  Mag= 5.90  Sep= 1.977
		Returned name: TYC 128-1551-2       RA=  87.001  Dec=   6.454  Mag= 6.03  Sep= 1.977

	New search for Altair               of magnitude 0.77
		Returned name: HD 187642            RA= 297.700  Dec=   8.871  Mag= 0.93  Sep= 0.058
		Returned name: HD 188310            RA= 298.563  Dec=   8.461  Mag= 4.41  Sep= 0.916
		Returned name: HD 187691            RA= 297.759  Dec=  10.415  Mag= 4.98  Sep= 1.515

	New search for Aldebaran            of magnitude 0.85
		Returned name: HD 29139             RA=  68.981  Dec=  16.508  Mag= 0.99  Sep= 0.020
		Returned name: HD 28319             RA=  67.166  Dec=  15.871  Mag= 3.38  Sep= 1.870
		Returned name: HD 28307             RA=  67.145  Dec=  15.962  Mag= 3.58  Sep= 1.861

	New search for Antares              of magnitude 1.06
		Returned name: HD 148478            RA= 247.352  Dec= -26.432  Mag= 1.07  Sep= 0.097
		Returned name: HD 147165            RA= 245.297  Dec= -25.593  Mag= 2.92  Sep= 1.932
		Returned name: HD 148605            RA= 247.552  Dec= -25.115  Mag= 4.75  Sep= 1.313

	New search for Spica                of magnitude 1.04
		Returned name: HD 116658            RA= 201.298  Dec= -11.161  Mag= 0.58  Sep= 0.061
		Returned name: HD 116870            RA= 201.679  Dec= -12.708  Mag= 4.67  Sep= 1.565
		Returned name: HD 116175            RA= 200.534  Dec= -12.580  Mag= 6.18  Sep= 1.547

	New search for Fomalhaut            of magnitude 1.16
		Returned name: HD 216956            RA= 344.415  Dec= -29.623  Mag= 0.76  Sep= 0.077
		Returned name: HD 217484            RA= 345.331  Dec= -28.854  Mag= 5.10  Sep= 1.040
		Returned name: HD 217236            RA= 344.899  Dec= -29.462  Mag= 5.45  Sep= 0.373

	New search for Deneb                of magnitude 1.25
		Returned name: HD 197345            RA= 310.358  Dec=  45.280  Mag= 1.33  Sep= 0.078
		Returned name: HD 198478            RA= 312.235  Dec=  46.114  Mag= 4.67  Sep= 1.607
		Returned name: HD 197139            RA= 310.012  Dec=  43.458  Mag= 5.62  Sep= 1.849

	New search for Pollux               of magnitude 1.14
		Returned name: HD 62044             RA= 115.829  Dec=  28.882  Mag= 3.97  Sep= 0.957
		Returned name: HD 63138             RA= 117.120  Dec=  28.764  Mag= 6.60  Sep= 1.082
		Returned name: HD 63433b            RA= 117.479  Dec=  27.363  Mag= 6.74  Sep= 1.261

	New search for Castor               of magnitude 1.58
		Returned name: SAO 60198            RA= 113.649  Dec=  31.888  Mag= 2.92  Sep= 0.086
		Returned name: SAO 60198            RA= 113.649  Dec=  31.888  Mag= 2.92  Sep= 0.086
		Returned name: HD 58946             RA= 112.279  Dec=  31.786  Mag= 4.09  Sep= 1.255

	New search for Regulus              of magnitude 1.35
		Returned name: HD 87901             RA= 152.090  Dec=  11.967  Mag= 1.41  Sep= 0.094
		Returned name: HD 88355             RA= 152.909  Dec=  13.355  Mag= 6.34  Sep= 1.620
		Returned name: HD 88853             RA= 153.790  Dec=  11.674  Mag= 6.94  Sep= 1.782

	New search for Bellatrix            of magnitude 1.64
		Returned name: HD 35468             RA=  81.283  Dec=   6.350  Mag= 1.24  Sep= 0.059
		Returned name: HD 36267             RA=  82.696  Dec=   5.948  Mag= 4.44  Sep= 1.480
		Returned name: TYC 126-1899-2       RA=  82.696  Dec=   5.948  Mag= 5.82  Sep= 1.481
```