### PR TITLE
SkyFit2: roll-aware WASD panning + pointing indicator

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -574,6 +574,192 @@ def rotationWrtHorizon(platepar):
 
 
 
+def screenNudgeToAzAltDelta(platepar, screen_dx, screen_dy, key_increment, screen_y_sign=-1, h_px=10):
+    """ Map a requested on-screen nudge direction to a change in the apparent reference azimuth and
+        altitude, so that pressing a pan key always moves the view in the apparent screen direction
+        regardless of the camera roll (rotation w.r.t. horizon) or FOV size.
+
+        The screen direction is sampled at the FOV centre as a 3D tangent on the sky, and the pointing
+        is then advanced by rotating its unit vector along the corresponding great circle by exactly
+        key_increment degrees. This automatically absorbs the camera roll and lens distortion, keeps
+        every step an equal angular size regardless of pointing, and carries the pointing cleanly over
+        the zenith (no alt = 90 deg singularity). The raw-space rotationWrtHorizon angle is only used as
+        a fallback when the sampling is degenerate.
+
+    Arguments:
+        platepar: [Platepar object] Input platepar.
+        screen_dx: [float] Requested screen direction X (+1 = right, -1 = left, 0 = none).
+        screen_dy: [float] Requested screen direction Y (+1 = up, -1 = down, 0 = none).
+        key_increment: [float] Desired angular step size (deg).
+
+    Keyword arguments:
+        screen_y_sign: [int] Sign mapping the image +Y axis to the screen vertical. -1 when the image
+            view is Y-inverted for display (SkyFit2 calls img_frame.invertY()), i.e. image +Y is screen
+            down. Default: -1.
+        h_px: [float] Finite-difference pixel step used to sample the local Jacobian. Default: 10.
+
+    Return:
+        (delta_az, delta_alt): [tuple of float] Degrees to add to az_centre/alt_centre. Returns
+            (0.0, 0.0) when the nudge is degenerate or non-finite (no-op).
+    """
+
+    # Numerical safety constants
+    NORM_EPS = 1e-12                        # threshold below which a sampled direction is treated as null
+    AZ_DELTA_CAP = 45.0                     # max azimuth step (deg) applied in the degenerate fallback
+
+
+    def _wrap(d):
+        # Wrap an angle difference (radians) to the (-pi, pi] range
+        return (d + np.pi)%(2*np.pi) - np.pi
+
+
+    def _vec(x, y):
+        # Unit pointing vector (horizontal Cartesian: North, East, Up) of an image pixel
+        jd_arr, ra_arr, dec_arr, _ = xyToRaDecPP([jd2Date(platepar.JD)], [x], [y], [1], platepar, \
+            extinction_correction=False, precompute_pointing_corr=True)
+        az, alt = cyTrueRaDec2ApparentAltAz(np.radians(ra_arr[0]), np.radians(dec_arr[0]), jd_arr[0], \
+            np.radians(platepar.lat), np.radians(platepar.lon), platepar.refraction)
+        ca = np.cos(alt)
+        return np.array([ca*np.cos(az), ca*np.sin(az), np.sin(alt)])
+
+
+    # Requested direction in image-pixel space (screen up maps to image -Y when the view is Y-inverted)
+    dX = screen_dx
+    dY = screen_y_sign*screen_dy
+
+    # Sample the centre pixel and one h_px step in the requested screen direction, as 3D unit vectors.
+    # Working in 3D (rather than with az/alt gradients) keeps the screen direction well-defined right up
+    # to the zenith, where the az/alt parametrisation is singular.
+    xc = platepar.X_res/2
+    yc = platepar.Y_res/2
+    p_c = _vec(xc, yc)
+    p_d = _vec(xc + h_px*dX, yc + h_px*dY)
+
+    # Tangent at the centre toward the requested screen direction (component of p_d perpendicular to p_c)
+    t = p_d - np.dot(p_d, p_c)*p_c
+    tn = np.linalg.norm(t)
+
+    # Degenerate sampling -> fall back to rotating the legacy raw command by the rotation w.r.t. horizon
+    if (tn < NORM_EPS) or (not np.isfinite(tn)):
+        theta = np.radians(rotationWrtHorizon(platepar))
+        cmd_az = key_increment*screen_dx
+        cmd_alt = key_increment*screen_dy
+        d_az = np.cos(theta)*cmd_az - np.sin(theta)*cmd_alt
+        d_alt = np.sin(theta)*cmd_az + np.cos(theta)*cmd_alt
+        if not (np.isfinite(d_az) and np.isfinite(d_alt)):
+            return 0.0, 0.0
+        return float(np.clip(d_az, -AZ_DELTA_CAP, AZ_DELTA_CAP)), float(d_alt)
+
+    t = t/tn
+
+    # Great-circle normal for the requested screen motion
+    k = np.cross(p_c, t)
+    kn = np.linalg.norm(k)
+    if (kn < NORM_EPS) or (not np.isfinite(kn)):
+        return 0.0, 0.0
+    k = k/kn
+
+    # Rotate the reference pointing about k by the step angle (Rodrigues). This advances the pointing an
+    # exact `key_increment` degrees of arc anywhere on the sky and carries it straight over the zenith --
+    # azimuth flips by 180 deg and the elevation turns back down -- without sticking at alt = 90 deg.
+    az_c = np.radians(platepar.az_centre)
+    alt_c = np.radians(platepar.alt_centre)
+    ca, sa = np.cos(alt_c), np.sin(alt_c)
+    cz, sz = np.cos(az_c), np.sin(az_c)
+    p_ref = np.array([ca*cz, ca*sz, sa])
+
+    theta = np.radians(key_increment)
+    ct, st = np.cos(theta), np.sin(theta)
+    p2 = p_ref*ct + np.cross(k, p_ref)*st + k*np.dot(k, p_ref)*(1.0 - ct)
+
+    alt2 = np.arcsin(np.clip(p2[2], -1.0, 1.0))
+    az2 = np.arctan2(p2[1], p2[0])
+
+    d_alt = np.degrees(alt2 - alt_c)
+    d_az = np.degrees(_wrap(az2 - az_c))
+
+    if not (np.isfinite(d_az) and np.isfinite(d_alt)):
+        return 0.0, 0.0
+
+    return float(d_az), float(d_alt)
+
+
+
+def fovCentreZenithDirection(platepar, h_px=10, centre=None):
+    """ Compute the on-screen direction toward the zenith and the apparent elevation at the FOV centre.
+
+        The altitude gradient of the projection is sampled at the FOV centre and expressed in screen
+        coordinates (so it already accounts for the camera roll and the lens distortion). This is used
+        to draw a zenith pointer at the optical-axis marker in SkyFit2.
+
+    Arguments:
+        platepar: [Platepar object] Input platepar.
+
+    Keyword arguments:
+        h_px: [float] Finite-difference pixel step. Default: 10.
+        centre: [tuple or None] (x, y) image pixel to evaluate at. Defaults to the image centre; pass the
+            distortion centre (optical axis) to match the indicator that is pinned there.
+
+    Return:
+        (angle_screen_deg, east_screen_deg, azimuth_deg, elevation_deg, valid):
+            angle_screen_deg: [float] Direction toward the zenith measured in screen coordinates
+                (0 = right, 90 = up), degrees.
+            east_screen_deg: [float] Direction of increasing azimuth (East along the horizon) measured in
+                the same screen coordinates, degrees.
+            azimuth_deg: [float] Apparent azimuth of the FOV centre, degrees (0-360, +E of due N).
+            elevation_deg: [float] Apparent elevation (altitude) of the FOV centre, degrees.
+            valid: [bool] False when the zenith direction is ill-defined (FOV centre near the zenith,
+                where the altitude gradient vanishes).
+    """
+
+    NORM_EPS = 1e-9             # below this the altitude gradient is treated as null
+    ELEV_VALID_MAX = 89.5       # above this elevation the zenith direction is meaningless
+
+    def _wrap(d):
+        return (d + np.pi)%(2*np.pi) - np.pi
+
+    def _azalt(x, y):
+        # Return the apparent (azimuth, altitude) in radians of an image pixel
+        jd_arr, ra_arr, dec_arr, _ = xyToRaDecPP([jd2Date(platepar.JD)], [x], [y], [1], platepar, \
+            extinction_correction=False, precompute_pointing_corr=True)
+        az, alt = cyTrueRaDec2ApparentAltAz(np.radians(ra_arr[0]), np.radians(dec_arr[0]), jd_arr[0], \
+            np.radians(platepar.lat), np.radians(platepar.lon), platepar.refraction)
+        return az, alt
+
+    if centre is None:
+        xc, yc = platepar.X_res/2, platepar.Y_res/2
+    else:
+        xc, yc = centre
+
+    az0, alt0 = _azalt(xc, yc)
+    azx, altx = _azalt(xc + h_px, yc)
+    azy, alty = _azalt(xc, yc + h_px)
+
+    azimuth_deg = np.degrees(az0)%360.0
+    elevation_deg = np.degrees(alt0)
+
+    # Altitude gradient in image space (per +h_px step). It points toward increasing altitude,
+    # i.e. toward the zenith.
+    gx = altx - alt0
+    gy = alty - alt0
+
+    # Azimuth gradient in image space (wrapped across the 0/360 boundary). Points toward increasing
+    # azimuth, i.e. East along the horizon.
+    ax = _wrap(azx - az0)
+    ay = _wrap(azy - az0)
+
+    # Convert to screen coordinates. The SkyFit2 image view is Y-inverted for display, so image +Y is
+    # screen down; the screen-up component is therefore -gy / -ay.
+    norm = np.hypot(gx, gy)
+    valid = bool((norm > NORM_EPS) and (elevation_deg < ELEV_VALID_MAX) and np.isfinite(norm))
+
+    angle_screen_deg = np.degrees(np.arctan2(-gy, gx))
+    east_screen_deg = np.degrees(np.arctan2(-ay, ax))
+
+    return angle_screen_deg, float(east_screen_deg), float(azimuth_deg), float(elevation_deg), valid
+
+
+
 def rotationWrtHorizonToPosAngle(platepar, rot_angle):
     """ Given the rotation angle w.r.t horizon, numerically compute the position angle.
 

--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -627,11 +627,13 @@ def screenNudgeToAzAltDelta(platepar, screen_dx, screen_dy, key_increment, scree
     dX = screen_dx
     dY = screen_y_sign*screen_dy
 
-    # Sample the centre pixel and one h_px step in the requested screen direction, as 3D unit vectors.
+    # Sample at the distortion centre (optical axis) and one h_px step in the requested screen direction,
+    # as 3D unit vectors. The reference az_centre/alt_centre track the optical axis (not the image
+    # midpoint when force_distortion_centre is False), so the screen tangent must be sampled there too,
+    # otherwise on a distorted wide field the nudge direction is taken from the wrong part of the image.
     # Working in 3D (rather than with az/alt gradients) keeps the screen direction well-defined right up
     # to the zenith, where the az/alt parametrisation is singular.
-    xc = platepar.X_res/2
-    yc = platepar.Y_res/2
+    xc, yc = platepar.getDistortionCentre()
     p_c = _vec(xc, yc)
     p_d = _vec(xc + h_px*dX, yc + h_px*dY)
 

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -1116,11 +1116,11 @@ class PointingIndicator(pg.GraphicsObject):
         tx = -tw - 15.0     # right edge clears the optical-axis plus arm
         painter.setFont(self.font)
         painter.setPen(QtGui.QPen(self.text_color))
-        # Two well-separated lines straddling the centre (Az above, Alt below)
+        # Two well-separated lines straddling the centre (Alt above, Az below)
         painter.drawText(QtCore.QRectF(tx, -30.0, tw, th),
-                         QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter, az_str)
-        painter.drawText(QtCore.QRectF(tx, 2.0, tw, th),
                          QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter, alt_str)
+        painter.drawText(QtCore.QRectF(tx, 2.0, tw, th),
+                         QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter, az_str)
 
         # Direction in device coordinates (screen-up = device -Y)
         ang = np.radians(self.angle)

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -971,6 +971,197 @@ class CursorItem(pg.GraphicsObject):
         return QtCore.QRectF(self.picture.boundingRect())
 
 
+class PointingIndicator(pg.GraphicsObject):
+    """ A HUD glyph pinned at the optical-axis marker that shows:
+
+          - a zenith arrow: points toward the zenith on screen (its angle conveys the camera roll),
+          - an elevation notch: a tick sliding along the arrow from the centre (horizon, 0 deg) to the
+            tip (zenith, 90 deg), marking the apparent elevation of the optical centre,
+          - an Az/Alt readout: the apparent azimuth and altitude of the optical centre,
+          - a horizon bar through the optical axis (along the East-West horizon, so it doubles as a
+            horizon/roll indicator). Its length is one WASD pan step on screen, and it carries an azimuth
+            compass: the middle is North, little notches mark West/East, and a notch slides to the
+            current azimuth.
+
+        The arrow and readout are a constant pixel size (ItemIgnoresTransformations), while the bar and
+        its notches scale with the image zoom; the whole glyph stays anchored to the optical-axis pixel.
+    """
+
+    def __init__(self, arrow_length=52):
+        """
+        Arguments:
+            arrow_length: [float] Length of the zenith arrow in screen pixels.
+        """
+        super().__init__()
+
+        # Keep the glyph a constant device-pixel size, anchored at setPos()
+        self.setFlag(QtGui.QGraphicsItem.ItemIgnoresTransformations, True)
+
+        self.arrow_length = float(arrow_length)
+
+        # State (screen frame: +x right, +y up)
+        self.angle = 90.0          # zenith direction (deg)
+        self.east_angle = 0.0      # screen direction of increasing azimuth (East along the horizon, deg)
+        self.azimuth = 0.0         # apparent azimuth of the optical centre (deg)
+        self.elevation = 0.0       # apparent elevation of the optical centre (deg)
+        self.step_px = 0.0         # one WASD step in screen pixels
+        self.precision = 0         # decimals for the Az/Alt readout (FOV-dependent)
+        self.valid_zenith = True   # False when the centre is at/near the zenith
+
+        # Colours (muted, so the glyph stays unobtrusive over the image)
+        self.arrow_color = QtGui.QColor(170, 175, 180)
+        self.notch_color = QtGui.QColor(210, 215, 220)
+        self.step_color = QtGui.QColor(255, 255, 255, 90)
+        self.text_color = QtGui.QColor(185, 190, 195)
+
+        # Compact, fixed-size font for the Az/Alt readout (independent of the system default)
+        self.font = QtGui.QFont()
+        self.font.setPointSize(9)
+
+
+    def setData(self, angle, east_angle, azimuth, elevation, step_px, precision, valid_zenith):
+        self.angle = float(angle)
+        self.east_angle = float(east_angle)
+        self.azimuth = float(azimuth)
+        self.elevation = float(elevation)
+        self.step_px = float(step_px)
+        self.precision = int(precision)
+        self.valid_zenith = bool(valid_zenith)
+        self.prepareGeometryChange()
+        self.update()
+
+
+    def refresh(self):
+        """ Recompute geometry and repaint. Connect this to the view's range-change signal so the
+            step bar (which scales with zoom) is redrawn with up-to-date bounds. """
+        self.prepareGeometryChange()
+        self.update()
+
+
+    def _deviceScaleX(self):
+        """ Device pixels per one image pixel (data unit) along X at the current zoom. Used to scale the
+            step bar, which represents a real on-screen distance, while the arrow/notch stay fixed size. """
+        parent = self.parentItem()
+        if parent is None:
+            return 1.0
+        try:
+            o = parent.mapToDevice(pg.Point(0.0, 0.0))
+            ex = parent.mapToDevice(pg.Point(1.0, 0.0))
+            if (o is None) or (ex is None):
+                return 1.0
+            return abs(ex.x() - o.x())
+        except Exception:
+            return 1.0
+
+
+    def boundingRect(self):
+        # Cover the arrow (plus arrowhead and text margin) and the horizontal step bar (zoom-scaled)
+        bar_half = 0.5*self.step_px*self._deviceScaleX()
+        reach = max(self.arrow_length + 34.0, bar_half + 24.0, 122.0)
+        return QtCore.QRectF(-reach, -reach, 2*reach, 2*reach)
+
+
+    def paint(self, painter, option, widget=None):
+
+        painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+
+        L = self.arrow_length
+
+        # Step-size / horizon / azimuth bar: a line through the optical-axis centre, oriented along the
+        # horizon (East-West). It doubles as (a) a horizon/roll indicator, (b) a pan step-size gauge -- its
+        # length is one WASD step on screen, so it scales with the image zoom -- and (c) an azimuth compass:
+        # the middle is North, little notches mark West and East (+/- 90 deg), and a longer notch slides to
+        # the current azimuth. The compass spans +/-180 deg over the bar (the ends are South).
+        if self.step_px > 0.5:
+            half = 0.5*self.step_px*self._deviceScaleX()
+            ea = np.radians(self.east_angle)
+            ux, uy = np.cos(ea), -np.sin(ea)         # unit toward East along the horizon (device coords)
+            px_, py_ = -uy, ux                       # unit perpendicular (for the notch ticks)
+
+            pen = QtGui.QPen(self.step_color, 2.0, QtCore.Qt.SolidLine)
+            painter.setPen(pen)
+            painter.drawLine(QtCore.QPointF(-half*ux, -half*uy), QtCore.QPointF(half*ux, half*uy))
+            # End caps
+            cap = 4.0
+            for s in (-1.0, 1.0):
+                painter.drawLine(QtCore.QPointF(s*half*ux - cap*px_, s*half*uy - cap*py_),
+                                 QtCore.QPointF(s*half*ux + cap*px_, s*half*uy + cap*py_))
+
+            if self.valid_zenith:
+                def _notch(frac, length, pen):
+                    # Perpendicular tick at the given fraction (-1..1) along the bar from the centre (N)
+                    f = min(max(frac, -1.0), 1.0)
+                    bx, by = f*half*ux, f*half*uy
+                    painter.setPen(pen)
+                    painter.drawLine(QtCore.QPointF(bx - length*px_, by - length*py_),
+                                     QtCore.QPointF(bx + length*px_, by + length*py_))
+
+                # Little reference notches: West (-90 deg) and East (+90 deg) at +/- half the bar
+                ref_pen = QtGui.QPen(self.step_color, 1.5, QtCore.Qt.SolidLine)
+                _notch(-0.5, 3.0, ref_pen)
+                _notch(+0.5, 3.0, ref_pen)
+
+                # Current-azimuth notch (azimuth wrapped to +/-180 deg, mapped over the bar)
+                az_frac = (((self.azimuth + 180.0)%360.0) - 180.0)/180.0
+                _notch(az_frac, 6.0, QtGui.QPen(self.notch_color, 2.2, QtCore.Qt.SolidLine))
+
+        # Az/Alt readout, in the middle just left of the optical-axis plus (right-aligned, two lines).
+        # 'Az' = azimuth (+E of due N), 'Alt' = altitude/elevation. The decimal precision scales with the
+        # FOV (coarser for wide/all-sky, finer for narrow fields).
+        dec = max(self.precision, 0)
+        az_str = ("Az {:." + str(dec) + "f}°").format(self.azimuth)
+        alt_str = ("Alt {:." + str(dec) + "f}°").format(self.elevation)
+        tw = 100.0
+        th = 20.0           # tall enough to not clip glyph descenders / the degree sign
+        tx = -tw - 15.0     # right edge clears the optical-axis plus arm
+        painter.setFont(self.font)
+        painter.setPen(QtGui.QPen(self.text_color))
+        # Two well-separated lines straddling the centre (Az above, Alt below)
+        painter.drawText(QtCore.QRectF(tx, -30.0, tw, th),
+                         QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter, az_str)
+        painter.drawText(QtCore.QRectF(tx, 2.0, tw, th),
+                         QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter, alt_str)
+
+        # Direction in device coordinates (screen-up = device -Y)
+        ang = np.radians(self.angle)
+        dx, dy = np.cos(ang), -np.sin(ang)
+
+        if not self.valid_zenith:
+            # Near the zenith the direction is undefined: draw a dashed ring instead of an arrow
+            pen = QtGui.QPen(self.arrow_color, 1.6, QtCore.Qt.DashLine)
+            painter.setPen(pen)
+            painter.setBrush(QtCore.Qt.NoBrush)
+            painter.drawEllipse(QtCore.QPointF(0.0, 0.0), 0.5*L, 0.5*L)
+            return
+
+        # Shaft (originates from the centre of the optical-axis plus, points toward the zenith)
+        x1, y1 = L*dx, L*dy
+        pen = QtGui.QPen(self.arrow_color, 2.2, QtCore.Qt.SolidLine)
+        pen.setCapStyle(QtCore.Qt.RoundCap)
+        painter.setPen(pen)
+        painter.drawLine(QtCore.QPointF(0.0, 0.0), QtCore.QPointF(x1, y1))
+
+        # Arrowhead (two short barbs at the tip)
+        head = 9.0
+        spread = np.radians(26.0)
+        for s in (+1, -1):
+            ba = ang + np.pi + s*spread
+            bx, by = x1 + head*np.cos(ba), y1 - head*np.sin(ba)
+            painter.drawLine(QtCore.QPointF(x1, y1), QtCore.QPointF(bx, by))
+
+        # Elevation notch: tick perpendicular to the shaft, sliding centre->tip with elevation 0->90 deg
+        f = min(max(self.elevation/90.0, 0.0), 1.0)
+        # Position along the shaft
+        px, py = f*L*dx, f*L*dy
+        # Perpendicular direction (screen) rotated 90 deg
+        perp = ang + np.pi/2.0
+        pwx, pwy = np.cos(perp), -np.sin(perp)
+        nw = 6.0
+        painter.setPen(QtGui.QPen(self.notch_color, 2.2, QtCore.Qt.SolidLine))
+        painter.drawLine(QtCore.QPointF(px - nw*pwx, py - nw*pwy),
+                         QtCore.QPointF(px + nw*pwx, py + nw*pwy))
+
+
 class HistogramLUTWidget(pg.HistogramLUTWidget):
     def __init__(self, gui, parent=None, *args, **kwargs):
 

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -4622,19 +4622,20 @@ class PlateTool(QtWidgets.QMainWindow):
         # Get current FOV center coordinates for filtering (apparent coordinates)
         fov_ra, fov_dec = self.computeCentreRADec()
 
-        # Use same FOV radius as catalog filtering, with margin for edge cases
-        # Cap at 90 degrees (gnomonic projection limit)
+        # Gate bodies on angular distance from the FOV centre, using the same selection radius as the
+        # catalog star filtering (subsetCatalog). The projected-bounds check below is NOT a sufficient
+        # FOV test on its own: a radial distortion polynomial extrapolated beyond its fit range can fold
+        # far-off-sky points back into the image, so a body well outside the FOV would otherwise project
+        # in-bounds and pop in and out as the pointing changes.
         fov_radius = getFOVSelectionRadius(self.platepar)
-        max_ang_sep = min(90, fov_radius * 1.5)
 
         for display_name, ra_deg, dec_deg, mag in self._planet_cache_radec:
-            # Check angular separation from FOV center
-            # Skip bodies outside the extended FOV radius (prevents gnomonic projection wrapping)
+            # Skip bodies outside the FOV selection radius
             ang_sep = np.degrees(angularSeparation(
                 np.radians(ra_deg), np.radians(dec_deg),
                 np.radians(fov_ra), np.radians(fov_dec)
             ))
-            if ang_sep > max_ang_sep:
+            if ang_sep > fov_radius:
                 continue
 
             # Convert RA/Dec to image coordinates

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -151,7 +151,7 @@ from RMS.Astrometry.ApplyAstrometry import xyToRaDecPP, raDecToXYPP, \
     rotationWrtHorizon, rotationWrtHorizonToPosAngle, computeFOVSize, photomLine, photometryFit, \
     rotationWrtStandard, rotationWrtStandardToPosAngle, correctVignetting, \
     extinctionCorrectionTrueToApparent, applyAstrometryFTPdetectinfo, getFOVSelectionRadius, \
-    limitingMagnitude
+    limitingMagnitude, screenNudgeToAzAltDelta, fovCentreZenithDirection
 from RMS.Astrometry.AtmosphericExtinction import atmosphericExtinctionCorrection
 from RMS.Astrometry.StarClasses import CatalogStar, GeoPoint, PlanetPoint, PairedStars
 from RMS.Astrometry.StarFilters import filterPhotometricOutliers, filterBlendedStars
@@ -173,7 +173,7 @@ from RMS.Pickling import loadPickle, savePickle
 from RMS.Math import angularSeparation, RMSD, vectNorm
 from RMS.Misc import decimalDegreesToSexHours
 from RMS.Routines.AddCelestialGrid import updateRaDecGrid, updateAzAltGrid
-from RMS.Routines.CustomPyqtgraphClasses import ViewBox, TextItem, TextItemList, Crosshair, Plus, Cross, CursorItem, BrushCursorItem, ImageItem, RightOptionsTab, qmessagebox
+from RMS.Routines.CustomPyqtgraphClasses import ViewBox, TextItem, TextItemList, Crosshair, Plus, Cross, CursorItem, BrushCursorItem, ImageItem, RightOptionsTab, qmessagebox, PointingIndicator
 from RMS.Routines.GreatCircle import fitGreatCircle, greatCircle
 from RMS.Routines.SphericalPolygonCheck import sphericalPolygonCheck
 from RMS.Routines.Image import loadFlat, loadDark, applyFlat, applyDark, signalToNoise, gammaCorrectionImage, adjustLevels, saveImage, loadImage
@@ -3009,6 +3009,16 @@ class PlateTool(QtWidgets.QMainWindow):
         self.distortion_center_marker.setZValue(5)
         self.img_frame.addItem(self.distortion_center_marker)
 
+        # Pointing indicator (zenith arrow + elevation notch + WASD step-size bar) at the optical axis
+        self.pointing_indicator = PointingIndicator()
+        self.pointing_indicator.setZValue(6)
+        self.img_frame.addItem(self.pointing_indicator, ignoreBounds=True)
+        self.pointing_indicator.hide()
+
+        # Refresh the indicator on zoom/pan so the step-size bar (drawn in screen pixels but representing
+        # a real image distance) rescales with the view
+        self.img_frame.sigRangeChanged.connect(lambda *args: self.pointing_indicator.refresh())
+
         # Distortion center marker (red cross) - zoom window
         self.distortion_center_marker2 = pg.ScatterPlotItem()
         self.distortion_center_marker2.setPen((255, 0, 0), width=2)
@@ -3517,6 +3527,10 @@ class PlateTool(QtWidgets.QMainWindow):
             self.skyfit_button.setDisabled(False)
             self.manualreduction_button.setDisabled(True)
 
+            # The pointing indicator is only relevant in skyfit mode
+            if hasattr(self, 'pointing_indicator'):
+                self.pointing_indicator.hide()
+
             self.img_type_flag = 'avepixel'
             self.tab.settings.updateMaxAvePixel()
             self.img_zoom.loadImage(self.mode, self.img_type_flag)
@@ -3909,6 +3923,10 @@ class PlateTool(QtWidgets.QMainWindow):
 
         if not self.hasData():
             return
+
+        # Refresh the optical-axis pointing indicator (zenith arrow, elevation, WASD step size). This
+        # is the common path for the pan (WASD), rotation (Q/E), scale and step-size (+/-) keys.
+        self.updatePointingIndicator()
 
         ctrl = self.ctrl_label
 
@@ -7135,6 +7153,52 @@ class PlateTool(QtWidgets.QMainWindow):
             self.distortion_center_marker.setData(x=[x_centre], y=[y_centre])
             self.distortion_center_marker2.setData(x=[x_centre], y=[y_centre])
 
+            self.updatePointingIndicator()
+
+
+    def updatePointingIndicator(self):
+        """ Update the zenith arrow / elevation notch / WASD step-size indicator at the optical axis. """
+
+        # Only relevant when fitting a plate (skyfit mode) with a valid platepar
+        if (self.platepar is None) or (self.mode != 'skyfit'):
+            if hasattr(self, 'pointing_indicator'):
+                self.pointing_indicator.hide()
+            return
+
+        try:
+            # Anchor the glyph at the optical axis (same point as the red plus)
+            x_centre, y_centre = self.platepar.getDistortionCentre()
+
+            # Screen direction toward the zenith + East along the horizon + apparent az/elev, evaluated at
+            # the optical axis so the readout matches where the glyph is pinned
+            angle_screen, east_screen, azimuth, elevation, valid = fovCentreZenithDirection(self.platepar, \
+                centre=(x_centre, y_centre))
+
+            # On-screen size of one WASD step: panStepDeg is the FOV-relative angular step (deg) and
+            # F_scale is the reference plate scale (px/deg) at the centre
+            step_px = abs(self.panStepDeg()*self.platepar.F_scale)
+
+            # Az/Alt readout precision scales with the FOV: integer degrees for wide/all-sky fields, more
+            # decimals for narrow fields where finer pointing matters
+            fov_h, fov_v = computeFOVSize(self.platepar)
+            fov_diag = np.hypot(fov_h, fov_v)
+            if fov_diag >= 60:
+                precision = 0
+            elif fov_diag >= 20:
+                precision = 1
+            elif fov_diag >= 5:
+                precision = 2
+            else:
+                precision = 3
+
+            self.pointing_indicator.setPos(x_centre, y_centre)
+            self.pointing_indicator.setData(angle_screen, east_screen, azimuth, elevation, step_px, \
+                precision, valid)
+            self.pointing_indicator.show()
+
+        except Exception:
+            self.pointing_indicator.hide()
+
 
     def screenPlotDPI(self):
         """ Compute a matplotlib figure DPI scaled to the screen resolution so that the
