### PR TITLE
Fix ephem polar night/day crashes for high-latitude stations

### DIFF
--- a/RMS/CaptureDuration.py
+++ b/RMS/CaptureDuration.py
@@ -88,13 +88,17 @@ def captureDuration(lat, lon, elevation, current_time=None, continuous_capture=N
         duration = 3600*max_hours
         return start_time, duration
     
-    # If the day last more than 24, then the start of the capture is at the next sunset (which may be in days)
+    # If the day lasts more than 24 hours (polar day), the next sunset may be days or even
+    # months away. The start of the capture is then at the next sunset.
     except ephem.AlwaysUpError:
 
-        # Search in 1 hour increments until the next sunset is found (search for a maximum of 6 months)
+        # Search in 1 hour increments until the next sunset is found. The window covers ~13 months
+        # so that a full polar day at the exact poles (where day/night each last ~6 months) is
+        # always spanned.
         print("Searching for the next sunset...")
-        for i in range(0, 6*30*24):
-            
+        next_set = None
+        for i in range(0, 13*30*24):
+
             # Increment the time by 1 hour
             o.date = o.date.datetime() + datetime.timedelta(hours=1)
 
@@ -103,14 +107,36 @@ def captureDuration(lat, lon, elevation, current_time=None, continuous_capture=N
                 break
 
             except ephem.AlwaysUpError:
-                print("Still day at ", o.date.datetime(), "...")
-                pass
+                # Still polar day, keep searching forwards
+                continue
 
-        # Compute the next sunrise
-        next_rise = o.next_rising(s, start=next_set).datetime()
+            except ephem.NeverUpError:
+                # The search stepped from polar day straight into polar night without pinning a
+                # discrete sunset (happens at the exact pole, where the crossing is instantaneous).
+                # Night has arrived, so capture immediately for the maximum allowed time.
+                return True, 3600*max_hours
+
+        # No sunset found within the search window: capture immediately for the maximum allowed
+        # time instead of crashing.
+        if next_set is None:
+            return True, 3600*max_hours
+
+        # Compute the next sunrise after that sunset. If no discrete sunrise can be pinned (polar
+        # transitions at extreme latitudes), fall back to the maximum allowed duration.
+        try:
+            next_rise = o.next_rising(s, start=next_set).datetime()
+        except (ephem.AlwaysUpError, ephem.NeverUpError):
+            return next_set, 3600*max_hours
 
         # Compute the total capture duration
         duration = (next_rise - next_set).total_seconds()
+
+        # At very high latitudes the first night after a polar day can be very long (up to ~6
+        # months at the exact pole). Cap it to the maximum allowed time, matching the polar-night
+        # (NeverUpError) branch above.
+        max_duration = 3600*max_hours
+        if duration > max_duration:
+            duration = max_duration
 
         return next_set, duration
         

--- a/RMS/DeleteOldObservations.py
+++ b/RMS/DeleteOldObservations.py
@@ -811,8 +811,16 @@ def deleteOldObservations(data_dir, captured_dir, archived_dir, config, duration
         o.elevation = config.elevation
         sun = ephem.Sun()
 
-        sunrise = o.previous_rising(sun, start=ephem.now())
-        noon_time = o.next_transit(sun, start=sunrise).datetime()
+        try:
+            sunrise = o.previous_rising(sun, start=ephem.now())
+            noon_time = o.next_transit(sun, start=sunrise).datetime()
+
+        except (ephem.NeverUpError, ephem.AlwaysUpError):
+            # Polar night/day: the Sun never crosses the horizon, so there is no
+            # rising/transit. captureDuration() below handles polar conditions
+            # itself, so fall back to the current time as the reference point.
+            log.warning("Polar day/night: no Sun rising/transit; using current time for disk estimate")
+            noon_time = RmsDateTime.utcnow()
 
         # if ct.hour > 12:
         #     noon_time += datetime.timedelta(days=1)

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -329,12 +329,25 @@ def getObservationDurationContinuous(config, start_time):
 
     # Is this start time during night time capture hours
     s.compute()
-    while o.next_setting(s).datetime() < o.next_rising(s).datetime():
-        if DEBUG_PRINT:
-            print("{} is not at night time".format(start_time))
-        start_time +=datetime.timedelta(minutes=1)
-        o.date = start_time
-        s.compute()
+
+    # Bound the search so it can never spin (during polar night/day captureDuration
+    # never finds a concrete boundary), mirroring getObservationDurationNightTime.
+    max_advance_minutes = 24*60
+    advanced = 0
+    try:
+        while o.next_setting(s).datetime() < o.next_rising(s).datetime() and advanced < max_advance_minutes:
+            if DEBUG_PRINT:
+                print("{} is not at night time".format(start_time))
+            start_time += datetime.timedelta(minutes=1)
+            advanced += 1
+            o.date = start_time
+            s.compute()
+
+    except (ephem.AlwaysUpError, ephem.NeverUpError):
+        # Polar day/night: the Sun never sets/rises, so the start time cannot be
+        # refined. The duration block below falls back to duration=0.
+        log.warning("Polar day/night: no Sun setting/rising; cannot refine continuous-capture start time")
+
     if DEBUG_PRINT:
         print("Advanced time to {}".format(o.date))
 


### PR DESCRIPTION
## Problem

Station **AQ000A** (Antarctica) crashed on startup during polar night:

```
File ".../RMS/DeleteOldObservations.py", line 769, in deleteOldObservations
    sunrise = o.previous_rising(sun, start=ephem.now())
ephem.NeverUpError: 'Sun' is below the horizon at 2026/6/22 00:55:17
```

During **polar night** the Sun never crosses the horizon (`NeverUpError`) and during **polar day** it never sets (`AlwaysUpError`). Several `ephem` rise/set calls were unguarded, aborting capture. Most of the codebase already handles these conditions (`CaptureModeSwitcher`, `getObservationDurationNightTime`, `Flux`); this PR closes the remaining gaps.

## Changes

- **`RMS/DeleteOldObservations.py`** — guard the next-noon computation used for disk-space estimation (the reported crash). Falls back to current UTC time; `captureDuration()` downstream is already polar-safe. Catches only the two `ephem` exceptions.
- **`RMS/Formats/ObservationSummary.py`** (`getObservationDurationContinuous`) — guard the previously-unguarded sunset/sunrise `while`-loop and bound its iterations (`24*60`) so it cannot spin during polar conditions.
- **`RMS/CaptureDuration.py`** — harden the polar-day (`AlwaysUpError`) branch: also catch `NeverUpError` during the sunset search (the day→night transition is instantaneous at the exact pole), handle an exhausted search window, guard the subsequent sunrise lookup, cap duration to `max_hours` (was uncapped — could return ~6 months at the pole), and drop the per-hour debug `print` spam.

## Verification

`captureDuration()` exercised at both exact poles (±90), -89, Svalbard (78N), and mid-latitude (43N) for both solstices — all return sane `start`/`duration` without raising:

| location | condition | start | duration |
|---|---|---|---|
| -90 | polar night | True (now) | 23 h |
| -90 | polar day | True (now) | 23 h |
| +90 | polar night | True (now) | 23 h |
| +90 | polar day | True (now) | 23 h |
| -89 | polar day | next sunset (Apr) | 5.5 h |
| 78N | polar day | next sunset (Sep) | 1.8 h |
| 43N | normal | next sunset | 7.5 h |

The guarded `ObservationSummary` loop was confirmed to catch `NeverUpError`/`AlwaysUpError` at the poles and terminate normally at mid-latitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)