### PR TITLE
Schedule polar-day capture at the dark transition (follow-up to #902)

### DIFF
--- a/RMS/CaptureDuration.py
+++ b/RMS/CaptureDuration.py
@@ -113,8 +113,9 @@ def captureDuration(lat, lon, elevation, current_time=None, continuous_capture=N
             except ephem.NeverUpError:
                 # The search stepped from polar day straight into polar night without pinning a
                 # discrete sunset (happens at the exact pole, where the crossing is instantaneous).
-                # Night has arrived, so capture immediately for the maximum allowed time.
-                return True, 3600*max_hours
+                # o.date is now the start of the dark period, which may be months in the future, so
+                # schedule the capture to start then rather than immediately during polar day.
+                return o.date.datetime(), 3600*max_hours
 
         # No sunset found within the search window: capture immediately for the maximum allowed
         # time instead of crashing.


### PR DESCRIPTION
Follow-up to #902, addressing a Codex review note on the polar-day branch of `captureDuration()`.

## Problem

In the polar-day (`AlwaysUpError`) branch, the hourly sunset search can step from polar day straight into polar night without pinning a discrete sunset — the crossing is instantaneous at the exact pole. The `NeverUpError` handler returned `True`, which tells callers (`StartCapture`) to start recording **immediately**, scheduling a ~23 h capture in full daylight.

By the time that handler is reached, `o.date` has already been advanced forward to the start of the dark period (potentially months ahead).

## Fix

Return `o.date.datetime()` as a concrete future start time instead of `True`, matching the contract of the normal path (which returns the future `next_set`). Capture is then scheduled for when darkness actually begins.

## Verification

`captureDuration()` re-checked:

| location | condition | start | duration |
|---|---|---|---|
| -90 | polar day (Dec) | 2027-04-04 (dark transition) | 23 h |
| +90 | polar day (Jun) | 2026-10-08 (dark transition) | 23 h |
| -90 | polar night | True (immediate) | 23 h |
| -89 | polar day | next sunset (Apr) | 5.5 h |
| 43N | normal | next sunset | 7.5 h |

🤖 Generated with [Claude Code](https://claude.com/claude-code)