### PR TITLE
Harden photometry SNR and limiting-magnitude reporting

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -337,11 +337,14 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
 
     # Fit a line log10(S/N) = a*mag + b, with the covariance of (a, b) when enough points
     # remain (np.polyfit needs len > order + 2, i.e. >= 4 points, to scale the covariance).
+    # np.polyfit applies w to the *unsquared* residual (it minimises sum((w*resid)**2)), so to
+    # make the objective weight equal w_fit = min(S/N, 10) we pass sqrt(w_fit), not w_fit.
+    w_poly = np.sqrt(w_fit)
     cov = None
     if mags_fit.size >= 4:
-        (a, b), cov = np.polyfit(mags_fit, log_snr, 1, w=w_fit, cov=True)
+        (a, b), cov = np.polyfit(mags_fit, log_snr, 1, w=w_poly, cov=True)
     else:
-        a, b = np.polyfit(mags_fit, log_snr, 1, w=w_fit)
+        a, b = np.polyfit(mags_fit, log_snr, 1, w=w_poly)
 
     # A non-negative slope is unphysical (fainter stars must have lower S/N) and makes the
     # limiting magnitude inversion meaningless

--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -264,7 +264,7 @@ def photomLineMinimize(params, px_sum, radius, catalog_mags, fixed_vignetting, w
 
 
 def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_frames=None,
-                      n_eff=None):
+                      n_eff=None, weights=None):
     """ Fit log10(S/N) = a*mag + b and return limiting magnitudes at given S/N targets.
 
         Physical basis: in the background-limited regime S/N is proportional to flux and
@@ -286,12 +286,20 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
             noise ~sqrt(n_frames)). Pass a smaller value when the stack is noisier per frame
             than an ideal mean - e.g. a median over m samples has the noise of a mean of
             m*2/pi frames, so callers pass n_eff = m*2/pi.
+        weights: [ndarray] Per-star fit weights. None by default, in which case the fit is
+            weighted by min(S/N, 10) so faint near-limit stars (noisy log10(S/N), high
+            leverage at the faint end) do not dominate the slope - consistent with the
+            SNR-weighted photometry fit.
 
     Return:
         [dict] or None if the fit cannot be performed. Keys:
             'slope', 'intercept' : fit coefficients a, b (log10(S/N) = a*mag + b)
             'r2'                 : coefficient of determination
             'lm'                 : dict {snr_target: limiting_magnitude}
+            'lm_err'             : dict {snr_target: 1-sigma LM uncertainty} (None if the fit
+                                   has too few points for a covariance estimate)
+            'lm_extrapolated'    : dict {snr_target: bool} True if the target S/N lies outside
+                                   the measured S/N range (the LM is an extrapolation)
             'eqn_str'            : multi-line annotation string for the plot
             'n_frames'           : the n_frames argument (None if not given)
             'n_eff'              : the noise-equivalent frame count used (None if not given)
@@ -316,18 +324,35 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
     mags_fit = mags[mask]
     log_snr = np.log10(snr_arr[mask])
 
-    # Fit a line: log10(S/N) = a*mag + b
-    a, b = np.polyfit(mags_fit, log_snr, 1)
+    # Fit weights: down-weight faint, low-S/N stars near the limit (noisy log10(S/N) and high
+    # leverage at the faint end). Default to min(S/N, 10), matching the photometry fit.
+    if weights is None:
+        w_fit = np.clip(snr_arr[mask], 0, 10)
+    else:
+        w_fit = np.array(weights, dtype=np.float64)[mask]
+
+    # Guard against all-zero weights (fall back to an unweighted fit)
+    if not np.any(w_fit > 0):
+        w_fit = np.ones_like(mags_fit)
+
+    # Fit a line log10(S/N) = a*mag + b, with the covariance of (a, b) when enough points
+    # remain (np.polyfit needs len > order + 2, i.e. >= 4 points, to scale the covariance).
+    cov = None
+    if mags_fit.size >= 4:
+        (a, b), cov = np.polyfit(mags_fit, log_snr, 1, w=w_fit, cov=True)
+    else:
+        a, b = np.polyfit(mags_fit, log_snr, 1, w=w_fit)
 
     # A non-negative slope is unphysical (fainter stars must have lower S/N) and makes the
     # limiting magnitude inversion meaningless
     if a >= 0:
         return None
 
-    # Coefficient of determination
+    # Weighted coefficient of determination
     log_snr_pred = a*mags_fit + b
-    ss_res = np.sum((log_snr - log_snr_pred)**2)
-    ss_tot = np.sum((log_snr - np.mean(log_snr))**2)
+    w_mean = np.sum(w_fit*log_snr)/np.sum(w_fit)
+    ss_res = np.sum(w_fit*(log_snr - log_snr_pred)**2)
+    ss_tot = np.sum(w_fit*(log_snr - w_mean)**2)
     r2 = 1.0 - ss_res/ss_tot if ss_tot > 0 else 0.0
 
     # Invert the model so the limiting magnitude is expressed directly as a function of S/N:
@@ -335,6 +360,24 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
     c = 1.0/a
     d = -b/a
     lm = {target: c*np.log10(target) + d for target in snr_targets}
+
+    # Per-target LM uncertainty by propagating the (a, b) covariance through LM = (L - b)/a,
+    # where L = log10(target):  d(LM)/da = -LM/a,  d(LM)/db = -1/a.
+    lm_err = {target: None for target in snr_targets}
+    if cov is not None:
+        var_a, var_b, cov_ab = cov[0, 0], cov[1, 1], cov[0, 1]
+        for target in snr_targets:
+            dmag_da = -lm[target]/a
+            dmag_db = -1.0/a
+            var_mag = (dmag_da**2)*var_a + (dmag_db**2)*var_b + 2*dmag_da*dmag_db*cov_ab
+            lm_err[target] = float(np.sqrt(var_mag)) if var_mag > 0 else 0.0
+
+    # Flag targets whose S/N lies outside the measured S/N range: the LM there is an
+    # extrapolation beyond the data and should be read with caution.
+    log_snr_min, log_snr_max = np.min(log_snr), np.max(log_snr)
+    lm_extrapolated = {target: bool((np.log10(target) < log_snr_min)
+                                    or (np.log10(target) > log_snr_max))
+                       for target in snr_targets}
 
     # Single-frame correction: the measurement image stacks n_frames frames, so its
     # background noise is lower and the LM is deeper than a single frame by
@@ -353,11 +396,18 @@ def limitingMagnitude(mags, snr_arr, snr_targets=(5, 10), exclude_mask=None, n_f
     else:
         eqn_str = "LM = {:.3f} log10(S/N) + {:.2f} (R2={:.2f})".format(c, d, r2)
     for target in snr_targets:
-        eqn_str += "\nLM = {:.2f} mag @ S/N = {:g}".format(lm[target], target)
+        line = "\nLM = {:.2f}".format(lm[target])
+        if lm_err[target] is not None:
+            line += " ± {:.2f}".format(lm_err[target])
+        line += " mag @ S/N = {:g}".format(target)
+        if lm_extrapolated[target]:
+            line += " (extrap)"
+        eqn_str += line
     if single_frame_str is not None:
         eqn_str += "\n" + single_frame_str
 
-    return {'slope': a, 'intercept': b, 'r2': r2, 'lm': lm, 'eqn_str': eqn_str,
+    return {'slope': a, 'intercept': b, 'r2': r2, 'lm': lm, 'lm_err': lm_err,
+            'lm_extrapolated': lm_extrapolated, 'eqn_str': eqn_str,
             'n_frames': n_frames, 'n_eff': n_eff, 'single_frame_delta': delta_lm,
             'single_frame_str': single_frame_str}
 

--- a/RMS/Routines/DynamicFTPCompressionCy.pyx
+++ b/RMS/Routines/DynamicFTPCompressionCy.pyx
@@ -27,7 +27,9 @@ cdef class FFMimickInterface:
     
     # Stored frames for Reservoir Sampling (to estimate robust background)
     cdef np.ndarray sample_buf
-    cdef int res_size
+    # Public so consumers (e.g. SkyFit photometry) can read the reservoir size that bounds
+    # how many frames actually contribute to the avepixel median.
+    cdef public int res_size
     
     # Public output arrays (matching your original interface types)
     cdef public np.ndarray maxpixel, avepixel, stdpixel

--- a/RMS/Routines/Image.py
+++ b/RMS/Routines/Image.py
@@ -1101,6 +1101,49 @@ def thickLine(img_h, img_w, x_cent, y_cent, length, rotation, radius):
     return photom_mask
 
 
+def sigmaClippedStd(values, sigma=3.0, max_iter=5):
+    """ Robust standard deviation via iterative sigma clipping.
+
+        The plain np.std of a background annulus is inflated by neighbouring stars, cosmic
+        rays or hot pixels that leak into the annulus, which corrupts the SNR. Iteratively
+        rejecting points more than `sigma` standard deviations from the median yields a
+        background noise estimate resistant to such outliers.
+
+    Arguments:
+        values: [ndarray] Background pixel values (any shape; flattened internally).
+
+    Keyword arguments:
+        sigma: [float] Clipping threshold in standard deviations. Default 3.0.
+        max_iter: [int] Maximum clipping iterations. Default 5.
+
+    Return:
+        [float] Robust standard deviation. Returns 0.0 if there are no finite values.
+    """
+
+    v = np.asarray(values, dtype=np.float64).ravel()
+    v = v[np.isfinite(v)]
+
+    if v.size == 0:
+        return 0.0
+
+    for _ in range(max_iter):
+        med = np.median(v)
+        std = np.std(v)
+
+        if std == 0:
+            break
+
+        keep = np.abs(v - med) <= sigma*std
+
+        # Stop if nothing was clipped or too few points remain to estimate a std
+        if keep.all() or (np.count_nonzero(keep) < 2):
+            break
+
+        v = v[keep]
+
+    return float(np.std(v))
+
+
 def signalToNoise(source_intens, source_px_count, bg_median, bg_std):
     """ Compute the signal to noise ratio using the "CCD equation" (Howell et al., 1989).
 
