### PR TITLE
Wrap azimuth/RA difference in rotationWrtHorizon and rotationWrtStandard

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -490,8 +490,14 @@ def rotationWrtHorizon(platepar):
     azim_up, alt_up = cyTrueRaDec2ApparentAltAz(np.radians(ra_arr[1]), np.radians(dec_arr[1]), jd_arr[1], \
         np.radians(platepar.lat), np.radians(platepar.lon), platepar.refraction)
 
+    # Compute the azimuth difference, wrapping across the 0/360 deg boundary. Without this, a FOV centre
+    # pointing near due north (azimuth ~ 0/360 deg) puts the two sample points on opposite sides of the
+    # wrap, producing a spurious ~360 deg difference that pins the rotation near +/-180 deg and makes it
+    # insensitive to the true camera roll.
+    d_azim = (azim_up - azim_mid + np.pi)%(2*np.pi) - np.pi
+
     # Compute the rotation wrt horizon (deg)
-    rot_angle = np.degrees(np.arctan2(alt_up - alt_mid, azim_up - azim_mid))
+    rot_angle = np.degrees(np.arctan2(alt_up - alt_mid, d_azim))
 
     # Wrap output to <-180, 180] range
     if rot_angle > 180:
@@ -564,9 +570,13 @@ def rotationWrtStandard(platepar):
     ra_up = ra[1]
     dec_up = dec[1]
 
+    # Compute the RA difference, wrapping across the 0/360 deg boundary so a FOV centre near RA ~ 0 deg
+    # does not produce a spurious ~360 deg difference (same failure mode as the azimuth wrap in
+    # rotationWrtHorizon).
+    d_ra = (np.radians(ra_mid) - np.radians(ra_up) + np.pi)%(2*np.pi) - np.pi
+
     # Compute the equatorial orientation
-    rot_angle = np.degrees(np.arctan2(np.radians(dec_mid) - np.radians(dec_up), \
-        np.radians(ra_mid) - np.radians(ra_up)))
+    rot_angle = np.degrees(np.arctan2(np.radians(dec_mid) - np.radians(dec_up), d_ra))
 
     # Wrap output to 0-360 range
     rot_angle = rot_angle%360


### PR DESCRIPTION
The azimuth (resp. RA) difference was taken raw before arctan2. A FOV centre near due north (az ~ 0/360) or RA ~ 0 straddles the wrap, giving a spurious ~360 deg difference that pins the rotation near +/-180 and makes it nearly insensitive to the camera roll. Wrap into [-pi, pi]; no-op away from the seam.
<img width="900" height="750" alt="USC0F1_20260605_045039_270560_calibration_variation" src="https://github.com/user-attachments/assets/d335e762-2320-4ff2-9045-84c698e291e0" />
