### PR TITLE
Allow specifying kernel UDP buffer size

### DIFF
--- a/.config
+++ b/.config
@@ -104,6 +104,12 @@ device: rtsp://192.168.42.10:554/user=admin&password=&channel=1&stream=0.sdp
 ; provides more stable connectivity, but TCP has a longer track record.
 protocol: tcp
 
+; Per-socket UDP receive buffer size in bytes for the gst backend (rtspsrc).
+; Larger values give RTP bursts more room and prevent UDP RcvbufErrors ->
+; dropped frames. Requires net.core.rmem_max >= this value (run
+; Scripts/UpdateBuffers.sh) or the kernel clamps it back. Default is 16 MB.
+udp_buffer_size: 16777216
+
 ; Media Backend: options are gst, cv2, or v4l2.
 ; 'gst':    (default - preferred) GStreamer Standalone. Bypass OpenCV, and
 ;           provides the highest timestamps accuracy.

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1099,8 +1099,8 @@ class BufferedCapture(Process):
         # Define the source up to the point where we want to branch off
         source_to_tee = (
             # udp-buffer-size: per-socket RTP receive buffer. rtspsrc defaults to
-            # 512KB, which can overflows during bitrate bursts and shows
-            # up as net UDP RcvbufErrors -> dropped frames. The configured size
+            # 512KB, which can overflow during bitrate bursts and shows
+            # up as UDP RcvbufErrors -> dropped frames. The configured size
             # (default 16MB) gives bursts room.
             # NOTE: net.core.rmem_max must be >= this value (see Scripts/UpdateBuffers.sh)
             # or the kernel clamps it back. Only affects the UDP transport path.

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1098,7 +1098,12 @@ class BufferedCapture(Process):
 
         # Define the source up to the point where we want to branch off
         source_to_tee = (
-            "rtspsrc name=src buffer-mode=1 {:s} "
+            # udp-buffer-size: per-socket RTP receive buffer. rtspsrc defaults to
+            # 512KB, which can overflows during bitrate bursts and shows
+            # up as net UDP RcvbufErrors -> dropped frames. 16MB gives bursts room.
+            # NOTE: net.core.rmem_max must be >= this value (see Scripts/UpdateBuffers.sh)
+            # or the kernel clamps it back. Only affects the UDP transport path.
+            "rtspsrc name=src buffer-mode=1 udp-buffer-size=16777216 {:s} "
             "location=\"{:s}\" ! "
             "rtph264depay ! h264parse ! tee name=t"
             ).format(protocol_str, device_url)

--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1100,13 +1100,14 @@ class BufferedCapture(Process):
         source_to_tee = (
             # udp-buffer-size: per-socket RTP receive buffer. rtspsrc defaults to
             # 512KB, which can overflows during bitrate bursts and shows
-            # up as net UDP RcvbufErrors -> dropped frames. 16MB gives bursts room.
+            # up as net UDP RcvbufErrors -> dropped frames. The configured size
+            # (default 16MB) gives bursts room.
             # NOTE: net.core.rmem_max must be >= this value (see Scripts/UpdateBuffers.sh)
             # or the kernel clamps it back. Only affects the UDP transport path.
-            "rtspsrc name=src buffer-mode=1 udp-buffer-size=16777216 {:s} "
+            "rtspsrc name=src buffer-mode=1 udp-buffer-size={:d} {:s} "
             "location=\"{:s}\" ! "
             "rtph264depay ! h264parse ! tee name=t"
-            ).format(protocol_str, device_url)
+            ).format(self.config.udp_buffer_size, protocol_str, device_url)
 
         # Branch for processing
         processing_branch = (

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -289,6 +289,12 @@ class Config:
         # Transport Layer Protocol: tcp or udp
         self.protocol = "tcp"
 
+        # Per-socket UDP receive buffer size in bytes for the rtspsrc element (gst
+        # backend). Larger values give RTP bursts more room and prevent UDP
+        # RcvbufErrors -> dropped frames. Requires net.core.rmem_max >= this value
+        # (see Scripts/UpdateBuffers.sh) or the kernel clamps it back.
+        self.udp_buffer_size = 16777216
+
         # Media backend to use for capture. Options are gst, cv2, or v4l2
         self.media_backend = "gst"
 
@@ -1152,7 +1158,10 @@ def parseCapture(config, parser):
 
     if parser.has_option(section, "protocol"):
         config.protocol = parser.get(section, "protocol")
-    
+
+    if parser.has_option(section, "udp_buffer_size"):
+        config.udp_buffer_size = parser.getint(section, "udp_buffer_size")
+
     if parser.has_option(section, "media_backend"):
         config.media_backend = parser.get(section, "media_backend")
 

--- a/Scripts/UpdateBuffers.sh
+++ b/Scripts/UpdateBuffers.sh
@@ -24,8 +24,8 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 # Configuration
-RECOMMENDED_SIZE=1048576  # 1MB in bytes
-MIN_RECOMMENDED=524288    # 512KB in bytes (GStreamer requested size)
+RECOMMENDED_SIZE=16777216  # 16MB in bytes - must be >= rtspsrc udp-buffer-size in BufferedCapture.py
+MIN_RECOMMENDED=1048576    # 1MB in bytes (old default; below this UDP RtspSrc bursts overflow)
 
 # Function to convert bytes to human readable format
 human_readable() {

--- a/Scripts/UpdateBuffers.sh
+++ b/Scripts/UpdateBuffers.sh
@@ -6,12 +6,12 @@
 # Usage: sudo ./Scripts/UpdateBuffers.sh
 #
 # This script checks and optionally updates UDP buffer sizes to handle
-# GStreamer's UDP source requirements (512KB per camera). Default Linux
-# settings are often too small, causing GStreamer warnings.
+# GStreamer's UDP source requirements (rtspsrc udp-buffer-size, default 16MB).
+# Default Linux settings are often too small, causing dropped frames.
 #
 # The script will:
 # - Show current buffer sizes
-# - Warn if below recommended values (512KB min, 1MB recommended)
+# - Warn if below recommended values (1MB min, 16MB recommended)
 # - Create backup of original settings
 # - Update settings if confirmed
 # - Show before/after comparison
@@ -51,11 +51,11 @@ show_settings() {
     # Check if buffers are below recommended size
     local update_needed=false
     if [ $current_rmem_max -lt $MIN_RECOMMENDED ] || [ $current_wmem_max -lt $MIN_RECOMMENDED ]; then
-        echo -e "WARNING: Current buffer sizes are below the minimum recommended size (512KB)"
+        echo -e "WARNING: Current buffer sizes are below the minimum recommended size ($(human_readable $MIN_RECOMMENDED))"
         echo "This may cause issues with GStreamer UDP buffer allocation."
         update_needed=true
     elif [ $current_rmem_max -lt $RECOMMENDED_SIZE ] || [ $current_wmem_max -lt $RECOMMENDED_SIZE ]; then
-        echo -e "NOTE: Current buffer sizes are below the recommended size (1MB)"
+        echo -e "NOTE: Current buffer sizes are below the recommended size ($(human_readable $RECOMMENDED_SIZE))"
         echo "Increasing them would provide more headroom for UDP operations."
         update_needed=true
     fi
@@ -97,7 +97,7 @@ echo "Creating sysctl drop-in file: $SYSCTL_DROP_IN"
 cat > "$SYSCTL_DROP_IN" << EOF
 # RMS UDP Buffer Configuration
 # Created by UpdateBuffers.sh on $(date)
-# Required for GStreamer UDP streaming (512KB min per camera)
+# Required for GStreamer UDP streaming (rtspsrc udp-buffer-size, default 16MB)
 
 net.core.rmem_max=$RECOMMENDED_SIZE
 net.core.wmem_max=$RECOMMENDED_SIZE


### PR DESCRIPTION
Many stations have been observed to silently drop UDP payload during bursts due to kernel UDP buffers being too small. This PR increases the default size from 1 MB to 16 MB and makes it configurable.