### PR TITLE
Fix overstated single-frame LM correction for FFMimick inputs

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -263,7 +263,8 @@ def photomLineMinimize(params, px_sum, radius, catalog_mags, fixed_vignetting, w
 
 
 
-def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_frames=None):
+def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_frames=None,
+                      n_eff=None):
     """ Fit log10(S/N) = a*mag + b and return limiting magnitudes at given S/N targets.
 
         Physical basis: in the background-limited regime S/N is proportional to flux and
@@ -276,11 +277,15 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
     Keyword arguments:
         snr_targets: [tuple] S/N values at which to report the limiting magnitude.
         exclude_mask: [ndarray of bool] True = exclude star from the fit (e.g. saturated).
-        n_frames: [int] Number of frames stacked/averaged into the measurement image. If
-            given and > 1, a single-frame correction is reported: the measurement image
-            averages n_frames frames, so its background noise is ~sqrt(n_frames) lower and
-            the LM is correspondingly deeper than a single frame by
-             delta_lm = 2.5*log10(sqrt(n_frames)) mag. None by default (no correction).
+        n_frames: [int] Number of frames stacked into the measurement image (the displayed
+            stack depth, shown as "N=...fr"). If given and > 1, a single-frame correction is
+            reported: the stack's background noise is lower than a single frame, so the LM is
+            correspondingly deeper. None by default (no correction).
+        n_eff: [float] Noise-equivalent frame count used to size the correction:
+            delta_lm = 2.5*log10(sqrt(n_eff)). Defaults to n_frames (true mean stack,
+            noise ~sqrt(n_frames)). Pass a smaller value when the stack is noisier per frame
+            than an ideal mean - e.g. a median over m samples has the noise of a mean of
+            m*2/pi frames, so callers pass n_eff = m*2/pi.
 
     Return:
         [dict] or None if the fit cannot be performed. Keys:
@@ -289,6 +294,7 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
             'lm'                 : dict {snr_target: limiting_magnitude}
             'eqn_str'            : multi-line annotation string for the plot
             'n_frames'           : the n_frames argument (None if not given)
+            'n_eff'              : the noise-equivalent frame count used (None if not given)
             'single_frame_delta' : single-frame LM correction in mag, or None
             'single_frame_str'   : single-frame correction annotation line, or None
     """
@@ -330,12 +336,15 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
     d = -b/a
     lm = {target: c*np.log10(target) + d for target in snr_targets}
 
-    # Single-frame correction: the measurement image averages n_frames frames, so its
-    # background noise is ~sqrt(n_frames) lower and the LM is deeper by 2.5*log10(sqrt(N)).
+    # Single-frame correction: the measurement image stacks n_frames frames, so its
+    # background noise is lower and the LM is deeper than a single frame by
+    # 2.5*log10(sqrt(n_eff)), where n_eff is the noise-equivalent frame count.
     delta_lm = None
     single_frame_str = None
     if (n_frames is not None) and (n_frames > 1):
-        delta_lm = 2.5*np.log10(np.sqrt(n_frames))
+        if n_eff is None:
+            n_eff = n_frames
+        delta_lm = 2.5*np.log10(np.sqrt(n_eff))
         single_frame_str = "1-frame ΔLM = +{:.2f} mag".format(delta_lm)
 
     # Model equation line; include the stacking frame count when known
@@ -349,7 +358,7 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
         eqn_str += "\n" + single_frame_str
 
     return {'slope': a, 'intercept': b, 'r2': r2, 'lm': lm, 'eqn_str': eqn_str,
-            'n_frames': n_frames, 'single_frame_delta': delta_lm,
+            'n_frames': n_frames, 'n_eff': n_eff, 'single_frame_delta': delta_lm,
             'single_frame_str': single_frame_str}
 
 

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -7426,14 +7426,25 @@ class PlateTool(QtWidgets.QMainWindow):
         # magnitude minus the fit residual. Saturated stars are excluded (their flux is capped).
         predicted_mags = np.array(catalog_mags) - np.array(self.photom_fit_resids)
 