@@ -1112,8 +1155,19 @@ def signalToNoise(source_intens, source_px_count, bg_median, bg_std):
 
     Return:
         [float] Signal to noise ratio.
+
+    Note on stacked images:
+        When measured on an avepixel (a per-frame mean/median of N stacked frames),
+        source_intens is a per-frame-scaled flux (its sqrt is per-frame source shot noise)
+        while bg_std is the noise of the N-frame-averaged background (lower by ~sqrt(N)).
+        The two noise terms therefore correspond to different effective exposures, so the
+        returned value is neither the single-frame nor the full-integration SNR - it is an
+        intermediate measure that is consistent across stars on the same stack and is used
+        relatively (fit weighting, the log10(S/N) vs mag trend). It is not an absolute
+        radiometric SNR. See the single-frame LM correction in SkyFit photometry for how the
+        stack depth is folded back in.
     """
-    
+
     # Compute the SNR using the "CCD equation" (Howell et al., 1989)
     snr = source_intens/(math.sqrt(source_intens + source_px_count*(bg_median + bg_std**2)))
 

--- a/Utils/CalibrationReport.py
+++ b/Utils/CalibrationReport.py
@@ -569,10 +569,18 @@ def generateCalibrationReport(config, night_dir_path, match_radius=2.0, platepar
         # Draw the limiting magnitude at the target S/N values (catalog mag is on the y-axis)
         if lm_info is not None:
             lm_colors = {5: 'green', 10: 'darkorange'}
+            lm_err = lm_info.get('lm_err', {})
+            lm_extrap = lm_info.get('lm_extrapolated', {})
             for snr_target, lm_mag in lm_info['lm'].items():
+                lbl = "LM = {:.2f}".format(lm_mag)
+                err = lm_err.get(snr_target)
+                if err is not None:
+                    lbl += " ± {:.2f}".format(err)
+                lbl += " mag @ S/N = {:g}".format(snr_target)
+                if lm_extrap.get(snr_target):
+                    lbl += " (extrap)"
                 ax_p.axhline(lm_mag, linestyle='dotted', alpha=0.75,
-                    color=lm_colors.get(snr_target, 'm'),
-                    label="LM = {:.2f} mag @ S/N = {:g}".format(lm_mag, snr_target))
+                    color=lm_colors.get(snr_target, 'm'), label=lbl)
 
         # Split the legend so it does not crowd one corner and hide the data: the photometry
         # calibration entries go top-left, the limiting-magnitude lines go bottom-right

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -176,7 +176,7 @@ from RMS.Routines.AddCelestialGrid import updateRaDecGrid, updateAzAltGrid
 from RMS.Routines.CustomPyqtgraphClasses import ViewBox, TextItem, TextItemList, Crosshair, Plus, Cross, CursorItem, BrushCursorItem, ImageItem, RightOptionsTab, qmessagebox
 from RMS.Routines.GreatCircle import fitGreatCircle, greatCircle
 from RMS.Routines.SphericalPolygonCheck import sphericalPolygonCheck
-from RMS.Routines.Image import loadFlat, loadDark, applyFlat, applyDark, signalToNoise, gammaCorrectionImage, adjustLevels, saveImage, loadImage
+from RMS.Routines.Image import loadFlat, loadDark, applyFlat, applyDark, signalToNoise, sigmaClippedStd, gammaCorrectionImage, adjustLevels, saveImage, loadImage
 from RMS.Routines.MaskImage import getMaskFile, MaskStructure
 from RMS.Routines import RollingShutterCorrection
 from RMS.Misc import maxDistBetweenPoints, getRmsRootDir
@@ -7435,10 +7435,14 @@ class PlateTool(QtWidgets.QMainWindow):
         # a median over m samples equals that of a mean of m*2/pi frames.
         ff = getattr(self.img_handle, 'ff', None)
         n_total = getattr(ff, 'nframes', None)
-        res_size = getattr(ff, 'res_size', None)   # only FFMimickInterface has this
         n_frames = n_total
         n_eff = n_total
-        if (n_total is not None) and res_size:
+
+        # Detect the FFMimickInterface by class: its res_size is a private cdef not exposed to
+        # Python on older builds, so read it from the object if visible, else fall back to the
+        # config value it was built from (FrameInterface always passes background_reservoir_size).
+        if (n_total is not None) and (type(ff).__name__ == 'FFMimickInterface'):
+            res_size = getattr(ff, 'res_size', None) or self.config.background_reservoir_size
             n_frames = min(n_total, res_size)
             n_eff = n_frames*2.0/np.pi
 
@@ -7753,10 +7757,20 @@ class PlateTool(QtWidgets.QMainWindow):
                 # Colors set so the yellower line (higher S/N, brighter LM) is on the left and the
                 # greener line (lower S/N, fainter LM) is on the right
                 lm_colors = {5: 'green', 10: 'darkorange'}
+                lm_err = self.limiting_mag_info.get('lm_err', {})
+                lm_extrap = self.limiting_mag_info.get('lm_extrapolated', {})
                 for snr_target, lm_mag in self.limiting_mag_info['lm'].items():
-                    ax_m.axvline(lm_mag, linestyle='dashed', alpha=0.8,
-                                    color=lm_colors.get(snr_target, 'm'),
-                                    label="LM = {:.2f} mag @ S/N = {:g}".format(lm_mag, snr_target))
+                    lbl = "LM = {:.2f}".format(lm_mag)
+                    err = lm_err.get(snr_target)
+                    if err is not None:
+                        lbl += " ± {:.2f}".format(err)
+                    lbl += " mag @ S/N = {:g}".format(snr_target)
+                    if lm_extrap.get(snr_target):
+                        lbl += " (extrap)"
+                    # Extrapolated LMs are drawn dotted to distinguish them from interpolated ones
+                    ax_m.axvline(lm_mag,
+                                    linestyle=('dotted' if lm_extrap.get(snr_target) else 'dashed'),
+                                    alpha=0.8, color=lm_colors.get(snr_target, 'm'), label=lbl)
 
                 # Show the model equation so users can compute the LM for any S/N, plus the
                 # single-frame LM correction (when the measurement image stacks >1 frame)
@@ -14447,8 +14461,9 @@ class PlateTool(QtWidgets.QMainWindow):
         # Compute the median of the pixels in the aperture mask as the background
         bg_median = np.median(img_crop[annulus_mask == 1])
 
-        # Compute the standard deviation of the pixels in the aperture mask
-        bg_std = np.std(img_crop[annulus_mask == 1])
+        # Robust background std (sigma-clipped) so a neighbouring star or hot pixel leaking
+        # into the annulus does not inflate the noise and corrupt the SNR
+        bg_std = sigmaClippedStd(img_crop[annulus_mask == 1])
 
 
         ######################################################################################################
@@ -15674,8 +15689,9 @@ class PlateTool(QtWidgets.QMainWindow):
 
             ### Measure the SNR of the pick ###
 
-            # Compute the standard deviation of the background
-            background_stddev = np.ma.std(crop_bg)
+            # Robust (sigma-clipped) standard deviation of the background, resistant to
+            # neighbouring sources or hot pixels in the background crop
+            background_stddev = sigmaClippedStd(np.ma.compressed(crop_bg))
 
             # Count the number of pixels in the photometric area
             source_px_count = np.ma.sum(~crop_img.mask)


### PR DESCRIPTION
Follow-up improvements around SkyFit photometry, SNR and LM reporting. Includes the fix for the Codex P2 comment on PR #905.

## 1. Fix: `res_size` was private → single-frame LM cap never fired (Codex P2)
`FFMimickInterface.res_size` was a private `cdef int`, so `getattr(ff, 'res_size', None)` returned `None` and the reservoir cap added in #905 was **inert** — video/vid/image inputs still reported the uncapped 256-frame correction.
- `res_size` is now `cdef public int` (rebuilt).
- `SkyFit2.photometry()` detects the mimick by class name and reads `res_size` from the object, falling back to `config.background_reservoir_size`, so the cap works on old and new builds.

## 2. Robust background std (#2)
`bg_std` used `np.std` of the background annulus — a neighbour star / hot pixel inflates it and corrupts the SNR. New `Image.sigmaClippedStd` (iterative 3σ clip) replaces it at the star-centroid (`SkyFit2.py:14451`) and meteor-pick (`:15678`) SNR sites. Demo: `np.std=5.53` → `sigmaClippedStd=0.91` with 2 outliers in 200 points.

## 3. Limiting-magnitude fit robustness + reporting (#3)
`ApplyAstrometry.limitingMagnitude()`:
- **Weighted fit** by `min(S/N, 10)` (matches the photometry fit), so noisy faint near-limit stars no longer dominate the slope. New optional `weights` kwarg.
- **Per-target LM uncertainty** propagated from the fit covariance (`±` in the equation, legend, and report). `None` when <4 points.
- **Extrapolation flag**: targets whose S/N is outside the measured range are flagged (`(extrap)` label + dotted line). New `lm_err`, `lm_extrapolated` dict keys (additive — CalibrationReport unaffected).

## 4. SNR semantics doc (#4)
Documented that `signalToNoise` on a stacked avepixel mixes per-frame source shot noise with N-averaged background noise — a *relative*, not absolute radiometric, SNR.

## Verification
- All files `py_compile` clean; cython rebuilt; `res_size` now Python-visible (=64).
- `limitingMagnitude` returns weighted fit + `lm_err` (±0.01–0.02 on synthetic data) + correct `extrap` flags; high-S/N-only data flags S/N=5 as extrapolated; 3-point fit → `lm_err=None`.
- Detection logic: 256-frame mimick chunk → display `N=64`, `n_eff=40.7`.
- Pending: live GUI check on FF + video datasets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)