### PR TITLE
Fix plotFieldsums reusing stale intensities on corrupt FS file (#891)

### DIFF
--- a/Utils/PlotFieldsums.py
+++ b/Utils/PlotFieldsums.py
@@ -62,6 +62,12 @@ def plotFieldsums(dir_path, config):
 
             except TypeError:
                 print('File {:s} is corrupted!'.format(file_name))
+                continue
+
+            # Skip empty/zero-length arrays (np.max on empty raises ValueError)
+            if len(intensity_array) == 0:
+                print('File {:s} has no entries, skipping!'.format(file_name))
+                continue
 
             # Extract the date and time from the FS file
             dt = filenameToDatetime(file_name)


### PR DESCRIPTION
## Problem

Fixes #891.

In `Utils/PlotFieldsums.py`, `plotFieldsums()` wraps each `FS_*_fieldsum.bin` read in `try/except TypeError` (corrupt/truncated files make `readFieldIntensitiesBin` raise `TypeError` from `int(np.fromfile(...))` on an empty read). But the `except` only **printed** a warning and let execution fall through, so:

- `np.max`/`np.mean` ran on the **previous good file's** `intensity_array` (stale data),
- those stale values were appended alongside the **corrupt file's** datetime, desyncing `time_data` / `intensity_data_peak` / `intensity_data_avg`,
- if the *first* FS file was corrupt, `intensity_array` was unbound → `NameError`.

## Fix

- `continue` in the `except TypeError` block so corrupt files are skipped cleanly (core fix).
- Added a guard for empty arrays (`n_entries == 0`), which would otherwise crash `np.max` with `ValueError`.

## Verification

- Ran `python -m Utils.PlotFieldsums <night_dir>` on a real FS dir → `_fieldsums.png` produced.
- Corrupt-file test: truncate one `FS_*_fieldsum.bin`, rerun → "File ... is corrupted!" printed, plot still generated, no stale duplicate point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)