### PR TITLE
fix: close SSH connections that complete after hard timeout

### DIFF
--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -90,7 +90,7 @@ def interruptibleWait(seconds):
         raise
 
 
-def runWithTimeout(func, args=(), kwargs=None, timeout=60):
+def runWithTimeout(func, args=(), kwargs=None, timeout=60, on_late_completion=None):
     """
     Run a function with a hard timeout using threading.
 
@@ -99,6 +99,10 @@ def runWithTimeout(func, args=(), kwargs=None, timeout=60):
         args: Positional arguments to pass to the function.
         kwargs: Keyword arguments to pass to the function.
         timeout: Maximum time in seconds to wait for the function to complete.
+        on_late_completion: Optional callable invoked in the daemon thread if the
+            function completes after the caller has already timed out. Use this to
+            clean up resources (e.g., closing a connection) that the function opened
+            after the caller gave up.
 
     Return:
         A tuple of (success, result, exception):
@@ -109,16 +113,15 @@ def runWithTimeout(func, args=(), kwargs=None, timeout=60):
     Note:
         This function uses a daemon thread that continues running even after the timeout
         expires. The timeout only allows the calling thread to proceed; it does not stop
-        the underlying operation. This may result in resource leaks (open sockets, file
-        descriptors) if the operation eventually completes or hangs indefinitely. Callers
-        are responsible for cleaning up any resources (e.g., closing connections) when a
-        timeout occurs.
+        the underlying operation. Pass on_late_completion to clean up any resources
+        the function may open after the caller has already timed out.
     """
     if kwargs is None:
         kwargs = {}
 
     result = [None]
     exception = [None]
+    timed_out = [False]
     completed = threading.Event()
 
     def target():
@@ -128,6 +131,11 @@ def runWithTimeout(func, args=(), kwargs=None, timeout=60):
             exception[0] = e
         finally:
             completed.set()
+            if timed_out[0] and on_late_completion is not None:
+                try:
+                    on_late_completion()
+                except Exception:
+                    pass
 
     thread = threading.Thread(target=target)
     thread.daemon = True
@@ -140,7 +148,8 @@ def runWithTimeout(func, args=(), kwargs=None, timeout=60):
         # Function completed (possibly with exception)
         return (True, result[0], exception[0])
     else:
-        # Timed out
+        # Timed out — flag thread so on_late_completion fires if it finishes later
+        timed_out[0] = True
         return (False, None, None)
 
 

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -132,10 +132,11 @@ def runWithTimeout(func, args=(), kwargs=None, timeout=60, on_late_completion=No
         finally:
             completed.set()
             if timed_out[0] and on_late_completion is not None:
+                log.debug("runWithTimeout: function completed after caller timed out; running late cleanup")
                 try:
                     on_late_completion()
-                except Exception:
-                    pass
+                except Exception as e:
+                    log.debug("runWithTimeout: on_late_completion failed: %s", e)
 
     thread = threading.Thread(target=target)
     thread.daemon = True

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -161,7 +161,7 @@ def getSSHClient(hostname,
     if key_filename:
         # Use hard timeout wrapper around ssh.connect()
         success, result, exception = runWithTimeout(doConnectWithKey, timeout=hard_timeout,
-                                                     on_late_completion=lambda: ssh.close())
+                                                     on_late_completion=lambda c=ssh: c.close())
 
         if not success:
             log.error("SSH connection timed out after {} seconds (hard timeout)".format(hard_timeout))
@@ -221,7 +221,7 @@ def getSSHClient(hostname,
 
     # Use hard timeout wrapper around ssh.connect()
     success, result, exception = runWithTimeout(doConnectWithAgent, timeout=hard_timeout,
-                                                 on_late_completion=lambda: ssh.close())
+                                                 on_late_completion=lambda c=ssh: c.close())
 
     if not success:
         log.error("SSH connection timed out after {} seconds (hard timeout)".format(hard_timeout))
@@ -265,7 +265,7 @@ def getSFTPClient(ssh, sftp_timeout=300):
 
     # Use hard timeout wrapper around open_sftp() to prevent indefinite hangs
     success, sftp, exception = runWithTimeout(ssh.open_sftp, timeout=sftp_timeout,
-                                              on_late_completion=lambda: ssh.close())
+                                              on_late_completion=lambda c=ssh: c.close())
 
     if not success:
         log.error("SFTP connection timed out after {} seconds".format(sftp_timeout))

