### PR TITLE
Combine development work on ObservationSummary

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1445,6 +1445,13 @@ class BufferedCapture(Process):
                     self.device = cv2.VideoCapture(self.config.deviceID, cv2.CAP_V4L2)
                     self.device.set(cv2.CAP_PROP_CONVERT_RGB, 0)
 
+                    try:
+                        log.info("Getting observation summary dict")
+                        addObsParam(getObservationSummaryDict(None, config=self.config), "media_backend", self.video_device_type)
+                        log.info("Got observation summary dict")
+                    finally:
+                        pass
+
                     return True
                 
                 except Exception as e:
@@ -1457,6 +1464,14 @@ class BufferedCapture(Process):
             elif (self.config.media_backend == 'cv2') or self.media_backend_override:
                 log.info("Initialize OpenCV Device.")
                 self.device = cv2.VideoCapture(self.config.deviceID)
+
+                try:
+                    log.info("Getting observation summary dict")
+                    addObsParam(getObservationSummaryDict(None, config=self.config), "media_backend",
+                                self.video_device_type)
+                    log.info("Got observation summary dict")
+                finally:
+                    pass
 
                 return True
 

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -42,7 +42,7 @@ import json
 
 from RMS.Misc import obfuscatePassword
 from RMS.Routines.GstreamerCapture import GstVideoFile, getStructureValue
-from RMS.Formats.ObservationSummary import getObsDBConn, addObsParam
+from RMS.Formats.ObservationSummary import addObsParam, getObservationSummaryDict
 from RMS.RawFrameSave import RawFrameSaver
 from RMS.Misc import RmsDateTime, mkdirP, UTCFromTimestamp
 from RMS.Formats import FTfile, FTStruct
@@ -1422,11 +1422,12 @@ class BufferedCapture(Process):
                     # Set the video device type
                     self.video_device_type = "gst"
 
-                    conn = getObsDBConn(self.config)
                     try:
-                        addObsParam(conn, "media_backend", self.video_device_type)
+                        log.info("Getting observation summary dict")
+                        addObsParam(getObservationSummaryDict(None, config=self.config), "media_backend", self.video_device_type)
+                        log.info("Got observation summary dict")
                     finally:
-                        conn.close()
+                        pass
 
                     return True
 
@@ -1435,11 +1436,8 @@ class BufferedCapture(Process):
                     self.media_backend_override = True
                     self.releaseResources()
 
-                    conn = getObsDBConn(self.config)
-                    try:
-                        addObsParam(conn, "media_backend", self.video_device_type)
-                    finally:
-                        conn.close()
+
+
 
             if self.config.media_backend == 'v4l2':
                 try:
@@ -2401,7 +2399,7 @@ if __name__ == "__main__":
                              video_file=cml_args.video_file)
         
         bc.initVideoDevice()
-        
+
 
         # Read at least 256 frames from the video file
         for i in range(256):

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1422,12 +1422,11 @@ class BufferedCapture(Process):
                     # Set the video device type
                     self.video_device_type = "gst"
 
-                    try:
-                        log.info("Getting observation summary dict")
-                        addObsParam(getObservationSummaryDict(None, config=self.config), "media_backend", self.video_device_type)
-                        log.info("Got observation summary dict")
-                    finally:
-                        pass
+                    if self.night_data_dir is not None:
+                        try:
+                            addObsParam(getObservationSummaryDict(self.night_data_dir), "media_backend", "gst")
+                        except Exception as e:
+                            log.warning("Could not record media_backend in observation summary: {}".format(e))
 
                     return True
 
@@ -1445,12 +1444,14 @@ class BufferedCapture(Process):
                     self.device = cv2.VideoCapture(self.config.deviceID, cv2.CAP_V4L2)
                     self.device.set(cv2.CAP_PROP_CONVERT_RGB, 0)
 
-                    try:
-                        log.info("Getting observation summary dict")
-                        addObsParam(getObservationSummaryDict(None, config=self.config), "media_backend", self.video_device_type)
-                        log.info("Got observation summary dict")
-                    finally:
-                        pass
+                    # Note: video_device_type stays "cv2" - downstream logic (isOpened check,
+                    # first-frame skipping) treats v4l2 as an OpenCV device. Only the recorded
+                    # media_backend label is "v4l2".
+                    if self.night_data_dir is not None:
+                        try:
+                            addObsParam(getObservationSummaryDict(self.night_data_dir), "media_backend", "v4l2")
+                        except Exception as e:
+                            log.warning("Could not record media_backend in observation summary: {}".format(e))
 
                     return True
                 
@@ -1465,13 +1466,11 @@ class BufferedCapture(Process):
                 log.info("Initialize OpenCV Device.")
                 self.device = cv2.VideoCapture(self.config.deviceID)
 
-                try:
-                    log.info("Getting observation summary dict")
-                    addObsParam(getObservationSummaryDict(None, config=self.config), "media_backend",
-                                self.video_device_type)
-                    log.info("Got observation summary dict")
-                finally:
-                    pass
+                if self.night_data_dir is not None:
+                    try:
+                        addObsParam(getObservationSummaryDict(self.night_data_dir), "media_backend", "cv2")
+                    except Exception as e:
+                        log.warning("Could not record media_backend in observation summary: {}".format(e))
 
                 return True
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1489,7 +1489,7 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     # Convert AU0004_
     _, time_section = os.path.basename(d['night_data_dir']).split("_",1)
     session_start_time = datetime.datetime.strptime(time_section, "%Y%m%d_%H%M%S_%f").replace(tzinfo=datetime.timezone.utc)
-    addObsParam("traceback_count", countTracebacksInLogs(session_start_time, config))
+    addObsParam(d, "traceback_count", countTracebacksInLogs(session_start_time, config))
 
 
     try:

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1305,7 +1305,7 @@ def writeToFile(config, file_path_and_name, night_dir):
         summary_file_handle.flush()
 
 