-        # Number of frames stacked into the measurement image (avepixel). For all input types
-        # this is the loaded FF / FFMimickInterface frame count; used to report the single-frame
-        # LM correction (single-image mode and dfn have nframes=1 -> no correction).
-        n_frames = getattr(getattr(self.img_handle, 'ff', None), 'nframes', None)
+        # Number of frames stacked into the measurement image (avepixel), used to report the
+        # single-frame LM correction. For real FF files img_handle.ff is the on-disk FFStruct
+        # whose avepixel is a true mean over all nframes (noise ~ sqrt(nframes)). For all other
+        # inputs it is an FFMimickInterface whose avepixel is a *median* over only
+        # min(nframes, res_size) reservoir samples, so the displayed count is capped at the
+        # reservoir size and the noise-equivalent count carries the median penalty: the noise of
+        # a median over m samples equals that of a mean of m*2/pi frames.
+        ff = getattr(self.img_handle, 'ff', None)
+        n_total = getattr(ff, 'nframes', None)
+        res_size = getattr(ff, 'res_size', None)   # only FFMimickInterface has this
+        n_frames = n_total
+        n_eff = n_total
+        if (n_total is not None) and res_size:
+            n_frames = min(n_total, res_size)
+            n_eff = n_frames*2.0/np.pi
 
         self.limiting_mag_info = limitingMagnitude(
             predicted_mags, np.array(snr_list), snr_targets=(5, 10),
-            exclude_mask=np.array(saturation_list), n_frames=n_frames)
+            exclude_mask=np.array(saturation_list), n_frames=n_frames, n_eff=n_eff)
 
         # Update the values in the platepar tab in the GUI
         self.tab.param_manager.updatePlatepar()


### PR DESCRIPTION
Addresses the Codex P2 review comment on the single-frame LM correction.

## Problem

The correction uses `n_frames = img_handle.ff.nframes` as the stack depth N. For **video / UWO `.vid` / image-sequence / dfn** inputs, `img_handle.ff` is an `FFMimickInterface` whose `avepixel` is built from `np.median` of only `min(nframes, res_size)` reservoir samples (`res_size = config.background_reservoir_size`, default **64**) — not a mean over the full chunk. So a default 256-frame video chunk reported `N=256` / ΔLM=+3.01 while the measurement image actually used ≤64 samples.

**FF files are unaffected**: `img_handle.ff` is the real on-disk `FFStruct`; its `avepixel` is a true mean over all 256 frames and it has no `res_size`. `N=256` / +3.01 is correct there.

## Fix

`Utils/SkyFit2.py` `photometry()`: when the handle exposes `res_size` (FFMimick only), cap the displayed count at `res_size` and pass a **noise-equivalent** count that also carries the median penalty (the noise of a median over `m` samples equals a mean of `m·2/π` frames):

```python
n_frames = min(nframes, res_size)
n_eff    = n_frames*2.0/np.pi
```

`RMS/Astrometry/ApplyAstrometry.py` `limitingMagnitude()`: new `n_eff` kwarg (defaults to `n_frames`). The label `N={}fr` uses `n_frames`; ΔLM uses `n_eff`. The `CalibrationReport.py` caller passes neither → output unchanged.

## Resulting ΔLM
- FF (single file): `N=256fr`, **+3.01** mag (unchanged).
- video / `.vid` / images (chunk capped to 64): `N=64fr`, **+2.01** mag.
- single-image mode / dfn (`nframes=1`): no correction.

## Verification
- `py_compile` clean on both files.
- Numeric: `limitingMagnitude(n_frames=256)` → +3.01; `(n_frames=64, n_eff=64*2/π)` → +2.01; no args → unchanged.
- Pending: live GUI check on a video/FF dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)