--- a/RMS/UploadManager.py
+++ b/RMS/UploadManager.py
@@ -160,7 +160,8 @@ def getSSHClient(hostname,
     # Try key_filename first if provided
     if key_filename:
         # Use hard timeout wrapper around ssh.connect()
-        success, result, exception = runWithTimeout(doConnectWithKey, timeout=hard_timeout)
+        success, result, exception = runWithTimeout(doConnectWithKey, timeout=hard_timeout,
+                                                     on_late_completion=lambda: ssh.close())
 
         if not success:
             log.error("SSH connection timed out after {} seconds (hard timeout)".format(hard_timeout))
@@ -219,7 +220,8 @@ def getSSHClient(hostname,
         return True
 
     # Use hard timeout wrapper around ssh.connect()
-    success, result, exception = runWithTimeout(doConnectWithAgent, timeout=hard_timeout)
+    success, result, exception = runWithTimeout(doConnectWithAgent, timeout=hard_timeout,
+                                                 on_late_completion=lambda: ssh.close())
 
     if not success:
         log.error("SSH connection timed out after {} seconds (hard timeout)".format(hard_timeout))
@@ -262,7 +264,8 @@ def getSFTPClient(ssh, sftp_timeout=300):
     log.debug("Attempting to open SFTP connection...")
 
     # Use hard timeout wrapper around open_sftp() to prevent indefinite hangs
-    success, sftp, exception = runWithTimeout(ssh.open_sftp, timeout=sftp_timeout)
+    success, sftp, exception = runWithTimeout(ssh.open_sftp, timeout=sftp_timeout,
+                                              on_late_completion=lambda: ssh.close())
 
     if not success:
         log.error("SFTP connection timed out after {} seconds".format(sftp_timeout))


### PR DESCRIPTION
## Problem

  RMS stations connect to the upload server via SFTP and accumulate persistent
  SSH sessions over days. After a server reboot the issue resolves, then gradually
  returns — 130+ concurrent sessions dating back 3+ days were observed, eventually
  causing upload failures for new connections.

  ### Root cause

  getSSHClient() wraps ssh.connect() in runWithTimeout(), which uses a daemon
  thread. When the hard timeout fires:

  1. The calling thread proceeds, calls ssh.close(), returns None
  2. The daemon thread is still executing ssh.connect() in the background
  3. If ssh.connect() completes *after* ssh.close() was called — a no-op because
     the transport didn't exist yet — paramiko's Transport spins up its own
     background keepalive threads
  4. Those threads hold references back to the Transport, preventing GC
  5. The server now has a live, authenticated SSH session the client has forgotten

  This affects all three runWithTimeout call sites that wrap connection operations:
  - doConnectWithKey in getSSHClient()
  - doConnectWithAgent in getSSHClient()
  - ssh.open_sftp in getSFTPClient()
 
  Server-side symptom: hundreds of sftp-server processes per station user, all
  with live sshd parents, all idle — accumulating until the server exhausts
  resources or fills disk (each session creates an LXC container clone on root FS).

  ## Fix

  Add an on_late_completion callback to runWithTimeout(). The daemon thread invokes
  it only if the wrapped function completes *after* the caller already timed out.
  This ensures ssh.close() is called after the transport actually exists.

  ## Changes

  - RMS/Misc.py: add on_late_completion param + timed_out flag to runWithTimeout
  - RMS/UploadManager.py: pass on_late_completion=lambda: ssh.close() at all three
    connection runWithTimeout call sites

  ## Test plan

  - [ ] Normal upload (no timeout): connection opens, uploads, closes as before
  - [ ] Simulated timeout (hard_timeout=1 against slow host): no persistent session
        on server after connect eventually completes
  - [ ] ps aux | grep sftp-server count does not grow across repeated failed attempts
