### PR TITLE
Fix FITS/FF file-descriptor leak when reading many files (#406)

### DIFF
--- a/RMS/Formats/FFbin.py
+++ b/RMS/Formats/FFbin.py
@@ -44,58 +44,61 @@ def read(directory, filename, array=False, full_filename=False):
     """
     
     if (filename.startswith("FF") and ('.bin' in filename)) or full_filename:
-        fid = open(os.path.join(directory, filename), "rb")
+        file_path = os.path.join(directory, filename)
     else:
-        fid = open(os.path.join(directory, "FF" + filename + ".bin"), "rb")
+        file_path = os.path.join(directory, "FF" + filename + ".bin")
 
     ff = FFStruct()
-    
-    # Check if it is the new of the old CAMS data format
-    version_flag = int(np.fromfile(fid, dtype=np.int32, count = 1))
 
-    # Old format
-    if version_flag > 0:
+    # Read inside a context manager so the file handle is always closed, even on error
+    with open(file_path, "rb") as fid:
 
-        ff.nrows = version_flag
-        ff.ncols = int(np.fromfile(fid, dtype=np.uint32, count = 1))
-        ff.nbits = int(np.fromfile(fid, dtype=np.uint32, count = 1))
-        ff.nframes = 2**ff.nbits
-        ff.first = int(np.fromfile(fid, dtype=np.uint32, count = 1))
-        ff.camno = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+        # Check if it is the new of the old CAMS data format
+        version_flag = int(np.fromfile(fid, dtype=np.int32, count = 1))
 
-        ff.decimation_fact = 1
+        # Old format
+        if version_flag > 0:
 
-        
+            ff.nrows = version_flag
+            ff.ncols = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+            ff.nbits = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+            ff.nframes = 2**ff.nbits
+            ff.first = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+            ff.camno = int(np.fromfile(fid, dtype=np.uint32, count = 1))
 
-    # New format
-    elif version_flag == -1:
+            ff.decimation_fact = 1
 
-        ff.nrows = int(np.fromfile(fid, dtype=np.uint32, count = 1))
-        ff.ncols = int(np.fromfile(fid, dtype=np.uint32, count = 1))
 
-        ff.nframes = int(np.fromfile(fid, dtype=np.uint32, count = 1))
-        ff.first = int(np.fromfile(fid, dtype=np.uint32, count = 1))
-        ff.camno = int(np.fromfile(fid, dtype=np.uint32, count = 1))
 
-        ff.decimation_fact = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+        # New format
+        elif version_flag == -1:
 
-        ff.interleave_flag = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+            ff.nrows = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+            ff.ncols = int(np.fromfile(fid, dtype=np.uint32, count = 1))
 
-        ff.fps = float(np.fromfile(fid, dtype=np.uint32, count = 1))/1000
+            ff.nframes = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+            ff.first = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+            ff.camno = int(np.fromfile(fid, dtype=np.uint32, count = 1))
 
-    
-    if array:
-        N = 4*ff.nrows*ff.ncols
-    
-        ff.array = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (4, ff.nrows, ff.ncols))
-        
-    else:
-        N = ff.nrows*ff.ncols
-    
-        ff.maxpixel = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (ff.nrows, ff.ncols))
-        ff.maxframe = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (ff.nrows, ff.ncols))
-        ff.avepixel = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (ff.nrows, ff.ncols))
-        ff.stdpixel = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (ff.nrows, ff.ncols))
+            ff.decimation_fact = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+
+            ff.interleave_flag = int(np.fromfile(fid, dtype=np.uint32, count = 1))
+
+            ff.fps = float(np.fromfile(fid, dtype=np.uint32, count = 1))/1000
+
+
+        if array:
+            N = 4*ff.nrows*ff.ncols
+
+            ff.array = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (4, ff.nrows, ff.ncols))
+
+        else:
+            N = ff.nrows*ff.ncols
+
+            ff.maxpixel = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (ff.nrows, ff.ncols))
+            ff.maxframe = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (ff.nrows, ff.ncols))
+            ff.avepixel = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (ff.nrows, ff.ncols))
+            ff.stdpixel = np.reshape(np.fromfile(fid, dtype=np.uint8, count=N), (ff.nrows, ff.ncols))
 
     return ff
 

--- a/RMS/Formats/FFfits.py
+++ b/RMS/Formats/FFfits.py
@@ -84,48 +84,51 @@ def read(directory, filename, array=False, full_filename=False, memmap=True):
 
     # Make sure the file starts with "FF_"
     if (filename.startswith('FF') and ('.fits' in filename)) or full_filename:
-        fid = open(os.path.join(directory, filename), "rb")
+        file_path = os.path.join(directory, filename)
     else:
-        fid = open(os.path.join(directory, "FF_" + filename + ".fits"), "rb")
+        file_path = os.path.join(directory, "FF_" + filename + ".fits")
 
     # Init an empty FF structure
     ff = FFStruct()
 
-    # Read in the FITS
-    hdulist = fits.open(fid, memmap=memmap)
+    # Read in the FITS. Pass the path (not a pre-opened handle) so astropy owns and closes
+    # the file, and use a context manager so the file/memmap is always released, even on
+    # error. The image data is copied out of the HDUs (below) so it stays valid after the
+    # file is closed. Without the copy, returning memmap-backed views keeps a file handle
+    # open per FF; reading many FFs in sequence and retaining the arrays then exhausts the
+    # process file descriptor limit ("too many open files"). See issue #406.
+    with fits.open(file_path, memmap=memmap) as hdulist:
 
-    # Read the header
-    head = hdulist[0].header
+        # Read the header
+        head = hdulist[0].header
 
-    # Read in the data from the header
-    ff.nrows = head['NROWS']
-    ff.ncols = head['NCOLS']
-    ff.nbits = head['NBITS']
-    ff.nframes = head['NFRAMES']
-    ff.first = head['FIRST']
-    ff.camno = head['CAMNO']
-    ff.fps = head['FPS']
+        # Read in the data from the header
+        ff.nrows = head['NROWS']
+        ff.ncols = head['NCOLS']
+        ff.nbits = head['NBITS']
+        ff.nframes = head['NFRAMES']
+        ff.first = head['FIRST']
+        ff.camno = head['CAMNO']
+        ff.fps = head['FPS']
 
-    # Check for the DATE-OBS field and read datetime from filename it if it doesn't exist
-    if 'DATE-OBS' in head:
-        ff.starttime = head['DATE-OBS']
-    else:
-        ff.starttime = filenameToDatetimeStr(filename, iso8601=True)
+        # Check for the DATE-OBS field and read datetime from filename it if it doesn't exist
+        if 'DATE-OBS' in head:
+            ff.starttime = head['DATE-OBS']
+        else:
+            ff.starttime = filenameToDatetimeStr(filename, iso8601=True)
 
-    # Read in the image data
-    ff.maxpixel = hdulist[1].data
-    ff.maxframe = hdulist[2].data
-    ff.avepixel = hdulist[3].data
-    ff.stdpixel = hdulist[4].data
+        # Read in the image data, copying it so it remains valid (and detached from the
+        # memmap) after the file is closed
+        ff.maxpixel = hdulist[1].data.copy()
+        ff.maxframe = hdulist[2].data.copy()
+        ff.avepixel = hdulist[3].data.copy()
+        ff.stdpixel = hdulist[4].data.copy()
 
     if array:
         ff.array = np.dstack([ff.maxpixel, ff.maxframe, ff.avepixel, ff.stdpixel])
 
         ff.array = np.swapaxes(ff.array, 0, 1)
         ff.array = np.swapaxes(ff.array, 0, 2)
-
-    # CLose the FITS file
-    hdulist.close()
 
     return ff
 
@@ -205,6 +208,12 @@ if __name__ == "__main__":
 
     ff.ncols = wid
     ff.nrows = ht
+    ff.nbits = 8
+    ff.nframes = 256
+    ff.first = 0
+    ff.camno = 1
+    ff.fps = 25.0
+    ff.starttime = "2022-02-26T18:17:11.737000"
 
     # ff.maxpixel = np.zeros((ht, wid), dtype=np.uint8)
     # ff.avepixel = np.zeros((ht, wid), dtype=np.uint8) + 10


### PR DESCRIPTION
## Problem

Closes #406. Reading many FF FITS files in sequence and **retaining** their image arrays (e.g. plotting every FF that contains a given star) leaks one file descriptor per file, eventually hitting `OSError: Too many open files`. Matches the techsupport thread reports.

Root cause in `FFfits.read()`:
1. Opens a raw file handle and passes it to `fits.open(fid, memmap=True)`. astropy does **not** close a file object it didn't open.
2. Returns `ff.maxpixel = hdulist[1].data` (and friends) without copying — these are memmap-backed views. A retained view keeps its `HDUList` (and the fd) alive past `hdulist.close()`.
3. No `try/finally`, so any exception leaks both the handle and the HDUList.

`FFbin.read()` had the same fd-leak class — its raw `open()` was never closed (no context manager).

## Verification

On 505 real FITS (`FR0004`), retaining `ff.maxpixel` across reads:

| | before | after |
|---|---|---|
| open fds (retain loop) | 5 → **510** (linear) | **flat at 5** |

Default soft `ulimit -n` on RPi/typical installs is 1024 → crash at ~1000 retained FFs.

## Fix

`FFfits.read()`:
- Pass the **path** to `fits.open()` (astropy owns and closes the file).
- Wrap in `with fits.open(...) as hdulist:` (exception-safe close).
- `.copy()` each image array inside the block so it stays valid and detached from the memmap after close.

`FFbin.read()`: wrap the read in `with open(...) as fid:`, mirroring the existing `write()`.

No caller mutates the returned arrays in place (verified across 22 call sites), so the copy is safe and the signature / return shape are unchanged. `EventMonitor`'s existing `memmap=False` workaround stays correct.

Also fixes the `FFfits` `__main__` self-test, which crashed in `write()` because the test `FFStruct` never set `starttime`.

Round-trip (write→read) and `array=True` paths verified correct against raw astropy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)