### PR TITLE
When logging start time avoid returning a boolean as a time value

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -1222,10 +1222,10 @@ if __name__ == "__main__":
 
             # Calculate when and how should the capture run
             start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation)
-            if not isinstance(start_time, bool):
-                log.info(f'Next start time: {start_time} UTC')
-            else:
+            if isinstance(start_time, bool):
                 log.info(f'captureDuration returned {start_time}')
+            else:
+                log.info(f'Next start time: {start_time} UTC')
 
         # Reboot the computer after processing is done for the previous night
         if ran_once and config.reboot_after_processing:

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -1224,7 +1224,8 @@ if __name__ == "__main__":
             start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation)
             if not isinstance(start_time, bool):
                 log.info(f'Next start time: {start_time} UTC')
-
+            else:
+                log.info(f'captureDuration returned f{start_time}')
 
         # Reboot the computer after processing is done for the previous night
         if ran_once and config.reboot_after_processing:

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -1225,7 +1225,7 @@ if __name__ == "__main__":
             if not isinstance(start_time, bool):
                 log.info(f'Next start time: {start_time} UTC')
             else:
-                log.info(f'captureDuration returned f{start_time}')
+                log.info(f'captureDuration returned {start_time}')
 
         # Reboot the computer after processing is done for the previous night
         if ran_once and config.reboot_after_processing:

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -1222,7 +1222,8 @@ if __name__ == "__main__":
 
             # Calculate when and how should the capture run
             start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation)
-            log.info('Next start time: ' + str(start_time) + ' UTC')
+            if not isinstance(start_time, bool):
+                log.info(f'Next start time: {start_time} UTC')
 
 
         # Reboot the computer after processing is done for the previous night


### PR DESCRIPTION
In the log file the return from captureDuration is logged. If capture is in progress then this results in a boolean value of True being presented as a time. 

This PR still logs the return from captureDuration, however instead produces the log line

```
2026/06/09 11:43:21-INFO-StartCapture-line:1228 - captureDuration returned True
```

or

```
2026/06/09 11:54:58-INFO-StartCapture-line:1226 - Next start time: 2026-06-09 17:04:03.809705 UTC
```