@@ -10150,53 +10214,21 @@ class PlateTool(QtWidgets.QMainWindow):
 
                 print('Plate fitted!')
 
-            # Increase reference azimuth
+            # Pan the view left on screen (roll-aware)
             elif event.key() == QtCore.Qt.Key_A:
-                self.platepar.az_centre += self.key_increment
-                
-                self.checkParamRange()
-                self.platepar.updateRefRADec(preserve_rotation=True)
-                self.checkParamRange()
+                self.nudgeReferenceScreen(-1, 0)
 
-                self.tab.param_manager.updatePlatepar()
-                self.updateLeftLabels()
-                self.updateStars()
-
-            # Decrease reference azimuth
+            # Pan the view right on screen (roll-aware)
             elif event.key() == QtCore.Qt.Key_D:
-                self.platepar.az_centre -= self.key_increment
+                self.nudgeReferenceScreen(+1, 0)
 
-                self.checkParamRange()
-                self.platepar.updateRefRADec(preserve_rotation=True)
-                self.checkParamRange()
-
-                self.tab.param_manager.updatePlatepar()
-                self.updateLeftLabels()
-                self.updateStars()
-
-            # Increase reference altitude
+            # Pan the view up on screen (roll-aware)
             elif event.key() == QtCore.Qt.Key_W:
