### PR TITLE
Skip media_backend recording when night dir does not exist yet

### DIFF
--- a/RMS/BufferedCapture.py
+++ b/RMS/BufferedCapture.py
@@ -1479,7 +1479,7 @@ class BufferedCapture(Process):
                     # Set the video device type
                     self.video_device_type = "gst"
 
-                    if self.night_data_dir is not None:
+                    if self.night_data_dir is not None and os.path.isdir(self.night_data_dir):
                         try:
                             addObsParam(getObservationSummaryDict(self.night_data_dir), "media_backend", "gst")
                         except Exception as e:
@@ -1504,7 +1504,7 @@ class BufferedCapture(Process):
                     # Note: video_device_type stays "cv2" - downstream logic (isOpened check,
                     # first-frame skipping) treats v4l2 as an OpenCV device. Only the recorded
                     # media_backend label is "v4l2".
-                    if self.night_data_dir is not None:
+                    if self.night_data_dir is not None and os.path.isdir(self.night_data_dir):
                         try:
                             addObsParam(getObservationSummaryDict(self.night_data_dir), "media_backend", "v4l2")
                         except Exception as e:
@@ -1523,7 +1523,7 @@ class BufferedCapture(Process):
                 log.info("Initialize OpenCV Device.")
                 self.device = cv2.VideoCapture(self.config.deviceID)
 
-                if self.night_data_dir is not None:
+                if self.night_data_dir is not None and os.path.isdir(self.night_data_dir):
                     try:
                         addObsParam(getObservationSummaryDict(self.night_data_dir), "media_backend", "cv2")
                     except Exception as e:

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1572,6 +1572,10 @@ def saveObservationSummaryDict(d, night_dir=None):
         log.warning("saveObservationSummaryDict: no night_data_dir available; skipping save")
         return
 
+    if not os.path.isdir(night_dir):
+        log.warning("saveObservationSummaryDict: night_data_dir does not exist, skipping save: {}".format(night_dir))
+        return
+
     observation_summary_json_path = os.path.join(night_dir, getRMSStyleFileName(night_dir, OBSERVATION_SUMMARY_WORKING_NAME_JSON))
     lock_path = observation_summary_json_path + ".lock"
 


### PR DESCRIPTION
In daytime continuous-capture mode the night data dir is not created on disk, so recording media_backend raised FileNotFoundError on the lock file. Guard the recording calls and make saveObservationSummaryDict skip gracefully when the directory is absent.