### PR TITLE
Fix save_frames disabled when absent from config bug

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -1251,15 +1251,14 @@ def parseCapture(config, parser):
     # obtain the path to a working ffmpeg, if available
     config.ffmpeg_binary = isFfmpegWorking()
 
-    # Enable/disable saving video frames - automatically off if FFmpeg is missing
-    if parser.has_option(section, "save_frames"):
-        save_requested = parser.getboolean(section, "save_frames")
-        if save_requested and not config.ffmpeg_binary:
-            print("save_frames requested but FFmpeg not available - disabling.")
-        else:
-            config.save_frames = save_requested
-    else:
+    # Enable/disable saving video frames - automatically off if FFmpeg is missing.
+    # If the option is absent from the config, fall back to the class default.
+    save_requested = parser.getboolean(section, "save_frames", fallback=config.save_frames)
+    if save_requested and not config.ffmpeg_binary:
+        print("save_frames requested but FFmpeg not available - disabling.")
         config.save_frames = False
+    else:
+        config.save_frames = save_requested
 
     if parser.has_option(section, "frame_file_type"):
         config.frame_file_type = parser.get(section, "frame_file_type")


### PR DESCRIPTION
Behavior delta vs. the buggy prerelease code:                                                                                                        
                                                         
  ```
┌──────────────────────────────────┬───────────────────────────┬───────────────────────────┬─────────────────────────────────────────┐               
  │               Case               │     Old (buggy)           │            New            │                 Effect                  │
  ├──────────────────────────────────┼───────────────────────────┼───────────────────────────┼─────────────────────────────────────────┤
  │ save_frames absent from .config  │ forced False              │ True (class default)      │ Intended fix — restores frames pipeline │
  ├──────────────────────────────────┼───────────────────────────┼───────────────────────────┼─────────────────────────────────────────┤
  │ save_frames=True, ffmpeg present │ True                      │ True                      │ none                                    │               
  ├──────────────────────────────────┼───────────────────────────┼───────────────────────────┼─────────────────────────────────────────┤               
  │ save_frames=True, ffmpeg missing │ warning lied, stayed True │ False (actually disabled) │ safer — stops orphan JPG accumulation   │               
  ├──────────────────────────────────┼───────────────────────────┼───────────────────────────┼─────────────────────────────────────────┤               
  │ save_frames=False                │ False                     │ False                     │ none                                    │
  └──────────────────────────────────┴───────────────────────────┴───────────────────────────┴─────────────────────────────────────────┘   
```