-                self.platepar.alt_centre -= self.key_increment
+                self.nudgeReferenceScreen(0, +1)
 
-                self.checkParamRange()
-                self.platepar.updateRefRADec(preserve_rotation=True)
-                self.checkParamRange()
-
-                self.tab.param_manager.updatePlatepar()
-                self.updateLeftLabels()
-                self.updateStars()
-
-            # Decrease reference altitude
+            # Pan the view down on screen (roll-aware)
             elif event.key() == QtCore.Qt.Key_S:
-                self.platepar.alt_centre += self.key_increment
-
-                self.checkParamRange()
-                self.platepar.updateRefRADec(preserve_rotation=True)
-                self.checkParamRange()
-
-                self.tab.param_manager.updatePlatepar()
-                self.updateLeftLabels()
-                self.updateStars()
+                self.nudgeReferenceScreen(0, -1)
 
             # Pan to unmatched star most distant from all other matched stars
 
@@ -11418,6 +11450,73 @@ class PlateTool(QtWidgets.QMainWindow):
                     self.scrolls_back = 0
                     self.img_frame.wheelEventModified(event, axis)
 
+
+
+    def panStepDeg(self):
+        """ FOV-relative WASD pan step in angular degrees.
+
+            The pan step is decoupled from the absolute-degree meaning of key_increment (which is shared
+            with the rotation/scale/distortion keys) and is instead a fraction of the FOV diagonal, so a
+            press feels equally responsive on a narrow lens and on an all-sky camera. key_increment still
+            acts as a relative sensitivity knob via the +/- keys.
+        """
+
+        REF_INCREMENT = 1.0     # key_increment value at which the pan step equals BASE_FRACTION of the FOV
+        BASE_FRACTION = 0.04    # fraction of the FOV diagonal moved per press at the default increment
+        MIN_STEP = 0.002        # deg, lower clamp so the step never collapses to zero
+        MAX_STEP = 60.0         # deg, upper clamp so a single press can't fling the pointing across the sky
+
+        fov_h, fov_v = computeFOVSize(self.platepar)
+        fov_diag = np.hypot(fov_h, fov_v)
+
+        step = (self.key_increment/REF_INCREMENT)*BASE_FRACTION*fov_diag
+
+        return float(min(max(step, MIN_STEP), MAX_STEP))
+
+
+    def nudgeReferenceScreen(self, screen_dx, screen_dy):
+        """ Pan the FOV reference pointing in an on-screen direction (roll-aware).
+
+        Arguments:
+            screen_dx: [float] Screen direction X (+1 = right, -1 = left, 0 = none).
+            screen_dy: [float] Screen direction Y (+1 = up, -1 = down, 0 = none).
+        """
+
+        # Convert the requested screen direction into a change of the apparent reference az/alt. The step
+        # magnitude is FOV-relative (panStepDeg) and the direction is roll-independent. The image view is
+        # Y-inverted for display (img_frame.invertY()), so image +Y is screen down.
+        step = self.panStepDeg()
+        d_az, d_alt = screenNudgeToAzAltDelta(self.platepar, screen_dx, screen_dy, step, screen_y_sign=-1)
+
+        # Skip degenerate / no-op nudges so the UI isn't churned
+        if (d_az == 0.0) and (d_alt == 0.0):
+            return
+
+        # Decide how the camera roll is carried. Away from the zenith/nadir we keep the rotation w.r.t.
+        # horizon fixed (preserve_rotation) so the horizon stays level while panning azimuth. Close to a
+        # pole that solver is degenerate and traps the pointing, so there we hold the celestial roll
+        # (skip_rot_update) instead, which lets the pointing cross the pole cleanly with the horizon
+        # rotation flipping by ~180 deg. The threshold is at least 5 deg from the pole, and at least one
+        # step (so the crossing press itself is handled in the pole regime).
+        near_pole = (90.0 - abs(self.platepar.alt_centre)) < max(step, 5.0)
+
+        self.platepar.az_centre += d_az
+        self.platepar.alt_centre += d_alt
+
+        self.checkParamRange()
+
+        if near_pole:
+            self.platepar.updateRefRADec(skip_rot_update=True)
+        else:
+            self.platepar.updateRefRADec(preserve_rotation=True)
+        self.checkParamRange()
+
+        # Keep the stored rotation-w.r.t.-horizon in sync with the new pointing for the labels/indicator
+        self.platepar.rotation_from_horiz = rotationWrtHorizon(self.platepar)
+
+        self.tab.param_manager.updatePlatepar()
+        self.updateLeftLabels()
+        self.updateStars()
 
 
     def checkParamRange(self):


