### PR TITLE
RawFrameSave: Fix saving YUYV/UYVY frames

### DIFF
--- a/RMS/RawFrameSave.py
+++ b/RMS/RawFrameSave.py
@@ -103,6 +103,17 @@ class RawFrameSaver(multiprocessing.Process):
             if timestamp == 0:
                 break
 
+            # Handle when frame has only two channels (yuyv/uyvy)
+            # OpenCV only supports 1, 3, or 4 color channels
+            if len(frame.shape) == 3 and frame.shape[2] == 2:
+                # If UYVY image given, luma (Y) channel is channel 1
+                if self.config.uyvy_pixelformat:
+                    frame = frame[:, :, 1]
+                
+                # Otherwise, take the first available channel
+                else:
+                    frame = frame[:, :, 0]
+
             # In case the timestamp day changes mid-block
             if self.day_of_year != time.strftime("%j", time.gmtime(timestamp)):
                 
@@ -285,5 +296,3 @@ class RawFrameSaver(multiprocessing.Process):
             log.debug(repr(traceback.format_exception(*sys.exc_info())))
             self.exit.set()
             self.run_exited.set()
-
-

--- a/RMS/RawFrameSave.py
+++ b/RMS/RawFrameSave.py
@@ -105,7 +105,7 @@ class RawFrameSaver(multiprocessing.Process):
 
             # Handle when frame has only two channels (yuyv/uyvy)
             # OpenCV only supports 1, 3, or 4 color channels
-            if len(frame.shape) == 3 and frame.shape[2] == 2:
+            if (len(frame.shape) == 3) and (frame.shape[2] == 2):
                 # If UYVY image given, luma (Y) channel is channel 1
                 if self.config.uyvy_pixelformat:
                     frame = frame[:, :, 1]


### PR DESCRIPTION
When frame has only two channels try to get lumina channel to convert it into a one channel frame. `imwrite` in OpenCV only supports 1, 3, and 4 channel images.