### PR TITLE
Fix empty-array truthiness in getAllPoints

### DIFF
--- a/RMS/Routines/Grouping3Dcy.pyx
+++ b/RMS/Routines/Grouping3Dcy.pyx
@@ -195,7 +195,7 @@ def getAllPoints(np.ndarray[UINT16_TYPE_t, ndim=2] point_list, x1, y1, z1, x2, y
     point1_index = np.where(np.all(point_list == np.array((x1, y1, z1)), axis=1))[0]
 
     # Check if the first point exists, if not start from the point closes to the given point
-    if not point1_index:
+    if point1_index.size == 0:
 
         best_distance = np.inf
 


### PR DESCRIPTION
Addresses #899.

`getAllPoints` in `RMS/Routines/Grouping3Dcy.pyx` does:

```python
point1_index = np.where(np.all(point_list == np.array((x1, y1, z1)), axis=1))[0]
if not point1_index:
```

`np.where(...)[0]` returns a NumPy array. `if not point1_index` only works when that array has exactly one element. On Python 3.13 / modern NumPy, the empty-array case (first point not found in the cloud) raises `ValueError: The truth value of an empty array is ambiguous` instead of falling through to the nearest-point fallback — the traceback reported in #899.

Fix: use the explicit emptiness test `point1_index.size == 0`.

Note: this is a Cython file, so the extension must be rebuilt for the change to take effect (RMS_Update handles this).