### PR TITLE
Add single-frame LM correction to SkyFit photometry plot

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -263,7 +263,7 @@ def photomLineMinimize(params, px_sum, radius, catalog_mags, fixed_vignetting, w
 
 
 
-def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None):
+def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_frames=None):
     """ Fit log10(S/N) = a*mag + b and return limiting magnitudes at given S/N targets.
 
         Physical basis: in the background-limited regime S/N is proportional to flux and
@@ -276,6 +276,11 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None):
     Keyword arguments:
         snr_targets: [tuple] S/N values at which to report the limiting magnitude.
         exclude_mask: [ndarray of bool] True = exclude star from the fit (e.g. saturated).
+        n_frames: [int] Number of frames stacked/averaged into the measurement image. If
+            given and > 1, a single-frame correction is reported: the measurement image
+            averages n_frames frames, so its background noise is ~sqrt(n_frames) lower and
+            the LM is correspondingly deeper than a single frame by
+             delta_lm = 2.5*log10(sqrt(n_frames)) mag. None by default (no correction).
 
     Return:
         [dict] or None if the fit cannot be performed. Keys:
@@ -283,6 +288,9 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None):
             'r2'                 : coefficient of determination
             'lm'                 : dict {snr_target: limiting_magnitude}
             'eqn_str'            : multi-line annotation string for the plot
+            'n_frames'           : the n_frames argument (None if not given)
+            'single_frame_delta' : single-frame LM correction in mag, or None
+            'single_frame_str'   : single-frame correction annotation line, or None
     """
 
     mags = np.array(mags, dtype=np.float64)
@@ -322,11 +330,27 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None):
     d = -b/a
     lm = {target: c*np.log10(target) + d for target in snr_targets}
 
-    eqn_str = "LM = {:.3f} log10(S/N) + {:.2f} (R2={:.2f})".format(c, d, r2)
+    # Single-frame correction: the measurement image averages n_frames frames, so its
+    # background noise is ~sqrt(n_frames) lower and the LM is deeper by 2.5*log10(sqrt(N)).
+    delta_lm = None
+    single_frame_str = None
+    if (n_frames is not None) and (n_frames > 1):
+        delta_lm = 2.5*np.log10(np.sqrt(n_frames))
+        single_frame_str = "1-frame ΔLM = +{:.2f} mag".format(delta_lm)
+
+    # Model equation line; include the stacking frame count when known
+    if n_frames is not None and n_frames > 1:
+        eqn_str = "LM = {:.3f} log10(S/N) + {:.2f} (R2={:.2f}, N={:d}fr)".format(c, d, r2, int(n_frames))
+    else:
+        eqn_str = "LM = {:.3f} log10(S/N) + {:.2f} (R2={:.2f})".format(c, d, r2)
     for target in snr_targets:
         eqn_str += "\nLM = {:.2f} mag @ S/N = {:g}".format(lm[target], target)
+    if single_frame_str is not None:
+        eqn_str += "\n" + single_frame_str
 
-    return {'slope': a, 'intercept': b, 'r2': r2, 'lm': lm, 'eqn_str': eqn_str}
+    return {'slope': a, 'intercept': b, 'r2': r2, 'lm': lm, 'eqn_str': eqn_str,
+            'n_frames': n_frames, 'single_frame_delta': delta_lm,
+            'single_frame_str': single_frame_str}
 
 
 

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -7425,9 +7425,15 @@ class PlateTool(QtWidgets.QMainWindow):
         # corrected) apparent magnitude. The predicted magnitude per star equals the catalog
         # magnitude minus the fit residual. Saturated stars are excluded (their flux is capped).
         predicted_mags = np.array(catalog_mags) - np.array(self.photom_fit_resids)
+
+        # Number of frames stacked into the measurement image (avepixel). For all input types
+        # this is the loaded FF / FFMimickInterface frame count; used to report the single-frame
+        # LM correction (single-image mode and dfn have nframes=1 -> no correction).
+        n_frames = getattr(getattr(self.img_handle, 'ff', None), 'nframes', None)
+
         self.limiting_mag_info = limitingMagnitude(
             predicted_mags, np.array(snr_list), snr_targets=(5, 10),
-            exclude_mask=np.array(saturation_list))
+            exclude_mask=np.array(saturation_list), n_frames=n_frames)
 
         # Update the values in the platepar tab in the GUI
         self.tab.param_manager.updatePlatepar()
@@ -7741,8 +7747,13 @@ class PlateTool(QtWidgets.QMainWindow):
                                     color=lm_colors.get(snr_target, 'm'),
                                     label="LM = {:.2f} mag @ S/N = {:g}".format(lm_mag, snr_target))
 
-                # Show the model equation so users can compute the LM for any S/N
-                ax_m.text(0.02, 0.03, self.limiting_mag_info['eqn_str'].split('\n')[0],
+                # Show the model equation so users can compute the LM for any S/N, plus the
+                # single-frame LM correction (when the measurement image stacks >1 frame)
+                annot = self.limiting_mag_info['eqn_str'].split('\n')[0]
+                sf = self.limiting_mag_info.get('single_frame_str')
+                if sf:
+                    annot += '\n' + sf
+                ax_m.text(0.02, 0.03, annot,
                             transform=ax_m.transAxes, fontsize=7, va='bottom', ha='left',
                             bbox=dict(boxstyle='round', fc='white', alpha=0.6, ec='none'))
 


### PR DESCRIPTION
## Context

In SkyFit, the limiting magnitude (LM) is fit from `log10(S/N) = a*mag + b` over paired stars measured on the **stacked/averaged image** (the avepixel), not a single sensor frame. The number of frames stacked varies by input type:

- `ff`: 256 (FF header `NFRAMES`)
- `video`: chunk size (default 256)
- `vid` (UWO): 128
- `images`: 64 (1 in single-image mode)
- `dfn`: 1

Because the avepixel averages N frames, its background noise is ~√N lower, so the displayed LM is ~`2.5*log10(sqrt(N))` mag deeper than a single frame achieves. Users reading the LM off the plot had no indication of this.

## Change

The correction (background-limited regime, S/N ∝ √N):

    ΔLM = 2.5*log10(sqrt(N))   (= 1.25*log10(N))
    LM_single_frame = LM_stack − ΔLM

- **`ApplyAstrometry.py:limitingMagnitude()`** — new optional `n_frames`. When `>1`: appends frame count to the equation line (`N=256fr`) and a `1-frame ΔLM = +X.XX mag` line; returns `n_frames`, `single_frame_delta`, `single_frame_str`. `None`/`1` → output unchanged (backward compatible; `CalibrationReport.py` caller unaffected).
- **`SkyFit2.py:photometry()`** — reads `N = img_handle.ff.nframes`, passes it to the fit, and renders the correction line under the equation annotation. Single-image mode and dfn have `nframes=1` → no correction.

Resulting annotation box:

```
LM = -2.50 log10(S/N) + 6.80 (R2=0.95, N=256fr)
1-frame ΔLM = +3.01 mag
```

The terminal "Limiting magnitude fit:" printout gets the line for free via `eqn_str`.

## Verification

- Numeric check: N=256 → +3.01, N=128 → +2.63, N=64 → +2.26 (matches `2.5*log10(sqrt(N))`).
- N=None/1 → identical to prior output.
- Both files byte-compile.
- Pending: live GUI check on an FF dataset (open photometry plot, confirm annotation + terminal printout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)