-def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, col_gap=20):
+def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, col_gap=20, line_height=15):
 
     as_ascii = serialize(
         config,
@@ -1325,9 +1325,6 @@ def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, co
 
     # Colours orange on warm black
     text_color, bg_color = (255, 140, 0), (25, 10, 0)
-
-    # Measure line height (fixed)
-    _, line_height = font.getsize("A")
 
     # Measure column widths
     col1_width = max(font.getsize(line)[0] for line in col1) if col1 else 0

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1439,7 +1439,7 @@ def startObservationSummaryReport(config, night_data_dir, duration, force_delete
     captured_directories = captureDirectories(os.path.join(config.data_dir, config.captured_dir), config.stationID)
     addObsParam(d, "captured_directories", captured_directories)
     try:
-        #sensor, firmware, build_date = gatherCameraInformation(config)
+        sensor, firmware, build_date = gatherCameraInformation(config)
         addObsParam(d, "camera_information", sensor)
         addObsParam(d, "camera_firmware_version", firmware)
         addObsParam(d, "camera_firmware_build_date", build_date)

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1,6 +1,6 @@
 # The MIT License
 
-# Copyright (c) 2025
+# Copyright (c) 2026
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,10 +23,6 @@
 """ Summary text and json files for station and observation session
 """
 
-from __future__ import print_function, division, absolute_import
-
-
-
 import os
 import sys
 import socket
@@ -45,6 +41,8 @@ import struct
 import time
 import tempfile
 import ephem
+import traceback
+import argparse
 
 from RMS.ConfigReader import parse
 from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
@@ -52,7 +50,14 @@ from RMS.Formats.FFfits import filenameToDatetimeStr
 from RMS.Formats.Platepar import Platepar
 from RMS.CaptureDuration import captureDuration
 from RMS.CaptureModeSwitcher import SWITCH_HORIZON_DEG
+from RMS.Formats.FTPdetectinfo import findFTPdetectinfoFile, readFTPdetectinfo
+from RMS.Logger import getLogger
+from pathlib import Path
 
+import RMS.ConfigReader as cr
+
+# Get the logger from the main module
+log = getLogger("rmslogger")
 
 if sys.version_info.major > 2:
     import dvrip as dvr
@@ -60,9 +65,141 @@ else:
     # Python2 compatible version
     import Utils.CameraControl27 as dvr
 
-EM_RAISE = True
+
+
+
 DEBUG_PRINT = False
 
+OBSERVATION_SUMMARY_WORKING_NAME_JSON = "observation_summary_working.json"
+OBSERVATION_SUMMARY_NAME_JSON = "observation_summary.json"
+OBSERVATION_SUMMARY_NAME_TXT = "observation_summary.txt"
+OBSERVATIONS_TABLE_NAME = "observations"
+OBSERVATION_DB_FILE_NAME = "observation.db"
+NIGHT_DATA_DIR_COL = "night_data_dir"
+
+
+def getObsDBConn(config, force_delete=False):
+    """Creates the Observation Summary database. Tries only once.
+
+    Arguments:
+        config: [config] config instance.
+
+    Keyword arguments:
+        force_delete: [bool] default false, if set then deletes the database before recreating.
+
+    Return:
+        conn: [connection] connection to database if success else None.
+
+    """
+
+    # Create the Observation Summary database
+    observation_records_db_path = os.path.join(config.data_dir,OBSERVATION_DB_FILE_NAME)
+    log.info(f"Opening database at {observation_records_db_path}")
+    if force_delete:
+        os.unlink(observation_records_db_path)
+
+    if not os.path.exists(os.path.dirname(observation_records_db_path)):
+        # Handle the very rare case where this could run before any observation sessions
+        # and RMS_data does not exist
+        try:
+            # Create the required directory
+            os.makedirs(os.path.dirname(observation_records_db_path))
+
+        except Exception as e:
+            log.error(f'Unable to create {observation_records_db_path}:' + repr(e))
+            log.error("".join(traceback.format_exception(*sys.exc_info())))
+            return None
+
+    try:
+        conn = sqlite3.connect(observation_records_db_path)
+
+    except Exception as e:
+        log.error('Unable to get database connection:' + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
+
+        return None
+
+    # Returns true if the table observations exists in the database
+    try:
+        sql_command = f"SELECT name FROM sqlite_master WHERE type='table' and name='{OBSERVATIONS_TABLE_NAME}';"
+
+        tables = conn.cursor().execute(sql_command).fetchall()
+
+        if len(tables) > 0:
+            return conn
+    except:
+        print(f"{OBSERVATIONS_TABLE_NAME} does not exist")
+
+
+    sql_command = ""
+    sql_command += f"CREATE TABLE {OBSERVATIONS_TABLE_NAME} \n"
+    sql_command += f"( \n"
+    sql_command += f"{NIGHT_DATA_DIR_COL} TEXT PRIMARY KEY \n"
+    sql_command += f") \n"
+
+    conn.execute(sql_command)
+
+    return conn
+
+def getColumns(conn):
+
+    cursor = conn.execute(f"PRAGMA table_info({OBSERVATIONS_TABLE_NAME})")
+    return {row[1] for row in cursor.fetchall()}
+
+def addRequiredColumns(conn, d):
+
+    existing = getColumns(conn)
+    for key in d:
+        if key.lower() not in existing:
+            sql_command = f"ALTER TABLE {OBSERVATIONS_TABLE_NAME} ADD COLUMN {key.lower()} TEXT"
+            print(sql_command)
+            conn.execute(sql_command)
+
+def storeDictInDB(conn, d, debug=False):
+    # Ensure schema is up to date
+    addRequiredColumns(conn, d)
+
+    # Normalise booleans safely (TEXT columns expect strings)
+    clean = {
+        k: ("True" if v is True else "False" if v is False else v)
+        for k, v in d.items()
+    }
+
+    # Only store the basename for night_data_dir
+    if "night_data_dir" in clean:
+        clean["night_data_dir"] = os.path.basename(clean["night_data_dir"])
+
+
+    columns = list(clean.keys())
+    placeholders = ", ".join("?" for _ in columns)
+    values = [clean[col] for col in columns]
+
+
+    assignments = ", ".join(f"{col}=excluded.{col}" for col in columns if col != "night_data_dir")
+
+
+    if debug:
+        for c, v in zip(columns, values):
+            print(f"{c:40} -> {repr(v)}")
+
+
+    sql_command = ""
+    sql_command += f"INSERT INTO {OBSERVATIONS_TABLE_NAME} ({', '.join(columns)})\n"
+    sql_command += f"VALUES ({placeholders})\n"
+    sql_command += f"ON CONFLICT(night_data_dir) DO UPDATE SET {assignments}\n"
+
+    # Show the SQL with placeholders (safe)
+    if debug:
+        print(sql_command)
+        print(values)
+
+    try:
+        conn.execute(sql_command, values)
+        conn.commit()
+
+    except Exception as e:
+        log.error('Storing observation summary into database failed with error:' + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
 
 def roundWithoutTrailingZero(value, no):
     """Given a float, round to specified number of decimal places, then remove trailing zeroes.
@@ -81,7 +218,6 @@ def roundWithoutTrailingZero(value, no):
 def getObservationDurationNightTime(config, start_time):
     """Get the duration of an observation session not in continuous capture mode.
 
-
     Arguments:
         conn: [object] database connection instance.
         config: [object] RMS configuration instance.
@@ -90,11 +226,16 @@ def getObservationDurationNightTime(config, start_time):
         duration: [float] duration of observation in seconds.
     """
 
-    _, duration = captureDuration(config.latitude, config.longitude, config.elevation,start_time)
+    ephemeris_start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation,start_time)
 
-    end_time = start_time + datetime.timedelta(seconds=duration)
+    while isinstance(ephemeris_start_time, bool):
+        start_time -= datetime.timedelta(minutes=1)
+        # Go backwards through time until we are before the start time
+        ephemeris_start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation, start_time)
 
-    return start_time, duration, end_time
+    end_time = ephemeris_start_time + datetime.timedelta(seconds=duration)
+
+    return ephemeris_start_time, duration, end_time
 
 def getObservationDurationContinuous(config, start_time):
     """Get the duration of an observation session in continuous capture mode.
@@ -199,14 +340,14 @@ def getTimeClient():
             pass
     return "Not recognized"
 
-def timeSyncStatus(config, conn, force_client=None):
+def timeSyncStatus(config, d, force_client=None):
 
     """
     Add time sync information to the observation summary.
 
     Arguments:
         config: [Config] Configuration object.
-        conn: [Connection] database connection.
+        d: [Connection] Observation summary dictionary
 
     Keyword arguments:
         force_client: [string] optional, string to force resolution by ntpd, chrony, or a query on a remote server.
@@ -224,45 +365,117 @@ def timeSyncStatus(config, conn, force_client=None):
 
     if time_client =="ntpd":
         synchronized, uncertainty, ahead_ms = getNTPStatistics()
-        addObsParam(conn, "clock_measurement_source", "ntp")
-        addObsParam(conn, "clock_synchronized", synchronized)
-        addObsParam(conn, "clock_ahead_ms", ahead_ms)
-        addObsParam(conn, "clock_error_uncertainty_ms", uncertainty)
+        addObsParam(d, "clock_measurement_source", "ntp")
+        addObsParam(d, "clock_synchronized", synchronized)
+        addObsParam(d, "clock_ahead_ms", ahead_ms)
+        addObsParam(d, "clock_error_uncertainty_ms", uncertainty)
 
     elif time_client == "chronyd":
         synchronized, ahead_ms, uncertainty_ms = getChronyUncertainty()
-        addObsParam(conn, "clock_measurement_source", "chrony")
-        addObsParam(conn, "clock_synchronized", synchronized)
-        addObsParam(conn, "clock_ahead_ms", ahead_ms)
-        addObsParam(conn, "clock_error_uncertainty_ms", uncertainty_ms)
+        addObsParam(d, "clock_measurement_source", "chrony")
+        addObsParam(d, "clock_synchronized", synchronized)
+        addObsParam(d, "clock_ahead_ms", ahead_ms)
+        addObsParam(d, "clock_error_uncertainty_ms", uncertainty_ms)
 
     else:
-        addObsParam(conn, "clock_measurement_source", "Not detected")
+        addObsParam(d, "clock_measurement_source", "Not detected")
         remote_time_query, uncertainty = timestampFromNTP()
         if remote_time_query is not None:
             local_time_query = (datetime.datetime.now(datetime.timezone.utc)
                                 - datetime.datetime(1970, 1, 1)
                                         .replace(tzinfo=datetime.timezone.utc)).total_seconds()
             ahead_ms = (local_time_query - remote_time_query) * 1000
-            addObsParam(conn, "clock_error_uncertainty_ms", uncertainty * 1000)
+            addObsParam(d, "clock_error_uncertainty_ms", uncertainty * 1000)
 
         else:
             ahead_ms, uncertainty = "Unknown", "Unknown"
-            addObsParam(conn, "clock_error_uncertainty_ms", uncertainty)
-        addObsParam(conn, "clock_ahead_ms", ahead_ms)
+            addObsParam(d, "clock_error_uncertainty_ms", uncertainty)
+        addObsParam(d, "clock_ahead_ms", ahead_ms)
 
         result_list = subprocess.run(['timedatectl','status'], capture_output = True).stdout.splitlines()
 
         for raw_result in result_list:
             result = raw_result.decode('ascii')
             if "synchronized" in result:
-                conn = getObsDBConn(config)
+
                 if result.split(":")[1].strip() == "no":
-                    addObsParam(conn, "clock_synchronized", False)
+                    addObsParam(d, "clock_synchronized", False)
                 else:
-                    addObsParam(conn, "clock_synchronized", True)
+                    addObsParam(d, "clock_synchronized", True)
 
     return ahead_ms
+
+def getDaysSinceLastDetection(config, data_dir, d=None, debug=False):
+
+
+
+    last_fits_file_for_session_sql = ""
+    last_fits_file_for_session_sql += f"SELECT time_last_fits_file\n"
+    last_fits_file_for_session_sql += f"        FROM {OBSERVATIONS_TABLE_NAME}\n"
+    last_fits_file_for_session_sql += f"        WHERE night_data_dir = '{os.path.basename(data_dir)}'\n"
+    last_fits_file_for_session_sql += f"        LIMIT 1; "
+
+
+    if debug:
+        log.info("Last fits file for session SQL")
+        log.info(last_fits_file_for_session_sql)
+
+    try:
+        conn = getObsDBConn(config)
+        result = conn.execute(last_fits_file_for_session_sql).fetchone()
+        if result is None:
+            return "Unknown"
+        else:
+            result = str(result[0])
+        log.info(f"SQL query is \n {last_fits_file_for_session_sql}")
+        log.info(f"SQL query result is \n {result}")
+        # Keep microseconds
+        if '.' in result:
+            time_last_fits_file_for_session = datetime.datetime.strptime(result,  "%Y-%m-%d %H:%M:%S.%f")
+        else:
+            time_last_fits_file_for_session = datetime.datetime.strptime(result, "%Y-%m-%d %H:%M:%S")
+        conn.close()
+
+    except Exception as e:
+        log.error('Failed to calculate time since last detection:' + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
+        return "Error"
+
+
+    last_detection_time_for_session_sql = ""
+    last_detection_time_for_session_sql += "SELECT time_last_detection\n"
+    last_detection_time_for_session_sql += f"   FROM {OBSERVATIONS_TABLE_NAME}\n"
+    last_detection_time_for_session_sql += f"   WHERE COALESCE(detections_after_ml, '0') != '0'\n"
+    last_detection_time_for_session_sql += f"   AND detections_after_ml IS NOT NULL\n"
+    last_detection_time_for_session_sql += f"   AND time_last_fits_file <= '{time_last_fits_file_for_session}'\n"
+    last_detection_time_for_session_sql += f"   ORDER BY time_last_detection DESC LIMIT 1;\n"
+
+    if debug:
+        log.info("Last detection time for session SQL")
+        log.info(last_detection_time_for_session_sql)
+
+    log.info("Write dict to db before doing SQL")
+
+    try:
+        conn = getObsDBConn(config)
+        storeDictInDB(conn,d, debug=True)
+
+        cursor = conn.execute(last_detection_time_for_session_sql)
+        result =  cursor.fetchone()[0]
+        last_detection_time_for_session = datetime.datetime.strptime(result, "%Y-%m-%d %H:%M:%S")
+        seconds_since_last_detection = (time_last_fits_file_for_session - last_detection_time_for_session).total_seconds()
+        days_since_last_detection = seconds_since_last_detection / (60 * 60 * 23.934)
+        conn.close()
+
+    except Exception as e:
+        log.error('Failed to calculate time since last detection:' + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
+        return "Error"
+
+    log.info(f"Time since last detection is {days_since_last_detection} days")
+
+
+    return days_since_last_detection
 
 def getNTPStatistics():
     """Acquire the statistics of the ntp client.
@@ -439,70 +652,11 @@ def timestampFromNTP(addr='time.cloudflare.com'):
     else:
         return None, None
 
-def getObsDBConn(config, force_delete=False):
-    """Creates the Observation Summary database. Tries only once.
+def addObsParam(d, key, value):
+    """Add a single key value pair into the observation summary dictionary
 
     Arguments:
-        config: [config] config instance.
-
-    Keyword arguments:
-        force_delete: [bool] default false, if set then deletes the database before recreating.
-
-    Return:
-        conn: [connection] connection to database if success else None.
-
-    """
-
-    # Create the Observation Summary database
-    observation_records_db_path = os.path.join(config.data_dir,"observation.db")
-
-    if force_delete:
-        os.unlink(observation_records_db_path)
-
-    if not os.path.exists(os.path.dirname(observation_records_db_path)):
-        # Handle the very rare case where this could run before any observation sessions
-        # and RMS_data does not exist
-        try:
-            # Create the required directory
-            os.makedirs(os.path.dirname(observation_records_db_path))
-        except:
-            return None
-
-    try:
-        conn = sqlite3.connect(observation_records_db_path)
-
-    except:
-        return None
-
-    # Returns true if the table observation_records exists in the database
-    try:
-        tables = conn.cursor().execute(
-            """SELECT name FROM sqlite_master WHERE type = 'table' and name = 'records';""").fetchall()
-
-        if len(tables) > 0:
-            return conn
-    except:
-        if EM_RAISE:
-            raise
-        return None
-
-    sql_command = ""
-    sql_command += "CREATE TABLE records \n"
-    sql_command += "( \n"
-    sql_command += "id INTEGER PRIMARY KEY AUTOINCREMENT, \n"
-    sql_command += "TimeStamp TEXT NOT NULL, \n"
-    sql_command += "Key TEXT NOT NULL, \n"
-    sql_command += "Value TEXT NOT NULL \n"
-    sql_command += ") \n"
-    conn.execute(sql_command)
-
-    return conn
-
-def addObsParam(conn, key, value):
-    """Add a single key value pair into the database.
-
-    Arguments:
-        conn [connection]: the connection to the database
+        observation_summary_dict [c]: the dict holding the information
         key [str]: the key for the value to be added
         value [str]: the value to be added
 
@@ -511,29 +665,13 @@ def addObsParam(conn, key, value):
 
     """
 
-    sql_statement = ""
-    sql_statement += "INSERT INTO records \n"
-    sql_statement += "(\n"
-    sql_statement += "      TimeStamp, Key, Value \n"
-    sql_statement += ")\n\n"
+    if 'night_data_dir' in d and key == 'night_data_dir':
+        if d['night_data_dir'] != value:
+            log.warning("Observation summary night_data_dir is changing - this is unexpected")
 
-    sql_statement += "      VALUES "
-    sql_statement += "      (                            \n"
-    sql_statement += "      CURRENT_TIMESTAMP,'{}','{}'   \n".format(key, value)
-    sql_statement += "      )"
 
-    if conn is None:
-        return
-    else:
-        try:
-            cursor = conn.cursor()
-            cursor.execute(sql_statement)
-            conn.commit()
-
-        except:
-
-            if EM_RAISE:
-                raise
+    d[key] = str(value)
+    saveObservationSummaryDict(d)
 
 def estimateLens(fov_h):
     """Estimate the focal length of the lens in use.
@@ -655,7 +793,7 @@ def gatherCameraInformation(config, attempts=6, delay=10, sock_timeout=3):
         try:
             cam = dvr.DVRIPCam(ip, timeout=sock_timeout)
             if cam.login():
-                sys_info = cam.get_system_info()
+                sensor = cam.get_upgrade_info()['Hardware']
                 cam.close()
                 sensor = sys_info.get('HardWare', 'Unknown')
                 fw = sys_info.get('SoftWareVersion', '')
@@ -753,7 +891,6 @@ def nightSummaryData(config, night_data_dir):
             fits_file_shortfall, fits_file_shortfall_ephemeris, \
             fits_file_shortfall_as_time, fits_file_shortfall_as_time_ephemeris, \
             time_first_fits_file, time_last_fits_file, total_expected_fits, total_expected_fits_ephemeris
-
 
 def updateCommitHistoryDirectory(remote_urls, target_directory):
 
@@ -945,43 +1082,29 @@ def daysBehind():
         target_directory_obj.cleanup()
         return "Unable to determine"
 
-def retrieveObservationData(conn, config, night_directory=None, ordering=None):
-    """ Query the database to get the data more recent than the time passed in.
-
-        Usually this will be the start of the most recent observation session.
-        If no ordering is passed, then a default ordering is returned.
+def serialize(config, format_nicely=True, as_json=False, night_directory=None, drop_keys_list=None, ordering=None, final=False):
+    """ Returns the data from the most recent observation session as either colon
+        delimited text file, ar as a json.
 
     Arguments:
-            conn:  [object] connection to database.
+        config: [config] station config file.
 
-    Keyword arguments:
-            night_directory: [str] optional, directory of night directory if none, assume most recent
-            ordering: [list] optional, default None, sequence to order the keys.
+    Keyword Arguments:
+        format_nicely: [bool] optional, default true, present the data with delimiter characters aligned.
+        as_json: [bool] optional, default false, return the data as a json.
+        night_directory: [string] optional, default None, the night directory to use
+        drop_keys_list: [string] any keys to exclude
+        ordering: [list] List of keys showing the order they should be written for text files
 
-    return:
-            key value pairs committed to the database since the obs_start_time.
+    Return:
+        string of key value pairs committed to the database since the start of the previous observation session.
     """
 
-    if night_directory is None:
-        captured_data_dir = os.path.join(config.data_dir, config.captured_dir)
-        night_dir_list = os.listdir(captured_data_dir)
-        night_dir_list.sort(reverse=True)
+    d = getObservationSummaryDict(night_directory, final=final)
 
-        for night_directory in night_dir_list:
-            if night_directory.startswith(config.stationID) and os.path.isdir(os.path.join(captured_data_dir, night_directory)):
-                break
 
-    obs_start_time, obs_duration, obs_end_time = getEphemTimesFromCaptureDirectory(config, night_directory)
-
-    # print("Night directory was {}".format(night_directory))
-    # print("Observation start time was {}".format(obs_start_time))
-    # print("Observation duration was {}".format(obs_duration))
-    # print("Observation end time was {}".format(obs_end_time))
 
     if ordering is None:
-        # Be sure to add a comma after each list entry, IDE will not pick up this error as Python will concatenate
-        # the two items into one.
-
         ordering = ['stationID',
                     'commit_date', 'commit_hash', 'remote_branch', 'repository_lag_remote_days',
                     'media_backend','star_catalog_file',
@@ -991,13 +1114,11 @@ def retrieveObservationData(conn, config, night_directory=None, ordering=None):
                     'camera_lens','camera_fov_h','camera_fov_v',
                     'camera_pointing_alt','camera_pointing_az',
                     'camera_information',
-                    'camera_firmware_version',
-                    'camera_firmware_build_date',
                     'clock_measurement_source', 'clock_synchronized', 'clock_ahead_ms', 'clock_error_uncertainty_ms',
                     'start_time', 'duration_from_start_of_observation', 'continuous_capture',
                     'photometry_good', 'star_catalog_file',
-                    'time_start_ephem', 'time_first_fits_file',
-                    'time_end_ephem', 'time_last_fits_file',
+                    'time_start_ephem', 'time_first_fits_file', 'time_first_detection',
+                    'time_end_ephem', 'time_last_fits_file', 'time_last_detection', 'days_since_last_detection',
                     'total_expected_fits','total_fits',
                     'fits_files_from_duration','fits_file_shortfall', 'fits_file_shortfall_as_time',
                     'capture_duration_from_fits',
@@ -1006,56 +1127,31 @@ def retrieveObservationData(conn, config, night_directory=None, ordering=None):
                     'detections_after_ml',
                     'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate']
 
-    # Use this print call to check the ordering
-    # print("Ordering {}".format(ordering))
+    if drop_keys_list:
+        if isinstance(drop_keys_list, str):
+            drop_keys_list = [drop_keys_list]
 
-    next_start_time = getNextStartTime(conn, obs_end_time)
-    # print("Observation start time was {}".format(obs_start_time))
-    # print("Next start time was {}".format(next_start_time))
-
-    sql_statement = ""
-    sql_statement += "SELECT Key, Value from records \n"
-    sql_statement += "           WHERE TimeStamp >= '{}' \n".format(obs_start_time)
-    sql_statement += "           AND   TimeStamp <= '{}' \n".format(next_start_time)
-    sql_statement += "           GROUP BY KEY \n"
-    sql_statement += "           ORDER BY \n"
-    sql_statement += "              CASE Key \n"
-
-    # This SQL applies an ordering to all the keys in the ordering list. Any extra keys will be at the end.
-    count = 1
-    for ordering_key in ordering:
-        sql_statement += "                  WHEN '{:s}' THEN {:03d} \n".format(ordering_key,count)
-        count += 1
-
-    sql_statement += "                  ELSE {:03d} \n".format(count)
-    sql_statement += "              END"
-
-    # print(sql_statement)
-
-    return conn.cursor().execute(sql_statement).fetchall()
-
-def serialize(config, format_nicely=True, as_json=False, night_directory = None):
-    """ Returns the data from the most recent observation session as either colon
-        delimited text file, ar as a json.
-
-    Arguments:
-        config: [config] station config file.
-        format_nicely: [bool] optional, default true, present the data with delimiter characters aligned.
-        as_json: [bool] optional, default false, return the data as a json.
-
-    Return:
-        string of key value pairs committed to the database since the start of the previous observation session.
-    """
-
-    conn = getObsDBConn(config)
-    data = retrieveObservationData(conn, config, night_directory)
-    conn.close()
+        for key in drop_keys_list:
+            d.pop(key, None)
 
     if as_json:
-        return json.dumps(dict(data), default=lambda o: o.__dict__, indent=4, sort_keys=True)
+        return json.dumps(d, default=lambda o: o.__dict__, indent=4, sort_keys=True)
 
     output = ""
-    for key,value in data:
+
+    # Use list to make a copy - rather than iterating over the list we are modifying
+    output_ordering = list(ordering)
+    seen = set(ordering)
+
+    for key in d:
+        if key not in seen:
+            output_ordering.append(key)
+            seen.add(key)
+
+    for key in output_ordering:
+        if key not in d:
+            continue
+        value = d[key]
         # Does this look like a float
         if not re.match(r'^-?\d+(?:\.\d+)$', value) is None:
             # Handle as float
@@ -1105,9 +1201,9 @@ def writeToFile(config, file_path_and_name, night_dir):
 
 
     with open(file_path_and_name, "w") as summary_file_handle:
-        as_ascii = serialize(config, night_directory=night_dir).encode("ascii", errors="ignore").decode("ascii")
+        as_ascii = serialize(config, night_directory=night_dir, drop_keys_list="night_data_dir").encode("ascii", errors="ignore").decode("ascii")
         summary_file_handle.write(as_ascii)
-
+        summary_file_handle.flush()
 
 def writeToJSON(config, file_path_and_name, night_dir):
 
@@ -1121,10 +1217,114 @@ def writeToJSON(config, file_path_and_name, night_dir):
     """
 
     with open(file_path_and_name, "w") as summary_file_handle:
-        as_ascii = serialize(config, as_json=True, night_directory=night_dir).encode("ascii", errors="ignore").decode("ascii")
+        as_ascii = serialize(config, as_json=True, night_directory=night_dir, drop_keys_list=["night_data_dir"]).encode("ascii", errors="ignore").decode("ascii")
         summary_file_handle.write(as_ascii)
+        summary_file_handle.flush()
 
-def startObservationSummaryReport(config, duration, force_delete=False):
+
+def getTimeOfFirstAndLastDetectionInDir(data_dir):
+
+
+    first_detection, last_detection = "0", "0"
+    log.info(f"Looking for FTP file in {data_dir}")
+    ftp_file = findFTPdetectinfoFile(data_dir)
+    log.info(f"Found FTP file {ftp_file}")
+    ftp_detect_info = readFTPdetectinfo(data_dir, ftp_file)
+    if len(ftp_detect_info):
+        first_detection, last_detection = ftp_detect_info[0][0], ftp_detect_info[-1][0]
+        log.info("First detection info: {}".format(first_detection))
+        log.info("Last detection info: {}".format(last_detection))
+
+        first_detection = datetime.datetime.strptime(filenameToDatetimeStr(first_detection), "%Y-%m-%d %H:%M:%S.%f")
+        last_detection = datetime.datetime.strptime(filenameToDatetimeStr(last_detection), "%Y-%m-%d %H:%M:%S.%f")
+
+        log.info("First detection info: {}".format(first_detection))
+        log.info("Last detection info: {}".format(last_detection))
+
+        return str(first_detection.replace(microsecond=0)), str(last_detection.replace(microsecond=0))
+    return '0', '0'
+
+def getObservationSummaryDict(data_dir, final=False, config=None):
+    """
+
+    Arguments:
+        data_dir: [path] to the data directory, if none, then the latest confirming directory in
+        captured files is used.
+
+    Keyword Arguments:
+        final: [bool] Optional, default false, if true write to the final filename, rather than working, and delete
+            working.
+        config: [config] Optional, default None. If a config is passed, and data_dir is None, then attempt to guess
+            the appropriate data_dir to use.
+
+    Return:
+        [dict]: Observation summary dict.
+    """
+
+    log.info("Entered getObservationSummaryDict")
+    if data_dir is None and config is not None:
+        log.info("Attempting to guess captured files directory")
+        p = Path(os.path.join(config.data_dir, config.captured_dir))
+        regex = re.compile(rf"^{config.stationID}_[0-9]{{8}}_[0-9]{{6}}_[0-9]{{6}}$")
+
+        if p.exists() and p.is_dir():
+
+            candidate_dirs = [cd for cd in p.iterdir() if cd.is_dir() and regex.match(cd.name)]
+            candidate_dirs.sort(key=lambda d: d.stat().st_ctime, reverse=True)
+            if len(candidate_dirs):
+                data_dir = str(candidate_dirs[0].resolve())
+                log.info(f"Guessed directory {data_dir}")
+            else:
+                log.warning("Found no matching captured dirs, unable to guess")
+                return {}
+        else:
+            return {}
+
+    json_name = OBSERVATION_SUMMARY_NAME_JSON if final else OBSERVATION_SUMMARY_WORKING_NAME_JSON
+
+    observation_summary_json_path = os.path.join(data_dir, getRMSStyleFileName(data_dir, json_name))
+    if os.path.exists(observation_summary_json_path):
+        if os.path.isfile(observation_summary_json_path):
+            with open(observation_summary_json_path, "r") as f:
+                try:
+                    log.info(f"Found an existing {observation_summary_json_path}")
+                    d = json.load(f)
+                    log.info(f"Loaded")
+
+                except:
+                    os.remove(observation_summary_json_path)
+                    d = {'night_data_dir': data_dir}
+                    saveObservationSummaryDict(d, data_dir)
+
+            return d
+
+    log.info("Creating a new observation summary dictionary")
+    d = {'night_data_dir': data_dir}
+    saveObservationSummaryDict(d, data_dir)
+
+
+    return d
+
+def saveObservationSummaryDict(d, night_dir=None):
+
+    """
+
+    Arguments:
+        d: Observation summary dict.
+
+    Return:
+        Nothing
+    """
+    if night_dir is None:
+        if "night_data_dir" in d:
+            night_dir = d["night_data_dir"]
+
+    observation_summary_json_path = os.path.join(night_dir, getRMSStyleFileName(night_dir, OBSERVATION_SUMMARY_WORKING_NAME_JSON))
+    with open(observation_summary_json_path, "w") as f:
+        json.dump(d, f, default=lambda o: o.__dict__, indent=4, sort_keys=True)
+        f.flush()
+
+def startObservationSummaryReport(config, night_data_dir, duration, force_delete=False):
     """ Enters the parameters known at the start of observation into the database.
 
     Arguments:
@@ -1140,13 +1340,14 @@ def startObservationSummaryReport(config, duration, force_delete=False):
     """
 
 
-    conn = getObsDBConn(config, force_delete=force_delete)
+    d = getObservationSummaryDict(night_data_dir)
+
     start_time_object = (datetime.datetime.now(datetime.timezone.utc) -
                          datetime.timedelta(seconds=1)).replace(tzinfo=datetime.timezone.utc)
     start_time_object_rounded = start_time_object.replace(microsecond=0)
-    addObsParam(conn, "start_time", start_time_object_rounded)
-    addObsParam(conn, "duration_from_start_of_observation", duration)
-    addObsParam(conn, "stationID", sanitise(config.stationID, space_substitution=""))
+    addObsParam(d, "start_time", start_time_object_rounded.isoformat())
+    addObsParam(d, "duration_from_start_of_observation", duration)
+    addObsParam(d, "stationID", sanitise(config.stationID, space_substitution=""))
 
     if isRaspberryPi():
         with open('/sys/firmware/devicetree/base/model', 'r') as m:
@@ -1154,15 +1355,15 @@ def startObservationSummaryReport(config, duration, force_delete=False):
     else:
         hardware_version = sanitise(platform.machine(), space_substitution=" ")
 
-    addObsParam(conn, "hardware_version", hardware_version)
+    addObsParam(d, "hardware_version", hardware_version)
 
     try:
         repo_path = getRmsRootDir()
         repo = git.Repo(repo_path)
         if repo:
-            addObsParam(conn, "commit_date",
+            addObsParam(d, "commit_date",
                         UTCFromTimestamp.utcfromtimestamp(repo.head.object.committed_date).strftime('%Y%m%d_%H%M%S'))
-            addObsParam(conn, "commit_hash", repo.head.object.hexsha)
+            addObsParam(d, "commit_hash", repo.head.object.hexsha)
         else:
             print("RMS Git repository not found. Skipping Git-related information.")
     except:
@@ -1173,45 +1374,40 @@ def startObservationSummaryReport(config, duration, force_delete=False):
 
         try:
             storage_total, storage_used, storage_free = shutil.disk_usage(config.data_dir)
-            addObsParam(conn, "storage_total_gb", round(storage_total/(1024**3), 2))
-            addObsParam(conn, "storage_used_gb", round(storage_used/(1024**3), 2))
-            addObsParam(conn, "storage_free_gb", round(storage_free/(1024**3), 2))
+            addObsParam(d, "storage_total_gb", round(storage_total/(1024**3), 2))
+            addObsParam(d, "storage_used_gb", round(storage_used/(1024**3), 2))
+            addObsParam(d, "storage_free_gb", round(storage_free/(1024**3), 2))
         except:
-            addObsParam(conn, "storage_total_gb", "Not available")
-            addObsParam(conn, "storage_used_gb", "Not available")
-            addObsParam(conn, "storage_free_gb", "Not available")
+            addObsParam(d, "storage_total_gb", "Not available")
+            addObsParam(d, "storage_used_gb", "Not available")
+            addObsParam(d, "storage_free_gb", "Not available")
 
     captured_directories = captureDirectories(os.path.join(config.data_dir, config.captured_dir), config.stationID)
-    addObsParam(conn, "captured_directories", captured_directories)
+    addObsParam(d, "captured_directories", captured_directories)
     try:
         sensor, firmware, build_date = gatherCameraInformation(config)
-        addObsParam(conn, "camera_information", sensor)
-        addObsParam(conn, "camera_firmware_version", firmware)
-        addObsParam(conn, "camera_firmware_build_date", build_date)
+        addObsParam(d, "camera_information", sensor)
+        addObsParam(d, "camera_firmware_version", firmware)
+        addObsParam(d, "camera_firmware_build_date", build_date)
     except:
-        addObsParam(conn, "camera_information", "Unavailable")
-        addObsParam(conn, "camera_firmware_version", "Unavailable")
-        addObsParam(conn, "camera_firmware_build_date", "Unavailable")
+        addObsParam(d, "camera_information", "Unavailable")
+        addObsParam(d, "camera_firmware_version", "Unavailable")
+        addObsParam(d, "camera_firmware_build_date", "Unavailable")
 
     # Hardcoded for now, but should be calculated based on the config value
     no_of_frames_per_fits_file = 256
 
     # Calculate the number of fits files expected for the duration
     fps = config.fps
-
-
-    # Testing running without this code
-    """
-    if duration is None:
-        fits_files_from_duration = "None (Continuous Capture)"
-    else:
-        fits_files_from_duration = duration*fps/no_of_frames_per_fits_file
-    
-    addObsParam(conn, "fits_files_from_duration", fits_files_from_duration)
-    """
-
-    if not conn is None:
+    saveObservationSummaryDict(d)
+    try:
+        conn = getObsDBConn(config)
+        storeDictInDB(conn, d, debug=False)
         conn.close()
+
+    except Exception as e:
+        log.error('Storing initial observation summary into database failed with error:' + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
 
     return "Opening a new observations summary"
 
@@ -1232,6 +1428,7 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
 
             """
 
+    d = getObservationSummaryDict(night_data_dir)
     capture_duration_from_fits, start_ephem, capture_duration_from_ephemeris, end_ephem, \
     fits_count, \
     fits_file_shortfall, fits_file_shortfall_ephemeris, \
@@ -1239,10 +1436,10 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     time_first_fits_file, time_last_fits_file, \
     total_expected_fits, total_expected_fits_ephemeris = nightSummaryData(config, night_data_dir)
 
-    obs_db_conn = getObsDBConn(config)
+
 
     try:
-        timeSyncStatus(config, obs_db_conn)
+        timeSyncStatus(config, d)
     except Exception as e:
         print(repr(e))
 
@@ -1251,67 +1448,134 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     if os.path.exists(platepar_path):
         platepar = Platepar()
         platepar.read(platepar_path, use_flat=config.use_flat)
-        addObsParam(obs_db_conn, "camera_pointing_az", format("{:.2f} degrees".format(platepar.az_centre)))
-        addObsParam(obs_db_conn, "camera_pointing_alt", format("{:.2f} degrees".format(platepar.alt_centre)))
-        addObsParam(obs_db_conn, "camera_fov_h","{:.2f}".format(platepar.fov_h))
-        addObsParam(obs_db_conn, "camera_fov_v","{:.2f}".format(platepar.fov_v))
-        addObsParam(obs_db_conn, "camera_lens", estimateLens(platepar.fov_h))
+        addObsParam(d, "camera_pointing_az", format("{:.2f} degrees".format(platepar.az_centre)))
+        addObsParam(d, "camera_pointing_alt", format("{:.2f} degrees".format(platepar.alt_centre)))
+        addObsParam(d, "camera_fov_h", "{:.2f}".format(platepar.fov_h))
+        addObsParam(d, "camera_fov_v", "{:.2f}".format(platepar.fov_v))
+        addObsParam(d, "camera_lens", estimateLens(platepar.fov_h))
 
-    addObsParam(obs_db_conn, "continuous_capture", config.continuous_capture)
-    addObsParam(obs_db_conn, "time_start_ephem", start_ephem)
-    addObsParam(obs_db_conn, "time_first_fits_file", time_first_fits_file)
-    addObsParam(obs_db_conn, "time_end_ephem", end_ephem)
-    addObsParam(obs_db_conn, "time_last_fits_file", time_last_fits_file)
-    addObsParam(obs_db_conn, "capture_duration_from_fits", capture_duration_from_fits)
-    addObsParam(obs_db_conn, "capture_duration_from_ephemeris", capture_duration_from_ephemeris)
-    addObsParam(obs_db_conn, "total_expected_fits", round(total_expected_fits))
-    addObsParam(obs_db_conn, "total_expected_fits_ephemeris", round(total_expected_fits_ephemeris))
-    addObsParam(obs_db_conn, "total_fits", fits_count)
-    addObsParam(obs_db_conn, "fits_file_shortfall", fits_file_shortfall)
-    addObsParam(obs_db_conn, "fits_file_shortfall_ephemeris", fits_file_shortfall_ephemeris)
-    addObsParam(obs_db_conn, "fits_file_shortfall_as_time", fits_file_shortfall_as_time)
-    addObsParam(obs_db_conn, "fits_file_shortfall_as_time_ephemeris", fits_file_shortfall_as_time_ephemeris)
-    addObsParam(obs_db_conn, "protocol_in_use", config.protocol)
-    addObsParam(obs_db_conn, "star_catalog_file", config.star_catalog_file)
+    addObsParam(d, "continuous_capture", config.continuous_capture)
+    addObsParam(d, "time_start_ephem", start_ephem)
+    addObsParam(d, "time_first_fits_file", time_first_fits_file)
+    addObsParam(d, "time_end_ephem", end_ephem)
+    addObsParam(d, "time_last_fits_file", time_last_fits_file)
+    addObsParam(d, "capture_duration_from_fits", capture_duration_from_fits)
+    addObsParam(d, "capture_duration_from_ephemeris", capture_duration_from_ephemeris)
+    addObsParam(d, "total_expected_fits", round(total_expected_fits))
+    addObsParam(d, "total_expected_fits_ephemeris", round(total_expected_fits_ephemeris))
+    addObsParam(d, "total_fits", fits_count)
+    addObsParam(d, "fits_file_shortfall", fits_file_shortfall)
+    addObsParam(d, "fits_file_shortfall_ephemeris", fits_file_shortfall_ephemeris)
+    addObsParam(d, "fits_file_shortfall_as_time", fits_file_shortfall_as_time)
+    addObsParam(d, "fits_file_shortfall_as_time_ephemeris", fits_file_shortfall_as_time_ephemeris)
+    addObsParam(d, "protocol_in_use", config.protocol)
+    addObsParam(d, "star_catalog_file", config.star_catalog_file)
+
+    try:
+        first_detection, last_detection = getTimeOfFirstAndLastDetectionInDir(night_data_dir)
+        addObsParam(d, "time_first_detection", first_detection)
+        addObsParam(d, "time_last_detection", last_detection)
+    except Exception as e:
+        log.error('Storing first and last detections failed with error:' + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
 
     try:
         days_behind, remote_branch = daysBehind()
-        addObsParam(obs_db_conn, "repository_lag_remote_days", days_behind)
-        addObsParam(obs_db_conn, "remote_branch", os.path.basename(remote_branch))
+        addObsParam(d, "repository_lag_remote_days", days_behind)
+        addObsParam(d, "remote_branch", os.path.basename(remote_branch))
     except:
-        addObsParam(obs_db_conn, "repository_lag_remote_days", "Not determined")
-    obs_db_conn.close()
+        addObsParam(d, "repository_lag_remote_days", "Not determined")
 
-    writeToFile(config, getRMSStyleFileName(night_data_dir, "observation_summary.txt"), night_data_dir)
-    writeToJSON(config, getRMSStyleFileName(night_data_dir, "observation_summary.json"), night_data_dir)
+    try:
+        conn = getObsDBConn(config, force_delete=False)
+        storeDictInDB(conn, d, debug=True)
+        conn.close()
+
+    except Exception as e:
+        log.error('Storing final observation summary into database failed with error:' + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
+
+
+    addObsParam(d, 'days_since_last_detection', getDaysSinceLastDetection(config, night_data_dir, d=d))
+    saveObservationSummaryDict(d)
+
+    writeToFile(config, getRMSStyleFileName(night_data_dir, OBSERVATION_SUMMARY_NAME_TXT), night_data_dir)
+    writeToJSON(config, getRMSStyleFileName(night_data_dir, OBSERVATION_SUMMARY_NAME_JSON), night_data_dir)
+    working_json_path = getRMSStyleFileName(night_data_dir, OBSERVATION_SUMMARY_WORKING_NAME_JSON)
+    if os.path.exists(working_json_path):
+        if os.path.isfile(working_json_path):
+            os.unlink(working_json_path)
+
+    try:
+        conn = getObsDBConn(config, force_delete=False)
+        storeDictInDB(conn, d, debug=True)
+        conn.close()
+
+    except Exception as e:
+        log.error('Storing final observation summary into database failed with error:' + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
+
 
     return getRMSStyleFileName(night_data_dir, "observation_summary.txt"), \
                 getRMSStyleFileName(night_data_dir, "observation_summary.json")
 
 if __name__ == "__main__":
 
-    config = parse(os.path.expanduser("~/source/RMS/.config"))
+    ### COMMAND LINE ARGUMENTS
 
-    obs_db_conn = getObsDBConn(config)
+    # Init the command line arguments parser
+    arg_parser = argparse.ArgumentParser(description="Test run observation summary.")
 
-    capture_directory = os.path.join(config.data_dir, config.captured_dir)
+    arg_parser.add_argument('-c', '--config', nargs=1, metavar='CONFIG_PATH', type=str, \
+                            help="Path to a config file which will be used instead of the default one.")
+
+    # Parse the command line arguments
+    cml_args = arg_parser.parse_args()
+
+    #########################
+
+    # Load the config file
+
+    config = cr.loadConfigFromDirectory(cml_args.config, os.path.abspath('.'))
+
+    conn = getObsDBConn(config, force_delete=False)
+    full_path_capture_directory = os.path.join(config.data_dir, config.captured_dir)
     start_time = datetime.datetime.strptime("2025-06-25 08:03:37", "%Y-%m-%d %H:%M:%S")
+    d = getObservationSummaryDict(None, config=config)
 
-    dir_list = os.listdir(capture_directory)
+    ftp_detect_info_file = None
+    dir_list = os.listdir(full_path_capture_directory)
     dir_list.sort(reverse=True)
-    latest_dir = os.path.join(capture_directory, dir_list[0])
+    for directory_to_search in dir_list:
+        try:
+            ftp_detect_info_file = findFTPdetectinfoFile(os.path.join(full_path_capture_directory, directory_to_search))
+            break
+        except:
+            pass
+
+    if ftp_detect_info_file is None:
+        log.info("Unable to find a directory with a FTP file")
+    else:
+        log.info(f"Directory {directory_to_search} has a FTP file {ftp_detect_info_file}")
+
+    capture_directory = directory_to_search
+
+    latest_dir = os.path.join(full_path_capture_directory, capture_directory)
+    print(f"Days since last detection {getDaysSinceLastDetection(config, latest_dir, debug=True)}")
     start_time, duration, end_time = getEphemTimesFromCaptureDirectory(config, latest_dir)
     print("For directory {}".format(latest_dir))
     print("Start time was {}".format(start_time))
     print("Duration time was {:.2f} hours".format(duration/3600))
     print("End time was {}".format(end_time))
+    print(f"Days since last detection {getDaysSinceLastDetection(config, latest_dir, debug=True)}")
+    print(getTimeOfFirstAndLastDetectionInDir(latest_dir))
 
-
-
-    startObservationSummaryReport(config, 100, force_delete=False)
+    startObservationSummaryReport(config, latest_dir, duration, force_delete=False)
     pp = Platepar()
     finalizeObservationSummary(config, latest_dir , pp)
     print("Summary as colon delimited text")
     print(serialize(config, as_json=False, night_directory=latest_dir))
     print("Summary as json")
-    print(serialize(config, as_json=True, night_directory=latest_dir))
+    obs_sum_json = serialize(config, as_json=True, night_directory=latest_dir, final=True)
+    print(obs_sum_json)
+

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1494,9 +1494,7 @@ def getObservationSummaryDict(data_dir, final=False, config=None):
         [dict]: Observation summary dict.
     """
 
-    log.info("Entered getObservationSummaryDict")
     if data_dir is None and config is not None:
-        log.info("Attempting to guess captured files directory")
         p = Path(os.path.join(config.data_dir, config.captured_dir))
         regex = re.compile(rf"^{config.stationID}_[0-9]{{8}}_[0-9]{{6}}_[0-9]{{6}}$")
 
@@ -1506,9 +1504,8 @@ def getObservationSummaryDict(data_dir, final=False, config=None):
             candidate_dirs.sort(key=lambda d: d.stat().st_ctime, reverse=True)
             if len(candidate_dirs):
                 data_dir = str(candidate_dirs[0].resolve())
-                log.info(f"Guessed directory {data_dir}")
             else:
-                log.warning("Found no matching captured dirs, unable to guess")
+                log.warning("Found no matching captured dirs, unable to determine directory to use")
                 return {}
         else:
             return {}
@@ -1520,9 +1517,8 @@ def getObservationSummaryDict(data_dir, final=False, config=None):
         if os.path.isfile(observation_summary_json_path):
             with open(observation_summary_json_path, "r") as f:
                 try:
-                    log.info(f"Found an existing {observation_summary_json_path}")
                     d = json.load(f)
-                    log.info(f"Loaded")
+                    log.info(f"Loaded {os.path.basename(observation_summary_json_path)}")
 
                 except:
                     os.remove(observation_summary_json_path)
@@ -1534,7 +1530,6 @@ def getObservationSummaryDict(data_dir, final=False, config=None):
     log.info("Creating a new observation summary dictionary")
     d = {'night_data_dir': data_dir}
     saveObservationSummaryDict(d, data_dir)
-
 
     return d
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1365,6 +1365,8 @@ def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, 
         char_width: [int] width of characters used to compute column width.
         text_colour: (r,g,b) Colour for text, optional default (255,140,0)
         bg_colour: (r,g,b) Colour for text, optional default (25,10,0) - VT320 style
+        alpha_blur: [float] alpha for blurring overlay
+        radius_blur: [float] pixel radius for blurring
 
     Return:
         [string] string of key value pairs committed to the database since the start of the observation session.

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -43,9 +43,6 @@ import tempfile
 import ephem
 import traceback
 import argparse
-import cv2
-import numpy as np
-
 
 from RMS.ConfigReader import parse
 from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
@@ -56,7 +53,7 @@ from RMS.CaptureModeSwitcher import SWITCH_HORIZON_DEG
 from RMS.Formats.FTPdetectinfo import findFTPdetectinfoFile, readFTPdetectinfo
 from RMS.Logger import getLogger
 from pathlib import Path
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, ImageFilter
 
 import RMS.ConfigReader as cr
 import subprocess
@@ -70,9 +67,6 @@ else:
     # Python2 compatible version
     import Utils.CameraControl27 as dvr
 
-
-
-
 DEBUG_PRINT = False
 
 OBSERVATION_SUMMARY_WORKING_NAME_JSON = "observation_summary_working.json"
@@ -85,7 +79,15 @@ NIGHT_DATA_DIR_COL = "night_data_dir"
 
 
 def pingOnce(host):
+    """Quickly detect if a host is pingable
 
+    Arguments:
+        host: [str} ip address of host to be pinged.
+
+    Return:
+        [bool]: True if pinged, otherwise False.
+
+    """
     try:
         result = subprocess.run(
             ["ping", "-c", "1", "-W", "1", host],
@@ -161,20 +163,48 @@ def getObsDBConn(config, force_delete=False):
     return conn
 
 def getColumns(conn):
+    """Get the columns in the observation table.
+
+    Arguments:
+        conn: connection to database.
+
+    Return:
+        [set]: Set of columns in table.
+    """
 
     cursor = conn.execute(f"PRAGMA table_info({OBSERVATIONS_TABLE_NAME})")
     return {row[1] for row in cursor.fetchall()}
 
 def addRequiredColumns(conn, d):
+    """For each key in d if not already a column in table, add as a column.
+
+    Arguments:
+        conn: connection to database.
+        d: [dict] Dictionary of keys and values for the observation summary.
+
+     Return:
+        Nothing.
+    """
 
     existing = getColumns(conn)
     for key in d:
         if key.lower() not in existing:
             sql_command = f"ALTER TABLE {OBSERVATIONS_TABLE_NAME} ADD COLUMN {key.lower()} TEXT"
-            print(sql_command)
             conn.execute(sql_command)
 
 def storeDictInDB(conn, d, debug=False):
+    """
+    Store the dict d in the observation summary database.
+
+    Arguments:
+        conn: connection to database.
+        d: [dict] Dictionary of keys and values for the observation summary.
+
+
+    Return:
+        Nothing.
+    """
+
     # Ensure schema is up to date
     addRequiredColumns(conn, d)
 
@@ -188,19 +218,15 @@ def storeDictInDB(conn, d, debug=False):
     if "night_data_dir" in clean:
         clean["night_data_dir"] = os.path.basename(clean["night_data_dir"])
 
-
     columns = list(clean.keys())
     placeholders = ", ".join("?" for _ in columns)
     values = [clean[col] for col in columns]
 
-
     assignments = ", ".join(f"{col}=excluded.{col}" for col in columns if col != "night_data_dir")
-
 
     if debug:
         for c, v in zip(columns, values):
             print(f"{c:40} -> {repr(v)}")
-
 
     sql_command = ""
     sql_command += f"INSERT INTO {OBSERVATIONS_TABLE_NAME} ({', '.join(columns)})\n"
@@ -360,9 +386,7 @@ def getTimeClient():
     return "Not recognized"
 
 def timeSyncStatus(config, d, force_client=None):
-
-    """
-    Add time sync information to the observation summary.
+    """Add time sync information to the observation summary.
 
     Arguments:
         config: [Config] Configuration object.
@@ -425,7 +449,17 @@ def timeSyncStatus(config, d, force_client=None):
     return ahead_ms
 
 def getDaysSinceLastDetection(config, data_dir, d=None, debug=False):
+    """Get the number of days since the last meteor detection
 
+    Arguments:
+        config: [config] RMS configuration instance.
+        data_dir: [path] path to the data_dir.
+        d: [dict] Obseravation summary dictonary.
+        debug: [bool] Run in debug mode.
+
+    Returns:
+        days_since_last_detection: [int].
+    """
 
 
     last_fits_file_for_session_sql = ""
@@ -482,8 +516,10 @@ def getDaysSinceLastDetection(config, data_dir, d=None, debug=False):
         cursor = conn.execute(last_detection_time_for_session_sql)
         result =  cursor.fetchone()[0]
         last_detection_time_for_session = datetime.datetime.strptime(result, "%Y-%m-%d %H:%M:%S")
+
         # Guard against missing fits files causing negative time since last detection
         seconds_since_last_detection = max((time_last_fits_file_for_session - last_detection_time_for_session).total_seconds(), 0)
+
         days_since_last_detection = seconds_since_last_detection / (60 * 60 * 23.934)
         conn.close()
 
@@ -1309,7 +1345,9 @@ def writeToFile(config, file_path_and_name, night_dir):
         summary_file_handle.flush()
 
 
-def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, padding=10, col_gap=20, char_height=15, char_width=10):
+def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, padding=10,
+               col_gap=20, char_height=15, char_width=10,
+               text_colour=(255, 140, 0), bg_colour=(25, 10, 0), alpha_blur=0.8, radius_blur=2.0):
 
     """Write colon delimited text to png image.
 
@@ -1325,6 +1363,8 @@ def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, 
         col_gap: [int] gap between columns.
         char_height: [int] height of characters.
         char_width: [int] width of characters used to compute column width.
+        text_colour: (r,g,b) Colour for text, optional default (255,140,0)
+        bg_colour: (r,g,b) Colour for text, optional default (25,10,0) - VT320 style
 
     Return:
         [string] string of key value pairs committed to the database since the start of the observation session.
@@ -1346,9 +1386,6 @@ def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, 
     # Monospace font
     font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 16)
 
-    # Colours orange on warm black
-    text_color, bg_color = (255, 140, 0), (25, 10, 0)
-
     # Measure column widths
     col1_width = max(char_width * len(line) for line in col1) if col1 else 0
     col2_width = max(char_width * len(line) for line in col2) if col2 else 0
@@ -1358,21 +1395,25 @@ def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, 
     img_height = padding + (char_height + line_gap) * max(len(col1), len(col2)) + padding
 
     # Background
-    img = Image.new("RGB", (img_width, img_height), bg_color)
+    img = Image.new("RGB", (img_width, img_height), bg_colour)
     draw = ImageDraw.Draw(img)
 
     # Draw column 1
     y = padding
     for line in col1:
-        draw.text((padding, y), line, font=font, fill=text_color)
+        draw.text((padding, y), line, font=font, fill=text_colour)
         y += char_height + line_gap
 
     # Draw column 2
     x2 = padding + col1_width + col_gap
     y = padding
     for line in col2:
-        draw.text((x2, y), line, font=font, fill=text_color)
+        draw.text((x2, y), line, font=font, fill=text_colour)
         y += char_height + line_gap
+
+
+    glow = img.filter(ImageFilter.GaussianBlur(radius=radius_blur))
+    img = Image.blend(glow, img, alpha=alpha_blur)
 
     img.save(file_path_and_name)
 
@@ -1383,7 +1424,6 @@ def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, 
 
 
 def writeToJSON(config, file_path_and_name, night_dir):
-
     """Write as a json.
     Arguments:
         config: [config] station config file.
@@ -1400,7 +1440,16 @@ def writeToJSON(config, file_path_and_name, night_dir):
 
 
 def getTimeOfFirstAndLastDetectionInDir(data_dir):
+    """Get the time of the first and last meteor detections in the data_dir
 
+    Arguments:
+        data_dir:[path] Path to the data_dir to be checked
+
+    Return:
+        [str] First detection time
+        [str] Last detection time
+
+    """
 
     first_detection, last_detection = "0", "0"
     log.info(f"Looking for FTP file in {data_dir}")
@@ -1483,8 +1532,7 @@ def getObservationSummaryDict(data_dir, final=False, config=None):
     return d
 
 def saveObservationSummaryDict(d, night_dir=None):
-
-    """
+    """Save the observation summary dictionary as a json.
 
     Arguments:
         d: Observation summary dict.
@@ -1585,8 +1633,7 @@ def startObservationSummaryReport(config, night_data_dir, duration, force_delete
     return "Opening a new observations summary"
 
 def finalizeObservationSummary(config, night_data_dir, platepar=None):
-
-    """ Enters the parameters known at the end of observation into the database.
+    """Enters the parameters known at the end of observation into the database.
 
     Arguments:
         config: [config] config file.
@@ -1609,8 +1656,8 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     time_first_fits_file, time_last_fits_file, \
     total_expected_fits, total_expected_fits_ephemeris = nightSummaryData(config, night_data_dir)
 
-    # Convert AU0004_
-    _, time_section = os.path.basename(d['night_data_dir']).split("_",1)
+    # Convert AU0004_20260612_100206_674582 into a python time object
+    _, time_section = os.path.basename(d['night_data_dir']).split("_",maxsplit=1)
     session_start_time = datetime.datetime.strptime(time_section, "%Y%m%d_%H%M%S_%f").replace(tzinfo=datetime.timezone.utc)
     addObsParam(d, "traceback_count", countKeyStringsInLogs(session_start_time, config, key_string="Traceback (most recent call last)"))
     addObsParam(d, "kht_wrapper_count", countKeyStringsInLogs(session_start_time, config, key_string="undefined symbol: kht_wrapper"))

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1305,7 +1305,7 @@ def writeToFile(config, file_path_and_name, night_dir):
         summary_file_handle.flush()
 
 
-def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, col_gap=20, char_height=15, char_width=15):
+def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, col_gap=20, char_height=15, char_width=10):
 
     as_ascii = serialize(
         config,

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1305,7 +1305,7 @@ def writeToFile(config, file_path_and_name, night_dir):
         summary_file_handle.flush()
 
 
-def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, col_gap=20, line_height=15):
+def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, col_gap=20, char_height=15, char_width=15):
 
     as_ascii = serialize(
         config,
@@ -1327,12 +1327,12 @@ def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, co
     text_color, bg_color = (255, 140, 0), (25, 10, 0)
 
     # Measure column widths
-    col1_width = max(font.getsize(line)[0] for line in col1) if col1 else 0
-    col2_width = max(font.getsize(line)[0] for line in col2) if col2 else 0
+    col1_width = max(char_width * len(line) for line in col1) if col1 else 0
+    col2_width = max(char_width * len(line) for line in col2) if col2 else 0
 
     # Total image size
     img_width = padding + col1_width + col_gap + col2_width + padding
-    img_height = padding + (line_height + line_gap) * max(len(col1), len(col2)) + padding
+    img_height = padding + (char_height + line_gap) * max(len(col1), len(col2)) + padding
 
     # Background
     img = Image.new("RGB", (img_width, img_height), bg_color)
@@ -1342,14 +1342,14 @@ def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, co
     y = padding
     for line in col1:
         draw.text((padding, y), line, font=font, fill=text_color)
-        y += line_height + line_gap
+        y += char_height + line_gap
 
     # Draw column 2
     x2 = padding + col1_width + col_gap
     y = padding
     for line in col2:
         draw.text((x2, y), line, font=font, fill=text_color)
-        y += line_height + line_gap
+        y += char_height + line_gap
 
     img.save(file_path_and_name)
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1612,7 +1612,7 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     # Convert AU0004_
     _, time_section = os.path.basename(d['night_data_dir']).split("_",1)
     session_start_time = datetime.datetime.strptime(time_section, "%Y%m%d_%H%M%S_%f").replace(tzinfo=datetime.timezone.utc)
-    addObsParam(d, "traceback_count", countKeyStringsInLogs(session_start_time, config))
+    addObsParam(d, "traceback_count", countKeyStringsInLogs(session_start_time, config, key_string="Traceback (most recent call last)"))
     addObsParam(d, "kht_wrapper_count", countKeyStringsInLogs(session_start_time, config, key_string="undefined symbol: kht_wrapper"))
 
     try:

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -58,14 +58,16 @@ from PIL import Image, ImageDraw, ImageFont, ImageFilter
 import RMS.ConfigReader as cr
 import subprocess
 
+import dvrip as dvr
+
+# File locking for the per-night working JSON (POSIX only; degrade gracefully elsewhere)
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
 # Get the logger from the main module
 log = getLogger("rmslogger")
-
-if sys.version_info.major > 2:
-    import dvrip as dvr
-else:
-    # Python2 compatible version
-    import Utils.CameraControl27 as dvr
 
 DEBUG_PRINT = False
 RUNNING_FROM_CONSOLE = False
@@ -117,7 +119,7 @@ def getObsDBConn(config, force_delete=False):
     # Create the Observation Summary database
     observation_records_db_path = os.path.join(config.data_dir,OBSERVATION_DB_FILE_NAME)
     log.info(f"Opening database at {observation_records_db_path}")
-    if force_delete:
+    if force_delete and os.path.exists(observation_records_db_path):
         os.unlink(observation_records_db_path)
 
     if not os.path.exists(os.path.dirname(observation_records_db_path)):
@@ -189,6 +191,11 @@ def addRequiredColumns(conn, d):
 
     existing = getColumns(conn)
     for key in d:
+        # SQLite cannot bind identifiers in DDL, so guard against anything that is not a plain
+        # column name before interpolating it into the ALTER TABLE statement.
+        if not re.match(r'^[A-Za-z0-9_]+$', key):
+            log.warning("Skipping observation summary key with unsafe column name: {!r}".format(key))
+            continue
         if key.lower() not in existing:
             sql_command = f"ALTER TABLE {OBSERVATIONS_TABLE_NAME} ADD COLUMN {key.lower()} TEXT"
             conn.execute(sql_command)
@@ -272,12 +279,26 @@ def getObservationDurationNightTime(config, start_time):
         duration: [float] duration of observation in seconds.
     """
 
-    ephemeris_start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation,start_time)
+    original_start_time = start_time
+    ephemeris_start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation, start_time)
 
-    while isinstance(ephemeris_start_time, bool):
+    # captureDuration returns a bool (not a datetime) as the first element when it cannot pin a
+    # concrete sunset (we are already inside the dark window, or it is polar day/night). Walk back
+    # to find the sunset that began the current dark period, but cap the search - during polar
+    # night captureDuration always returns a bool regardless of start_time, so an unbounded loop
+    # would spin forever.
+    max_backoff_minutes = 24*60
+    backoff = 0
+    while isinstance(ephemeris_start_time, bool) and backoff < max_backoff_minutes:
         start_time -= datetime.timedelta(minutes=1)
+        backoff += 1
         # Go backwards through time until we are before the start time
         ephemeris_start_time, duration = captureDuration(config.latitude, config.longitude, config.elevation, start_time)
+
+    if isinstance(ephemeris_start_time, bool):
+        # No concrete sunset within the search window (e.g. polar night) - fall back to the passed time.
+        log.warning("getObservationDurationNightTime: no concrete sunset found; falling back to start_time")
+        ephemeris_start_time = original_start_time
 
     end_time = ephemeris_start_time + datetime.timedelta(seconds=duration)
 
@@ -391,7 +412,7 @@ def timeSyncStatus(config, d, force_client=None):
 
     Arguments:
         config: [Config] Configuration object.
-        d: [Connection] Observation summary dictionary
+        d: [dict] Observation summary dictionary
 
     Keyword arguments:
         force_client: [string] optional, string to force resolution by ntpd, chrony, or a query on a remote server.
@@ -466,7 +487,7 @@ def getDaysSinceLastDetection(config, data_dir, d=None, debug=False):
     last_fits_file_for_session_sql = ""
     last_fits_file_for_session_sql += f"SELECT time_last_fits_file\n"
     last_fits_file_for_session_sql += f"        FROM {OBSERVATIONS_TABLE_NAME}\n"
-    last_fits_file_for_session_sql += f"        WHERE night_data_dir = '{os.path.basename(data_dir)}'\n"
+    last_fits_file_for_session_sql += f"        WHERE night_data_dir = ?\n"
     last_fits_file_for_session_sql += f"        LIMIT 1; "
 
 
@@ -476,7 +497,7 @@ def getDaysSinceLastDetection(config, data_dir, d=None, debug=False):
 
     try:
         conn = getObsDBConn(config)
-        result = conn.execute(last_fits_file_for_session_sql).fetchone()
+        result = conn.execute(last_fits_file_for_session_sql, (os.path.basename(data_dir),)).fetchone()
         if result is None:
             return "Unknown"
         else:
@@ -521,7 +542,8 @@ def getDaysSinceLastDetection(config, data_dir, d=None, debug=False):
         # Guard against missing fits files causing negative time since last detection
         seconds_since_last_detection = max((time_last_fits_file_for_session - last_detection_time_for_session).total_seconds(), 0)
 
-        days_since_last_detection = seconds_since_last_detection / (60 * 60 * 23.934)
+        # Express the gap in solar days (24 h), which is the intuitive unit for "days since".
+        days_since_last_detection = seconds_since_last_detection / (60 * 60 * 24.0)
         conn.close()
 
     except Exception as e:
@@ -792,39 +814,6 @@ def getEphemTimesFromCaptureDirectory(config, capture_directory):
     start_time, duration, end_time = getObservationDuration(night_config, capture_directory_start_time)
 
     return start_time, duration, end_time
-
-def getNextStartTime(conn, time_point, tz_naive=True):
-    """Query the database to discover the next start time.
-
-    Arguments:
-        conn: [connection] connection to database.
-        obs_time: [datetime] A time before an observation session.
-
-    Return:
-        result: [string] the first entry in the next observation.
-
-    """
-
-
-    sql_statement = ""
-    sql_statement += "SELECT Value from records \n"
-    sql_statement += "      WHERE Key = 'start_time' \n"
-    sql_statement += "      AND Value > '{}'\n".format(time_point)
-    sql_statement += "      ORDER BY TimeStamp asc \n"
-
-    # print(sql_statement)
-    result_list = conn.cursor().execute(sql_statement).fetchall()
-    # print(result_list)
-    
-    if len(result_list) > 2:
-        result = result_list[1]
-        return result[0]
-    
-    else:
-
-        result = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-        return result
-
 
 def countKeyStringsInLogs(session_start, config, key_string="Traceback (most recent call last)"):
     """Count the number of occurences of key_string in log files from the current session.
@@ -1263,6 +1252,10 @@ def serialize(config, format_nicely=True, as_json=False, night_directory=None, d
                     'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate','kht_wrapper_count',
                     'traceback_count']
 
+    # Dedupe while preserving first occurrence - the ordering list contains a few repeats
+    # (e.g. media_backend, star_catalog_file) which would otherwise produce duplicate output lines.
+    ordering = list(dict.fromkeys(ordering))
+
     # Use this print call to check the ordering
     # print("Ordering {}".format(ordering))
 
@@ -1373,58 +1366,67 @@ def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, 
         [string] string of key value pairs committed to the database since the start of the observation session.
         """
 
-    as_ascii = serialize(
-        config,
-        night_directory=night_dir,
-        drop_keys_list="night_data_dir"
-    ).encode("ascii", errors="ignore").decode("ascii")
+    # Rendering the PNG is a nice-to-have for the weblog; never let it break finalization.
+    try:
+        as_ascii = serialize(
+            config,
+            night_directory=night_dir,
+            drop_keys_list="night_data_dir"
+        ).encode("ascii", errors="ignore").decode("ascii")
 
-    lines_list = as_ascii.split("\n")
+        lines_list = as_ascii.split("\n")
 
-    # Remove final empty line if present
-    if lines_list and lines_list[-1].strip() == "":
-        lines_list.pop()
+        # Remove final empty line if present
+        if lines_list and lines_list[-1].strip() == "":
+            lines_list.pop()
 
-    # Split into two columns
-    mid = (len(lines_list) + 1) // 2
-    col1_list, col2_list = lines_list[:mid], lines_list[mid:]
-
-
-    # Monospace font
-    font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 16)
-
-    # Measure column widths
-    col1_width = max(char_width * len(line) for line in col1_list) if col1_list else 0
-    col2_width = max(char_width * len(line) for line in col2_list) if col2_list else 0
-
-    # Total image size
-    img_width = padding + col1_width + col_gap + col2_width + padding
-    img_height = padding + (char_height + line_gap) * max(len(col1_list), len(col2_list)) + padding
-
-    # Background
-    img = Image.new("RGB", (img_width, img_height), bg_colour)
-    draw = ImageDraw.Draw(img)
-
-    # Draw column 1
-    y = padding
-    for line in col1_list:
-        draw.text((padding, y), line, font=font, fill=text_colour)
-        y += char_height + line_gap
-
-    # Draw column 2
-    x2 = padding + col1_width + col_gap
-    y = padding
-    for line in col2_list:
-        draw.text((x2, y), line, font=font, fill=text_colour)
-        y += char_height + line_gap
+        # Split into two columns
+        mid = (len(lines_list) + 1) // 2
+        col1_list, col2_list = lines_list[:mid], lines_list[mid:]
 
 
-    glow = img.filter(ImageFilter.GaussianBlur(radius=radius_blur))
-    img = Image.blend(glow, img, alpha=alpha_blur)
+        # Monospace font - fall back to the PIL default if the DejaVu font is not installed.
+        try:
+            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", font_size)
+        except Exception:
+            font = ImageFont.load_default()
 
-    img.save(file_path_and_name)
+        # Measure column widths
+        col1_width = max(char_width * len(line) for line in col1_list) if col1_list else 0
+        col2_width = max(char_width * len(line) for line in col2_list) if col2_list else 0
 
-    return os.path.basename(file_path_and_name)
+        # Total image size
+        img_width = padding + col1_width + col_gap + col2_width + padding
+        img_height = padding + (char_height + line_gap) * max(len(col1_list), len(col2_list)) + padding
+
+        # Background
+        img = Image.new("RGB", (img_width, img_height), bg_colour)
+        draw = ImageDraw.Draw(img)
+
+        # Draw column 1
+        y = padding
+        for line in col1_list:
+            draw.text((padding, y), line, font=font, fill=text_colour)
+            y += char_height + line_gap
+
+        # Draw column 2
+        x2 = padding + col1_width + col_gap
+        y = padding
+        for line in col2_list:
+            draw.text((x2, y), line, font=font, fill=text_colour)
+            y += char_height + line_gap
+
+
+        glow = img.filter(ImageFilter.GaussianBlur(radius=radius_blur))
+        img = Image.blend(glow, img, alpha=alpha_blur)
+
+        img.save(file_path_and_name)
+
+        return os.path.basename(file_path_and_name)
+
+    except Exception as e:
+        log.warning("Could not render observation summary PNG: {}".format(e))
+        return None
 
 
 
@@ -1521,7 +1523,16 @@ def getObservationSummaryDict(data_dir, final=False, config=None):
                     log.info(f"Loaded {os.path.basename(observation_summary_json_path)}")
 
                 except:
-                    os.remove(observation_summary_json_path)
+                    # Don't silently delete - back up the unparseable file so data is not lost,
+                    # then start fresh.
+                    corrupt_path = observation_summary_json_path + ".corrupt"
+                    try:
+                        os.replace(observation_summary_json_path, corrupt_path)
+                        log.warning("Could not parse {}; backed up to {}".format(
+                            os.path.basename(observation_summary_json_path), os.path.basename(corrupt_path)))
+                    except Exception as e:
+                        log.warning("Could not parse {}; backup failed: {}".format(
+                            os.path.basename(observation_summary_json_path), e))
                     d = {'night_data_dir': data_dir}
                     saveObservationSummaryDict(d, data_dir)
 
@@ -1536,20 +1547,71 @@ def getObservationSummaryDict(data_dir, final=False, config=None):
 def saveObservationSummaryDict(d, night_dir=None):
     """Save the observation summary dictionary as a json.
 
+    The working JSON is read-modify-written by several processes (the capture child writes
+    media_backend while the main process writes the start-of-session values, and Reprocess runs
+    later). To avoid lost updates and torn reads (the failure class behind issue #882) this:
+      - takes an exclusive file lock (POSIX; degrades gracefully where fcntl is unavailable),
+      - merges the in-memory dict on top of whatever is already on disk (so concurrent writers
+        adding distinct keys do not clobber each other),
+      - writes to a temp file and atomically replaces the target.
+    The caller's dict is updated in place to stay consistent with what was written.
+
     Arguments:
         d: Observation summary dict.
+
+    Keyword arguments:
+        night_dir: [path] optional, the night directory; if None it is taken from d['night_data_dir'].
 
     Return:
         Nothing
     """
     if night_dir is None:
-        if "night_data_dir" in d:
-            night_dir = d["night_data_dir"]
+        night_dir = d.get("night_data_dir")
+
+    if night_dir is None:
+        log.warning("saveObservationSummaryDict: no night_data_dir available; skipping save")
+        return
 
     observation_summary_json_path = os.path.join(night_dir, getRMSStyleFileName(night_dir, OBSERVATION_SUMMARY_WORKING_NAME_JSON))
-    with open(observation_summary_json_path, "w") as f:
-        json.dump(d, f, default=lambda o: o.__dict__, indent=4, sort_keys=True)
-        f.flush()
+    lock_path = observation_summary_json_path + ".lock"
+
+    lock_f = open(lock_path, "w")
+    try:
+        if fcntl is not None:
+            fcntl.flock(lock_f, fcntl.LOCK_EX)
+
+        # Merge with whatever is already on disk; in-memory values win for the keys they set.
+        merged = {}
+        if os.path.isfile(observation_summary_json_path):
+            try:
+                with open(observation_summary_json_path, "r") as rf:
+                    merged = json.load(rf)
+            except Exception:
+                merged = {}
+        merged.update(d)
+
+        # Keep the caller's dict consistent with what is persisted.
+        d.clear()
+        d.update(merged)
+
+        tmp_path = observation_summary_json_path + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(merged, f, default=lambda o: o.__dict__, indent=4, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, observation_summary_json_path)
+
+    except Exception as e:
+        log.error("Saving observation summary working JSON failed: " + repr(e))
+        log.error("".join(traceback.format_exception(*sys.exc_info())))
+
+    finally:
+        if fcntl is not None:
+            try:
+                fcntl.flock(lock_f, fcntl.LOCK_UN)
+            except Exception:
+                pass
+        lock_f.close()
 
 def startObservationSummaryReport(config, night_data_dir, duration, force_delete=False):
     """ Enters the parameters known at the start of observation into the database.
@@ -1712,9 +1774,10 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     except:
         addObsParam(d, "repository_lag_remote_days", "Not determined")
 
+    # Persist the values gathered so far so getDaysSinceLastDetection can query time_last_fits_file.
     try:
         conn = getObsDBConn(config, force_delete=False)
-        storeDictInDB(conn, d, debug=True)
+        storeDictInDB(conn, d, debug=False)
         conn.close()
 
     except Exception as e:
@@ -1735,7 +1798,7 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
 
     try:
         conn = getObsDBConn(config, force_delete=False)
-        storeDictInDB(conn, d, debug=True)
+        storeDictInDB(conn, d, debug=False)
         conn.close()
 
     except Exception as e:

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1242,7 +1242,7 @@ def serialize(config, format_nicely=True, as_json=False, night_directory=None, d
     if ordering is None:
         ordering = ['stationID',
                     'commit_date', 'commit_hash', 'remote_branch', 'repository_lag_remote_days',
-                    'media_backend','star_catalog_file',
+                    'star_catalog_file',
                     'hardware_version',
                     'captured_directories',
                     'storage_used_gb', 'storage_free_gb', 'storage_total_gb',

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1260,7 +1260,7 @@ def serialize(config, format_nicely=True, as_json=False, night_directory=None, d
                     'capture_duration_from_ephemeris', 'total_expected_fits_ephemeris', 'fits_file_shortfall_ephemeris',
                     'fits_file_shortfall_as_time_ephemeris',
                     'detections_after_ml',
-                    'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate','kht_wrapper_count'
+                    'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate','kht_wrapper_count',
                     'traceback_count']
 
     # Use this print call to check the ordering

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -43,6 +43,8 @@ import tempfile
 import ephem
 import traceback
 import argparse
+import cv2
+import numpy as np
 
 
 from RMS.ConfigReader import parse
@@ -54,8 +56,10 @@ from RMS.CaptureModeSwitcher import SWITCH_HORIZON_DEG
 from RMS.Formats.FTPdetectinfo import findFTPdetectinfoFile, readFTPdetectinfo
 from RMS.Logger import getLogger
 from pathlib import Path
+from PIL import Image, ImageDraw, ImageFont
 
 import RMS.ConfigReader as cr
+import subprocess
 
 # Get the logger from the main module
 log = getLogger("rmslogger")
@@ -74,9 +78,23 @@ DEBUG_PRINT = False
 OBSERVATION_SUMMARY_WORKING_NAME_JSON = "observation_summary_working.json"
 OBSERVATION_SUMMARY_NAME_JSON = "observation_summary.json"
 OBSERVATION_SUMMARY_NAME_TXT = "observation_summary.txt"
+OBSERVATION_SUMMARY_NAME_PNG = "observation_summary.png"
 OBSERVATIONS_TABLE_NAME = "observations"
 OBSERVATION_DB_FILE_NAME = "observation.db"
 NIGHT_DATA_DIR_COL = "night_data_dir"
+
+
+def pingOnce(host):
+
+    try:
+        result = subprocess.run(
+            ["ping", "-c", "1", "-W", "1", host],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
 
 
 def getObsDBConn(config, force_delete=False):
@@ -839,6 +857,9 @@ def gatherCameraInformation(config, attempts=6, delay=10, sock_timeout=3):
 
     ip = re.search(r'(?:\d{1,3}\.){3}\d{1,3}', config.deviceID).group()
 
+    if not pingOnce(ip):
+        return ("Unavailable", "Unavailable", "Unavailable")
+
     for _ in range(attempts):
         try:
             cam = dvr.DVRIPCam(ip, timeout=sock_timeout)
@@ -1090,9 +1111,12 @@ def getRemoteBranchNameForCommit(repo, commit):
         remote_branch_name: [str] the full name of the remote branch where commit exists.
     """
 
+
+    # This is the simple case, our latest commit is the HEAD
+
     local_branch_list = []
     try:
-        local_branch_list = subprocess.check_output(["git", "branch", "-a", "--contains", commit], cwd=repo).decode(
+        local_branch_list = subprocess.check_output(["git", "branch", "-r", "--points-at", commit], cwd=repo).decode(
             "utf-8").split("\n")
     except:
         pass
@@ -1103,6 +1127,27 @@ def getRemoteBranchNameForCommit(repo, commit):
         if branch_stripped.startswith("remotes/"):
             remote_branch_name = branch_stripped
 
+    # If we are not at the HEAD, then get all the branches which contain the commit.
+
+    # 2. Branches that *contain* the commit
+    try:
+        contains = subprocess.check_output(
+            ["git", "branch", "-r", "--contains", commit],
+            cwd=repo
+        ).decode().splitlines()
+    except Exception:
+        contains = []
+
+    contains = [c.strip() for c in contains if c.strip()]
+
+    if contains:
+        # If the branch is origin/main or origin/pre-release; then that is almost certainly where we are
+        for preferred in ["origin/master", "origin/prerelease"]:
+            if preferred in contains:
+                return preferred
+        return contains[0]
+
+    # Fall back return
     return remote_branch_name
 
 def daysBehind():
@@ -1258,6 +1303,64 @@ def writeToFile(config, file_path_and_name, night_dir):
         as_ascii = serialize(config, night_directory=night_dir, drop_keys_list="night_data_dir").encode("ascii", errors="ignore").decode("ascii")
         summary_file_handle.write(as_ascii)
         summary_file_handle.flush()
+
+
+def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, col_gap=20):
+
+    as_ascii = serialize(
+        config,
+        night_directory=night_dir,
+        drop_keys_list="night_data_dir"
+    ).encode("ascii", errors="ignore").decode("ascii")
+
+    lines = as_ascii.split("\n")
+
+    # Split into two columns
+    mid = (len(lines) + 1) // 2
+    col1, col2 = lines[:mid], lines[mid:]
+
+
+    # Monospace font
+    font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 16)
+
+    # Colours orange on warm black
+    text_color, bg_color = (255, 140, 0), (25, 10, 0)
+
+    # Measure line height (fixed)
+    _, line_height = font.getsize("A")
+
+    # Measure column widths
+    col1_width = max(font.getsize(line)[0] for line in col1) if col1 else 0
+    col2_width = max(font.getsize(line)[0] for line in col2) if col2 else 0
+
+    # Total image size
+    img_width = padding + col1_width + col_gap + col2_width + padding
+    img_height = padding + (line_height + line_gap) * max(len(col1), len(col2)) + padding
+
+    # Background
+    img = Image.new("RGB", (img_width, img_height), bg_color)
+    draw = ImageDraw.Draw(img)
+
+    # Draw column 1
+    y = padding
+    for line in col1:
+        draw.text((padding, y), line, font=font, fill=text_color)
+        y += line_height + line_gap
+
+    # Draw column 2
+    x2 = padding + col1_width + col_gap
+    y = padding
+    for line in col2:
+        draw.text((x2, y), line, font=font, fill=text_color)
+        y += line_height + line_gap
+
+    img.save(file_path_and_name)
+
+
+
+
+
+
 
 def writeToJSON(config, file_path_and_name, night_dir):
 
@@ -1555,6 +1658,7 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
 
     writeToFile(config, getRMSStyleFileName(night_data_dir, OBSERVATION_SUMMARY_NAME_TXT), night_data_dir)
     writeToJSON(config, getRMSStyleFileName(night_data_dir, OBSERVATION_SUMMARY_NAME_JSON), night_data_dir)
+    writeToPNG(config, getRMSStyleFileName(night_data_dir, OBSERVATION_SUMMARY_NAME_PNG), night_data_dir)
     working_json_path = getRMSStyleFileName(night_data_dir, OBSERVATION_SUMMARY_WORKING_NAME_JSON)
     if os.path.exists(working_json_path):
         if os.path.isfile(working_json_path):

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -68,6 +68,7 @@ else:
     import Utils.CameraControl27 as dvr
 
 DEBUG_PRINT = False
+RUNNING_FROM_CONSOLE = False
 
 OBSERVATION_SUMMARY_WORKING_NAME_JSON = "observation_summary_working.json"
 OBSERVATION_SUMMARY_NAME_JSON = "observation_summary.json"
@@ -896,7 +897,7 @@ def gatherCameraInformation(config, attempts=6, delay=10, sock_timeout=3):
 
     ip = re.search(r'(?:\d{1,3}\.){3}\d{1,3}', config.deviceID).group()
 
-    if not pingOnce(ip):
+    if RUNNING_FROM_CONSOLE and not pingOnce(ip):
         return ("Unavailable", "Unavailable", "Unavailable")
 
     for _ in range(attempts):
@@ -1764,6 +1765,8 @@ if __name__ == "__main__":
     cml_args = arg_parser.parse_args()
 
     #########################
+
+    RUNNING_FROM_CONSOLE = True
 
     # Load the config file
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -789,8 +789,8 @@ def getNextStartTime(conn, time_point, tz_naive=True):
         return result
 
 
-def countTracebacksInLogs(session_start, config):
-    """Count the number of tracebacks in log files from the current session.
+def countKeyStringsInLogs(session_start, config, key_string="Traceback (most recent call last)"):
+    """Count the number of occurences of key_string in log files from the current session.
 
     Scans all log files in the log directory that were modified after the session's
     start_time (from the observation database) for lines containing 'Traceback
@@ -799,6 +799,9 @@ def countTracebacksInLogs(session_start, config):
     Arguments:
         session_start: [datetime] Time object for session start
         config: [config] RMS configuration instance.
+
+    Keyword arguments:
+        key_string: [str] Optional default "Traceback (most recent call last)" - string to be sought
 
     Return:
         count: [int] Number of tracebacks found, or 0 if logs cannot be read.
@@ -810,7 +813,7 @@ def countTracebacksInLogs(session_start, config):
         return 0
 
     # Find log files modified after the session start
-    traceback_count = 0
+    key_string_count = 0
     log_pattern = "log_{}_".format(config.stationID)
 
     for filename in sorted(os.listdir(log_dir)):
@@ -827,12 +830,12 @@ def countTracebacksInLogs(session_start, config):
         try:
             with open(filepath, 'r', errors='replace') as f:
                 for line in f:
-                    if 'Traceback (most recent call last)' in line:
-                        traceback_count += 1
+                    if key_string in line:
+                        key_string_count += 1
         except Exception:
             continue
 
-    return traceback_count
+    return key_string_count
 
 
 def gatherCameraInformation(config, attempts=6, delay=10, sock_timeout=3):
@@ -1220,7 +1223,7 @@ def serialize(config, format_nicely=True, as_json=False, night_directory=None, d
                     'capture_duration_from_ephemeris', 'total_expected_fits_ephemeris', 'fits_file_shortfall_ephemeris',
                     'fits_file_shortfall_as_time_ephemeris',
                     'detections_after_ml',
-                    'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate',
+                    'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate','kht_wrapper_count'
                     'traceback_count']
 
     # Use this print call to check the ordering
@@ -1609,8 +1612,8 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     # Convert AU0004_
     _, time_section = os.path.basename(d['night_data_dir']).split("_",1)
     session_start_time = datetime.datetime.strptime(time_section, "%Y%m%d_%H%M%S_%f").replace(tzinfo=datetime.timezone.utc)
-    addObsParam(d, "traceback_count", countTracebacksInLogs(session_start_time, config))
-
+    addObsParam(d, "traceback_count", countKeyStringsInLogs(session_start_time, config))
+    addObsParam(d, "kht_wrapper_count", countKeyStringsInLogs(session_start_time, config, key_string="undefined symbol: kht_wrapper"))
 
     try:
         timeSyncStatus(config, d)

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1292,7 +1292,8 @@ def writeToFile(config, file_path_and_name, night_dir):
 
     Arguments:
         config: [config] station config file.
-        file_path_and_name: [path full path to the target file.
+        file_path_and_name: [path] full path to the target file.
+        night_dir: [path] path to capture directory for the night
 
     Return:
         [string] string of key value pairs committed to the database since the start of the observation session.
@@ -1305,7 +1306,26 @@ def writeToFile(config, file_path_and_name, night_dir):
         summary_file_handle.flush()
 
 
-def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, col_gap=20, char_height=15, char_width=10):
+def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, padding=10, col_gap=20, char_height=15, char_width=10):
+
+    """Write colon delimited text to png image.
+
+    Arguments:
+        config: [config] station config file.
+        file_path_and_name: [path full path to the target file.
+        night_dir: [path] path to capture directory for the night.
+
+    Keyword arguments:
+        font_size: [int] Font size.
+        line_gap: [int] Gap between lines.
+        padding: [int] Border around image.
+        col_gap: [int] gap between columns.
+        char_height: [int] height of characters.
+        char_width: [int] width of characters used to compute column width.
+
+    Return:
+        [string] string of key value pairs committed to the database since the start of the observation session.
+        """
 
     as_ascii = serialize(
         config,
@@ -1353,7 +1373,7 @@ def writeToPNG(config, file_path_and_name, night_dir, line_gap=4, padding=10, co
 
     img.save(file_path_and_name)
 
-
+    return os.path.basename(file_path_and_name)
 
 
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -44,6 +44,7 @@ import ephem
 import traceback
 import argparse
 
+
 from RMS.ConfigReader import parse
 from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
 from RMS.Formats.FFfits import filenameToDatetimeStr
@@ -458,12 +459,13 @@ def getDaysSinceLastDetection(config, data_dir, d=None, debug=False):
 
     try:
         conn = getObsDBConn(config)
-        storeDictInDB(conn,d, debug=True)
+        storeDictInDB(conn,d, debug=False)
 
         cursor = conn.execute(last_detection_time_for_session_sql)
         result =  cursor.fetchone()[0]
         last_detection_time_for_session = datetime.datetime.strptime(result, "%Y-%m-%d %H:%M:%S")
-        seconds_since_last_detection = (time_last_fits_file_for_session - last_detection_time_for_session).total_seconds()
+        # Guard against missing fits files causing negative time since last detection
+        seconds_since_last_detection = max((time_last_fits_file_for_session - last_detection_time_for_session).total_seconds(), 0)
         days_since_last_detection = seconds_since_last_detection / (60 * 60 * 23.934)
         conn.close()
 
@@ -768,6 +770,53 @@ def getNextStartTime(conn, time_point, tz_naive=True):
         result = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         return result
 
+
+def countTracebacksInLogs(session_start, config):
+    """Count the number of tracebacks in log files from the current session.
+
+    Scans all log files in the log directory that were modified after the session's
+    start_time (from the observation database) for lines containing 'Traceback
+    (most recent call last)'.
+
+    Arguments:
+        session_start: [datetime] Time object for session start
+        config: [config] RMS configuration instance.
+
+    Return:
+        count: [int] Number of tracebacks found, or 0 if logs cannot be read.
+    """
+
+    log_dir = os.path.join(config.data_dir, config.log_dir)
+
+    if not os.path.isdir(log_dir):
+        return 0
+
+    # Find log files modified after the session start
+    traceback_count = 0
+    log_pattern = "log_{}_".format(config.stationID)
+
+    for filename in sorted(os.listdir(log_dir)):
+        if not filename.endswith(".log") or log_pattern not in filename:
+            continue
+
+        filepath = os.path.join(log_dir, filename)
+
+        # Only consider log files modified after the session started
+        file_mtime = datetime.datetime.fromtimestamp(os.path.getmtime(filepath),tz=datetime.timezone.utc)
+        if file_mtime < session_start:
+            continue
+
+        try:
+            with open(filepath, 'r', errors='replace') as f:
+                for line in f:
+                    if 'Traceback (most recent call last)' in line:
+                        traceback_count += 1
+        except Exception:
+            continue
+
+    return traceback_count
+
+
 def gatherCameraInformation(config, attempts=6, delay=10, sock_timeout=3):
     """ Gather information about the sensor in use.
         Retry the DVRIP handshake until it works, or we exhaust attempts.
@@ -789,11 +838,12 @@ def gatherCameraInformation(config, attempts=6, delay=10, sock_timeout=3):
     """
 
     ip = re.search(r'(?:\d{1,3}\.){3}\d{1,3}', config.deviceID).group()
+
     for _ in range(attempts):
         try:
             cam = dvr.DVRIPCam(ip, timeout=sock_timeout)
             if cam.login():
-                sensor = cam.get_upgrade_info()['Hardware']
+                sys_info = cam.get_system_info()
                 cam.close()
                 sensor = sys_info.get('HardWare', 'Unknown')
                 fw = sys_info.get('SoftWareVersion', '')
@@ -1113,7 +1163,7 @@ def serialize(config, format_nicely=True, as_json=False, night_directory=None, d
                     'storage_used_gb', 'storage_free_gb', 'storage_total_gb',
                     'camera_lens','camera_fov_h','camera_fov_v',
                     'camera_pointing_alt','camera_pointing_az',
-                    'camera_information',
+                    'camera_information', 'camera_firmware_build_date', 'camera_firmware_version',
                     'clock_measurement_source', 'clock_synchronized', 'clock_ahead_ms', 'clock_error_uncertainty_ms',
                     'start_time', 'duration_from_start_of_observation', 'continuous_capture',
                     'photometry_good', 'star_catalog_file',
@@ -1125,7 +1175,11 @@ def serialize(config, format_nicely=True, as_json=False, night_directory=None, d
                     'capture_duration_from_ephemeris', 'total_expected_fits_ephemeris', 'fits_file_shortfall_ephemeris',
                     'fits_file_shortfall_as_time_ephemeris',
                     'detections_after_ml',
-                    'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate']
+                    'media_backend','protocol_in_use','jitter_quality','dropped_frame_rate',
+                    'traceback_count']
+
+    # Use this print call to check the ordering
+    # print("Ordering {}".format(ordering))
 
     if drop_keys_list:
         if isinstance(drop_keys_list, str):
@@ -1385,7 +1439,7 @@ def startObservationSummaryReport(config, night_data_dir, duration, force_delete
     captured_directories = captureDirectories(os.path.join(config.data_dir, config.captured_dir), config.stationID)
     addObsParam(d, "captured_directories", captured_directories)
     try:
-        sensor, firmware, build_date = gatherCameraInformation(config)
+        #sensor, firmware, build_date = gatherCameraInformation(config)
         addObsParam(d, "camera_information", sensor)
         addObsParam(d, "camera_firmware_version", firmware)
         addObsParam(d, "camera_firmware_build_date", build_date)
@@ -1394,11 +1448,7 @@ def startObservationSummaryReport(config, night_data_dir, duration, force_delete
         addObsParam(d, "camera_firmware_version", "Unavailable")
         addObsParam(d, "camera_firmware_build_date", "Unavailable")
 
-    # Hardcoded for now, but should be calculated based on the config value
-    no_of_frames_per_fits_file = 256
 
-    # Calculate the number of fits files expected for the duration
-    fps = config.fps
     saveObservationSummaryDict(d)
     try:
         conn = getObsDBConn(config)
@@ -1436,6 +1486,10 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     time_first_fits_file, time_last_fits_file, \
     total_expected_fits, total_expected_fits_ephemeris = nightSummaryData(config, night_data_dir)
 
+    # Convert AU0004_
+    _, time_section = os.path.basename(d['night_data_dir']).split("_",1)
+    session_start_time = datetime.datetime.strptime(time_section, "%Y%m%d_%H%M%S_%f").replace(tzinfo=datetime.timezone.utc)
+    traceback_count = countTracebacksInLogs(session_start_time, config)
 
 
     try:
@@ -1540,7 +1594,6 @@ if __name__ == "__main__":
 
     conn = getObsDBConn(config, force_delete=False)
     full_path_capture_directory = os.path.join(config.data_dir, config.captured_dir)
-    start_time = datetime.datetime.strptime("2025-06-25 08:03:37", "%Y-%m-%d %H:%M:%S")
     d = getObservationSummaryDict(None, config=config)
 
     ftp_detect_info_file = None
@@ -1568,7 +1621,10 @@ if __name__ == "__main__":
     print("Duration time was {:.2f} hours".format(duration/3600))
     print("End time was {}".format(end_time))
     print(f"Days since last detection {getDaysSinceLastDetection(config, latest_dir, debug=True)}")
-    print(getTimeOfFirstAndLastDetectionInDir(latest_dir))
+    try:
+        print(getTimeOfFirstAndLastDetectionInDir(latest_dir))
+    except:
+        pass
 
     startObservationSummaryReport(config, latest_dir, duration, force_delete=False)
     pp = Platepar()

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1489,7 +1489,7 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     # Convert AU0004_
     _, time_section = os.path.basename(d['night_data_dir']).split("_",1)
     session_start_time = datetime.datetime.strptime(time_section, "%Y%m%d_%H%M%S_%f").replace(tzinfo=datetime.timezone.utc)
-    traceback_count = countTracebacksInLogs(session_start_time, config)
+    addObsParam("traceback_count", countTracebacksInLogs(session_start_time, config))
 
 
     try:

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1378,23 +1378,27 @@ def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, 
         drop_keys_list="night_data_dir"
     ).encode("ascii", errors="ignore").decode("ascii")
 
-    lines = as_ascii.split("\n")
+    lines_list = as_ascii.split("\n")
+
+    # Remove final empty line if present
+    if lines_list and lines_list[-1].strip() == "":
+        lines_list.pop()
 
     # Split into two columns
-    mid = (len(lines) + 1) // 2
-    col1, col2 = lines[:mid], lines[mid:]
+    mid = (len(lines_list) + 1) // 2
+    col1_list, col2_list = lines_list[:mid], lines_list[mid:]
 
 
     # Monospace font
     font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 16)
 
     # Measure column widths
-    col1_width = max(char_width * len(line) for line in col1) if col1 else 0
-    col2_width = max(char_width * len(line) for line in col2) if col2 else 0
+    col1_width = max(char_width * len(line) for line in col1_list) if col1_list else 0
+    col2_width = max(char_width * len(line) for line in col2_list) if col2_list else 0
 
     # Total image size
     img_width = padding + col1_width + col_gap + col2_width + padding
-    img_height = padding + (char_height + line_gap) * max(len(col1), len(col2)) + padding
+    img_height = padding + (char_height + line_gap) * max(len(col1_list), len(col2_list)) + padding
 
     # Background
     img = Image.new("RGB", (img_width, img_height), bg_colour)
@@ -1402,14 +1406,14 @@ def writeToPNG(config, file_path_and_name, night_dir, font_size=16, line_gap=4, 
 
     # Draw column 1
     y = padding
-    for line in col1:
+    for line in col1_list:
         draw.text((padding, y), line, font=font, fill=text_colour)
         y += char_height + line_gap
 
     # Draw column 2
     x2 = padding + col1_width + col_gap
     y = padding
-    for line in col2:
+    for line in col2_list:
         draw.text((x2, y), line, font=font, fill=text_colour)
         y += char_height + line_gap
 

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -39,7 +39,8 @@ from Utils.PlotFieldsums import plotFieldsums
 from Utils.RMS2UFO import FTPdetectinfo2UFOOrbitInput
 from Utils.ShowerAssociation import showerAssociation
 from Utils.PlotTimeIntervals import plotFFTimeIntervals
-from RMS.Formats.ObservationSummary import addObsParam, getObsDBConn
+from RMS.Formats.ObservationSummary import addObsParam, getObservationSummaryDict, saveObservationSummaryDict, \
+    startObservationSummaryReport
 from RMS.Formats.ObservationSummary import serialize, finalizeObservationSummary
 from Utils.AuditConfig import compareConfigs
 from RMS.Misc import RmsDateTime, tarWithProgress
@@ -204,7 +205,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
 
 
-        obs_db_conn = getObsDBConn(config)
+        obs_dict = getObservationSummaryDict(night_data_dir)
         # Filter out detections using machine learning
         if config.ml_filter > 0:
 
@@ -212,10 +213,10 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
             ff_detected = filterFTPdetectinfoML(config, os.path.join(night_data_dir, ftpdetectinfo_name), 
                 threshold=config.ml_filter, keep_pngs=False, clear_prev_run=True)
-            addObsParam(obs_db_conn, "detections_after_ml", len(ff_detected))
+            addObsParam(obs_dict, "detections_after_ml", len(ff_detected))
 
-        addObsParam(obs_db_conn,"detections_after_ml", len(readFTPdetectinfo(night_data_dir,ftpdetectinfo_name)))
-        obs_db_conn.close()
+        addObsParam(obs_dict,"detections_after_ml", len(readFTPdetectinfo(night_data_dir,ftpdetectinfo_name)))
+        saveObservationSummaryDict(obs_dict, night_data_dir)
 
         # Get the platepar file
         platepar, platepar_path, platepar_fmt = getPlatepar(config, night_data_dir)
@@ -231,21 +232,21 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
             # Run astrometry check and refinement
             platepar, fit_status = autoCheckFit(config, platepar, calstars_data)
 
-            obs_db_conn = getObsDBConn(config)
+            obs_dict = getObservationSummaryDict(night_data_dir)
             # If the fit was successful, apply the astrometry to detected meteors
             if fit_status:
 
                 log.info('Astrometric calibration SUCCESSFUL!')
-                addObsParam(obs_db_conn, "photometry_good", "True")
+                addObsParam(obs_dict, "photometry_good", "True")
                 # Save the refined platepar to the night directory and as default
                 platepar.write(os.path.join(night_data_dir, config.platepar_name), fmt=platepar_fmt)
                 platepar.write(platepar_path, fmt=platepar_fmt)
 
             else:
                 log.info('Astrometric calibration FAILED!, Using old platepar for calibration...')
-                addObsParam(obs_db_conn, "photometry_good", "False")
+                addObsParam(obs_dict, "photometry_good", "False")
 
-            obs_db_conn.close()
+            saveObservationSummaryDict(obs_dict)
             # If a flat is used, disable vignetting correction
             if config.use_flat:
                 platepar.vignetting_coeff = 0.0
@@ -497,10 +498,10 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
         # Add the timelapse to the extra files
         if intervals_path is not None:
             extra_files.append(intervals_path)
-        obs_db_conn = getObsDBConn(config)
-        addObsParam(obs_db_conn,"jitter_quality",jitter_quality)
-        addObsParam(obs_db_conn,"dropped_frame_rate",dropped_frame_rate)
-        obs_db_conn.close()
+        obs_dict = getObservationSummaryDict(night_data_dir)
+        addObsParam(obs_dict,"jitter_quality",jitter_quality)
+        addObsParam(obs_dict,"dropped_frame_rate",dropped_frame_rate)
+
 
     except Exception as e:
         log.debug('Plotting timestamp interval failed with message:\n' + repr(e))
@@ -645,19 +646,20 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
                     celestial_coords_given=(platepar is not None))
 
     try:
+        log.info("Calling finalize observation summary")
         observation_summary_path_file_name, observation_summary_json_path_file_name = (
             finalizeObservationSummary(config, night_data_dir))
-        
+        log.info("Returned from finalize observation summary")
         extra_files.append(observation_summary_path_file_name)
         extra_files.append(observation_summary_json_path_file_name)
-        
-        log.info("\n\nObservation Summary\n===================\n\n" + serialize(config) + "\n\n")
+
 
     except Exception as e:
-        log.debug('Generating Observation Summary failed with message:\n' + repr(e))
+        log.debug('Finalizing Observation Summary failed with message:\n' + repr(e))
         log.debug(repr(traceback.format_exception(*sys.exc_info())))
 
-
+    obs_summary_to_log = serialize(config, night_directory=night_data_dir, final=True)
+    log.info("\n\nObservation Summary\n===================\n\n" + obs_summary_to_log + "\n\n")
 
     night_archive_dir = os.path.join(os.path.abspath(config.data_dir), config.archived_dir,
         night_data_dir_name)
@@ -839,6 +841,9 @@ if __name__ == "__main__":
             config.num_cores = -1
 
             log.info("Using all available cores for detection.")
+
+    log.info(f"Starting Observation summary report for {cml_args.dir_path[0]}")
+    startObservationSummaryReport(config, cml_args.dir_path[0], None)
 
     # Process the night
     night_archive_dir, archive_name, imgdata_archive_name, metadata_archive_name, detector =  \

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -30,7 +30,7 @@ import threading
 import multiprocessing
 import traceback
 import git
-from RMS.Formats.ObservationSummary import getObsDBConn, addObsParam
+from RMS.Formats.ObservationSummary import addObsParam, getObservationSummaryDict
 
 import numpy as np
 
@@ -614,7 +614,7 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
 
             # Open the observation summary report
             if video_file is None:
-                log.info(startObservationSummaryReport(config, duration, force_delete=False))
+                log.info(startObservationSummaryReport(config, night_data_dir, duration, force_delete=False))
 
             # Start the compressor
             compressor.start()
@@ -719,9 +719,10 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
             log.debug('Capture stopped')
 
             log.info('Total number of late or dropped frames: ' + str(dropped_frames))
-            obs_db_conn = getObsDBConn(config)
-            addObsParam(obs_db_conn, "dropped_frames", dropped_frames)
-            obs_db_conn.close()
+            log.info(f"Starting an observation summary in {night_data_dir}")
+            obs_dict = getObservationSummaryDict(night_data_dir)
+            addObsParam(obs_dict, "dropped_frames", dropped_frames)
+
 
             # Free shared memory after the compressor is done
             try:


### PR DESCRIPTION
This PR is in response to Issue #882. 

On high performance computers a race condition caused the values recorded at the start of an observation session not to be recorded. This PR fixes this by recording all the values in a dict, then stored as a json in the captured files directory. This information is then written into a sqlite database with dynamic schema adjustment. 

Work by others to add additional keys has also been incorporated. These keys are 

```
kht_wrapper_count                         : 0
traceback_count                           : 0
```
kht_wrapper_count counts the occurences of kht wrapper errors, which might indicate a badly linked kht so file.
traceback_count counts the number of tracebacks in the log, useful for detecting execution anomalies.

```
camera_information                        : 50H20L
camera_firmware_build_date                : 2018-11-26 16:11:24
camera_firmware_version                   : V4.03.R12.00031520.11012.042800.00200
```

And also reports on the camera firmware. 

The ObservationSummary is rendered is a png file for display in the weblog, for future implementation; in this case 

```
AU000A_20260613_100215_850897_observation_summary.png
```
Which looks like

<img width="1530" height="514" alt="AU000A_20260613_100215_850897_observation_summary" src="https://github.com/user-attachments/assets/fa2a0019-8950-4611-991f-484ad2407626" />