### PR DESCRIPTION
## What

Two related SkyFit2 usability changes for adjusting the pointing.

### Roll-aware WASD panning
Previously WASD changed the reference azimuth/altitude directly, so when the camera frame was rolled the view moved in confusing, rotated directions, and panning toward the zenith got stuck at the pole.

- WASD now move the view in the apparent **on-screen** directions (W=up, S=down, A=left, D=right) regardless of camera roll or FOV size.
- The step advances the pointing along a **great circle** (rotating the pointing vector on the sphere), so every step is the same angular size anywhere on the sky and the pointing **crosses the zenith cleanly** instead of sticking — the horizon rotation flips ~180° as it goes over.
- Step size is **FOV-relative** (a fraction of the FOV diagonal), so a press feels equally responsive on a narrow lens and an all-sky camera; still tunable with `+`/`-`.
- Away from the poles the rotation w.r.t. horizon is held fixed (azimuth panning stays level); within ~one step of a pole the celestial roll is held instead, which is what lets it cross the pole.

New helper `screenNudgeToAzAltDelta` and methods `panStepDeg` / `nudgeReferenceScreen`.

### Pointing indicator HUD
A glyph pinned at the optical-axis plus (`PointingIndicator`), evaluated at the optical axis:
- **Zenith arrow** — points to the zenith on screen; its angle conveys the camera roll.
- **Elevation notch** — slides along the arrow (centre = horizon, tip = zenith).
- **Az/Alt readout** — apparent azimuth and altitude; decimal precision scales with the FOV (integer for wide/all-sky, finer for narrow).
- **Horizon bar** through the optical axis that triple-serves as: a horizon/roll indicator (lies along the E–W horizon), a pan **step-size gauge** (length = one WASD step, scaling with zoom), and an **azimuth compass** (middle = N, little W/E notches, a notch sliding to the current azimuth).

New helper `fovCentreZenithDirection`; wired into `updateLeftLabels` / `updateDistortionCenterMarker` / `changeMode` and the view range-change signal so it tracks pointing changes and zoom.

## Files
- `RMS/Astrometry/ApplyAstrometry.py` — `screenNudgeToAzAltDelta`, `fovCentreZenithDirection`
- `RMS/Routines/CustomPyqtgraphClasses.py` — `PointingIndicator`
- `Utils/SkyFit2.py` — `panStepDeg`, `nudgeReferenceScreen`, `updatePointingIndicator`, WASD handlers, hooks, imports

## Testing
Numerically verified (offscreen, sample platepars): equal 2.0° angular steps at altitudes up to 89.95°; clean zenith crossing under repeated W (climb → flip ~180° → descend) with no sticking; level azimuth panning away from the poles; pan direction stays screen-correct across rolls of 0/58/122/165/−123°; FOV-relative step scaling; indicator rendering for upright/rolled and N/E/W azimuth cases. Not yet exercised in a live interactive GUI session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)