### PR TITLE
Delete PyGObject from requirements as it is NOT installed via pip.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,6 @@ pyclean>=2.7.6; python_version >= "3.5"
 wheel>=0.30.0
 setuptools>=40.0.0
 ifaddr; sys_platform =="win32"
-# PyGObject installed via system package (python3-gi) on Linux
-PyGObject; python_version >= '3.6' and sys_platform != 'linux'
 rawpy; sys_platform == "win32"
 rawpy; sys_platform == "darwin"
 rawpy; sys_platform == "linux" and platform_machine == "x86_64"


### PR DESCRIPTION
PyGObject is NOT installed via pip. On Linux it comes from the system package (python3-gi).
Pip-building it fails on Windows/macOS and GStreamer capture isn't used there anyway (BufferedCapture falls back to OpenCV when gi is absent).