### PR TITLE
SkyFit2 Performance & Fit‑Quality

### DIFF
--- a/RMS/ExtractStars.py
+++ b/RMS/ExtractStars.py
@@ -540,8 +540,9 @@ def fitPSF(img, img_median, x_init, y_init, gamma=1.0, segment_radius=4, roundne
     snr_fitted = []
     saturated_count_fitted = []
 
-    # Set the initial guess
-    initial_guess = (30.0, segment_radius, segment_radius, 1.0, 1.0, 0.0, img_median)
+    # Initial guess for positions and sigmas (amplitude and offset are seeded per-star
+    # below from the actual segment, so the fit converges at any bit depth).
+    init_pos_sigma = (segment_radius, segment_radius, 1.0, 1.0, 0.0)
 
     # Get the image dimensions
     nrows, ncols = img.shape
@@ -586,6 +587,16 @@ def fitPSF(img, img_median, x_init, y_init, gamma=1.0, segment_radius=4, roundne
 
         # Estimate saturation level from image type
         saturation = (2**bit_depth - 1)*np.ones_like(y_ind)
+
+        # Skip empty segments (can happen at the very edge of the image)
+        if star_seg.size == 0:
+            continue
+
+        # Seed the amplitude from this segment's peak so the fit converges regardless of bit
+        # depth. A fixed amplitude guess (e.g. 30, an 8-bit value) starts ~1000x too low on
+        # 16-bit data, so bright stars never converge within maxfev and are silently dropped.
+        amp_guess = max(float(np.max(star_seg)) - img_median, 1.0)
+        initial_guess = (amp_guess,) + init_pos_sigma + (img_median,)
 
         # Fit a PSF to the star
         try:

--- a/RMS/Formats/Platepar.py
+++ b/RMS/Formats/Platepar.py
@@ -778,6 +778,30 @@ class Platepar(object):
 
             return dist_sum
 
+        def _calcImageResidualsDistortionVect(params, platepar, jd, catalog_stars, img_stars, dimension):
+            """Vector-residual form of _calcImageResidualsDistortion for scipy.least_squares.
+               Returns per-star residuals; least_squares minimizes their sum of squares, which
+               equals the scalar dist_sum above, so the optimum is identical."""
+
+            pp_copy = copy.copy(platepar)
+
+            if (dimension == 'x') or (dimension == 'radial'):
+                pp_copy.x_poly_rev = params
+                pp_copy.y_poly_rev = np.zeros(platepar.poly_length)
+            else:
+                pp_copy.x_poly_rev = np.zeros(platepar.poly_length)
+                pp_copy.y_poly_rev = params
+
+            img_x, img_y, _ = img_stars.T
+            catalog_x, catalog_y, _ = getCatalogStarsImagePositions(catalog_stars, jd, pp_copy)
+
+            if dimension == 'x':
+                return catalog_x - img_x
+            elif dimension == 'y':
+                return catalog_y - img_y
+            else:
+                return np.concatenate([catalog_x - img_x, catalog_y - img_y])
+
         # Modify the residuals function so that it takes a list of arguments
         def _calcImageResidualsDistortionListArguments(params, *args, **kwargs):
             return [_calcImageResidualsDistortion(param_line, *args, **kwargs) for param_line in params]
@@ -900,6 +924,29 @@ class Platepar(object):
             )
 
             return separation_sum
+
+        def _calcSkyResidualsAstroAndDistortionRadialVect(params, platepar, jd, catalog_stars, img_stars):
+            """Vector-residual form of _calcSkyResidualsAstroAndDistortionRadial for scipy.least_squares.
+               Returns per-star angular separations; least_squares minimizes their sum of squares,
+               which equals the scalar separation_sum above, so the optimum is identical."""
+
+            pp_copy = copy.copy(platepar)
+
+            ra_ref, dec_ref, pos_angle_ref, F_scale = params[:4]
+            pp_copy.RA_d = (360 * ra_ref) % (360)
+            pp_copy.dec_d = -90 + (90 * dec_ref + 90) % (180.000001)
+            pp_copy.pos_angle_ref = (360 * pos_angle_ref) % (360)
+            pp_copy.F_scale = abs(F_scale)
+            pp_copy.x_poly_fwd = np.array(params[4:])
+
+            img_x, img_y, _ = img_stars.T
+            ra_array, dec_array = getPairedStarsSkyPositions(img_x, img_y, jd, pp_copy)
+            ra_catalog, dec_catalog, _ = catalog_stars.T
+
+            return angularSeparation(
+                np.radians(ra_array), np.radians(dec_array),
+                np.radians(ra_catalog), np.radians(dec_catalog),
+            )
 
         def _calcSkyResidualsAstroAndDistortionRadialNN(params, platepar, jd, catalog_stars, img_stars):
             """Like _calcSkyResidualsAstroAndDistortionRadial but uses nearest-neighbor matching.
@@ -1541,14 +1588,16 @@ class Platepar(object):
                         prev_x_poly_rev = self.x_poly_rev.copy()
 
                         ### FORWARD MAPPING FIT ###
-                        res = scipy.optimize.minimize(
-                            cost_func,
+                        # Prototype: Levenberg-Marquardt least-squares on the vector residual.
+                        # Converges in far fewer evals than Nelder-Mead and lands on the same
+                        # (or lower-residual) least-squares minimum.
+                        res = scipy.optimize.least_squares(
+                            _calcSkyResidualsAstroAndDistortionRadialVect,
                             p0,
                             args=(self, jd, catalog_stars, img_stars),
-                            method='Nelder-Mead',
-                            options=opt_options_final,
+                            method='lm', ftol=1e-12, xtol=1e-12, gtol=1e-12,
                         )
-                        fwd_status = "maxiter" if res.nit >= opt_options_final['maxiter'] else "converged"
+                        fwd_status = "converged" if res.success else "stopped"
 
                         # Update fitted astrometric parameters (Unnormalize the pointing parameters)
                         ra_ref, dec_ref, pos_angle_ref, F_scale = res.x[:4]
@@ -1573,15 +1622,13 @@ class Platepar(object):
                         # cameras with extreme distortion center offset where the optimizer
                         # can diverge when starting from zeros
                         rev_init = self.x_poly_fwd.copy()
-                        rev_maxiter = 10000
-                        res_rev = scipy.optimize.minimize(
-                            _calcImageResidualsDistortion,
+                        res_rev = scipy.optimize.least_squares(
+                            _calcImageResidualsDistortionVect,
                             rev_init,
                             args=(self, jd, catalog_stars, img_stars, 'radial'),
-                            method='Nelder-Mead',
-                            options={'maxiter': rev_maxiter, 'adaptive': True},
+                            method='lm', ftol=1e-12, xtol=1e-12, gtol=1e-12,
                         )
-                        rev_status = "maxiter" if res_rev.nit >= rev_maxiter else "converged"
+                        rev_status = "converged" if res_rev.success else "stopped"
 
                         self.x_poly_rev = res_rev.x
 

--- a/RMS/Formats/Platepar.py
+++ b/RMS/Formats/Platepar.py
@@ -938,6 +938,23 @@ class Platepar(object):
 
             return dist_sum
 
+        def _calcImageResidualsAstroAndDistortionRadialVect(params, platepar, jd, catalog_stars, img_stars):
+            """Vector-residual form of _calcImageResidualsAstroAndDistortionRadial for least_squares:
+               fits pointing + reverse distortion on the per-star pixel residual."""
+
+            pp_copy = copy.copy(platepar)
+            ra_ref, dec_ref, pos_angle_ref, F_scale = params[:4]
+            pp_copy.RA_d = (360 * ra_ref) % (360)
+            pp_copy.dec_d = -90 + (90 * dec_ref + 90) % (180.000001)
+            pp_copy.pos_angle_ref = (360 * pos_angle_ref) % (360)
+            pp_copy.F_scale = abs(F_scale)
+            pp_copy.x_poly_rev = np.array(params[4:])
+
+            img_x, img_y, _ = img_stars.T
+            catalog_x, catalog_y, _ = getCatalogStarsImagePositions(catalog_stars, jd, pp_copy)
+
+            return np.concatenate([catalog_x - img_x, catalog_y - img_y])
+
         def _calcSkyResidualsAstroAndDistortionRadial(params, platepar, jd, catalog_stars, img_stars):
             """Calculates the differences between the stars on the image and catalog stars in celestial
             coordinates with the given astrometrical solution. Pointing and distortion parameters are used
@@ -1704,6 +1721,27 @@ class Platepar(object):
                             if fwd_rev_iter > 0:
                                 print("    Converged after {} iterations".format(fwd_rev_iter + 1))
                             break
+
+                    # Final refinement: fit pointing + reverse distortion jointly on the IMAGE
+                    # (pixel) residual -- the metric reported to users. The fwd-rev loop fits the
+                    # forward mapping on SKY angular separation, whose optimum can leave the
+                    # pointing slightly off for the pixel residual (forward/reverse mappings are
+                    # not exact inverses), which showed up as a worse RMSD with least_squares.
+                    # This recovers the old Nelder-Mead pixel accuracy while keeping the speedup.
+                    p_final = [self.RA_d/360.0, self.dec_d/90.0, self.pos_angle_ref/360.0,
+                               abs(self.F_scale)] + self.x_poly_rev.tolist()
+                    res_final = _lstsqFit(
+                        _calcImageResidualsAstroAndDistortionRadialVect,
+                        p_final,
+                        (self, jd, catalog_stars, img_stars),
+                    )
+                    xf = res_final.x
+                    self.RA_d = (360*xf[0]) % 360
+                    self.dec_d = -90 + (90*xf[1] + 90) % (180.000001)
+                    self.pos_angle_ref = (360*xf[2]) % 360
+                    self.F_scale = abs(xf[3])
+                    self.x_poly_rev = np.array(xf[4:])
+                    self.updateRefAltAz()
 
                 ### ###
 

--- a/RMS/Formats/Platepar.py
+++ b/RMS/Formats/Platepar.py
@@ -458,7 +458,7 @@ class Platepar(object):
 
             img_x, img_y, _ = img_stars.T
 
-            pp_copy = copy.deepcopy(platepar)
+            pp_copy = copy.copy(platepar)
 
             # Assign guessed parameters
             pp_copy.RA_d = ra_ref
@@ -488,7 +488,7 @@ class Platepar(object):
 
             img_x, img_y, _ = img_stars.T
 
-            pp_copy = copy.deepcopy(platepar)
+            pp_copy = copy.copy(platepar)
 
             # Assign guessed parameters
             pp_copy.RA_d = ra_ref
@@ -747,7 +747,7 @@ class Platepar(object):
             """
 
             # Set distortion parameters
-            pp_copy = copy.deepcopy(platepar)
+            pp_copy = copy.copy(platepar)
 
             if (dimension == 'x') or (dimension == 'radial'):
                 pp_copy.x_poly_rev = params
@@ -790,7 +790,7 @@ class Platepar(object):
                 dimension: [str] 'x' for X polynomial fit, 'y' for Y polynomial fit
             """
 
-            pp_copy = copy.deepcopy(platepar)
+            pp_copy = copy.copy(platepar)
 
             if (dimension == 'x') or (dimension == 'radial'):
                 pp_copy.x_poly_fwd = params
@@ -832,13 +832,12 @@ class Platepar(object):
                 dimension: [str] 'x' for X polynomial fit, 'y' for Y polynomial fit
             """
 
-            # Set distortion parameters
-            pp_copy = copy.deepcopy(platepar)
-
             # Unpack pointing parameters and assign to the copy of platepar used for the fit
             ra_ref, dec_ref, pos_angle_ref, F_scale = params[:4]
 
-            pp_copy = copy.deepcopy(platepar)
+            # Shallow copy: the residual only rebinds scalar/poly attributes below and the
+            # projection reads the rest, so a full deepcopy (per optimizer eval) is wasted.
+            pp_copy = copy.copy(platepar)
 
             # Unnormalize the pointing parameters
             pp_copy.RA_d = (360 * ra_ref) % (360)
@@ -866,13 +865,12 @@ class Platepar(object):
 
             """
 
-            # Set distortion parameters
-            pp_copy = copy.deepcopy(platepar)
-
             # Unpack pointing parameters and assign to the copy of platepar used for the fit
             ra_ref, dec_ref, pos_angle_ref, F_scale = params[:4]
 
-            pp_copy = copy.deepcopy(platepar)
+            # Shallow copy: the residual only rebinds scalar/poly attributes below and the
+            # projection reads the rest, so a full deepcopy (per optimizer eval) is wasted.
+            pp_copy = copy.copy(platepar)
 
             # Unnormalize the pointing parameters
             pp_copy.RA_d = (360 * ra_ref) % (360)
@@ -920,7 +918,7 @@ class Platepar(object):
                 Sum of squared angular separations to nearest catalog star for each detected star
             """
             # Set distortion parameters
-            pp_copy = copy.deepcopy(platepar)
+            pp_copy = copy.copy(platepar)
 
             # Unpack pointing parameters and assign to the copy of platepar used for the fit
             ra_ref, dec_ref, pos_angle_ref, F_scale = params[:4]

--- a/RMS/Formats/Platepar.py
+++ b/RMS/Formats/Platepar.py
@@ -132,6 +132,32 @@ def getPairedStarsSkyPositions(img_x, img_y, jd, platepar):
     return ra_array, dec_array
 
 
+def _lstsqFit(residual_func, x0, args):
+    """Levenberg-Marquardt least-squares fit on a vector-valued residual.
+
+    Replaces Nelder-Mead on the smooth, matched-pair cost functions: it uses the residual's
+    Jacobian structure, so it converges in far fewer evaluations and reaches the same (or a
+    lower-residual) least-squares minimum. Uses 'lm' when there are at least as many residuals
+    as parameters (lm's requirement); otherwise falls back to the robust 'trf'. Tight
+    tolerances ensure full convergence.
+
+    Arguments:
+        residual_func: [callable] Returns the per-observation residual VECTOR (not the sum of
+            squares). least_squares minimizes 0.5*sum(residual**2), so this must match the
+            squared-and-summed scalar cost it replaces.
+        x0: [array] Initial parameters.
+        args: [tuple] Extra args passed to residual_func.
+
+    Return:
+        scipy.optimize.OptimizeResult
+    """
+    x0 = np.asarray(x0, dtype=float)
+    n_resid = len(np.atleast_1d(residual_func(x0, *args)))
+    method = 'lm' if n_resid >= len(x0) else 'trf'
+    return scipy.optimize.least_squares(
+        residual_func, x0, args=args, method=method, ftol=1e-12, xtol=1e-12, gtol=1e-12)
+
+
 class Platepar(object):
     def __init__(self, distortion_type="radial7-odd"):
         """Astrometric and photometric calibration plate parameters. Several distortion types are supported.
@@ -842,6 +868,26 @@ class Platepar(object):
 
             return separation_sum
 
+        def _calcSkyResidualsDistortionVect(params, platepar, jd, catalog_stars, img_stars, dimension):
+            """Vector-residual form of _calcSkyResidualsDistortion for scipy.least_squares.
+               Returns per-star angular separations (sum of squares == the scalar cost above)."""
+
+            pp_copy = copy.copy(platepar)
+
+            if (dimension == 'x') or (dimension == 'radial'):
+                pp_copy.x_poly_fwd = params
+            else:
+                pp_copy.y_poly_fwd = params
+
+            img_x, img_y, _ = img_stars.T
+            ra_array, dec_array = getPairedStarsSkyPositions(img_x, img_y, jd, pp_copy)
+            ra_catalog, dec_catalog, _ = catalog_stars.T
+
+            return angularSeparation(
+                np.radians(ra_array), np.radians(dec_array),
+                np.radians(ra_catalog), np.radians(dec_catalog),
+            )
+
         # Modify the residuals function so that it takes a list of arguments
         def _calcSkyResidualsDistortionListArguments(params, *args, **kwargs):
             return [_calcSkyResidualsDistortion(param_line, *args, **kwargs) for param_line in params]
@@ -1036,24 +1082,20 @@ class Platepar(object):
                 ### REVERSE MAPPING FIT ###
 
                 # Fit distortion parameters in X direction, reverse mapping
-                res = scipy.optimize.minimize(
-                    _calcImageResidualsDistortion,
+                res = _lstsqFit(
+                    _calcImageResidualsDistortionVect,
                     self.x_poly_rev,
-                    args=(self, jd, catalog_stars, img_stars, 'x'),
-                    method='Nelder-Mead',
-                    options={'maxiter': 10000, 'adaptive': True},
+                    (self, jd, catalog_stars, img_stars, 'x'),
                 )
 
                 # Extract fitted X polynomial
                 self.x_poly_rev = res.x
 
                 # Fit distortion parameters in Y direction, reverse mapping
-                res = scipy.optimize.minimize(
-                    _calcImageResidualsDistortion,
+                res = _lstsqFit(
+                    _calcImageResidualsDistortionVect,
                     self.y_poly_rev,
-                    args=(self, jd, catalog_stars, img_stars, 'y'),
-                    method='Nelder-Mead',
-                    options={'maxiter': 10000, 'adaptive': True},
+                    (self, jd, catalog_stars, img_stars, 'y'),
                 )
 
                 # Extract fitted Y polynomial
@@ -1070,24 +1112,20 @@ class Platepar(object):
                 ### FORWARD MAPPING FIT ###
 
                 # Fit distortion parameters in X direction, forward mapping
-                res = scipy.optimize.minimize(
-                    _calcSkyResidualsDistortion,
+                res = _lstsqFit(
+                    _calcSkyResidualsDistortionVect,
                     self.x_poly_fwd,
-                    args=(self, jd, catalog_stars, img_stars, 'x'),
-                    method='Nelder-Mead',
-                    options={'maxiter': 10000, 'adaptive': True},
+                    (self, jd, catalog_stars, img_stars, 'x'),
                 )
 
                 # Extract fitted X polynomial
                 self.x_poly_fwd = res.x
 
                 # Fit distortion parameters in Y direction, forward mapping
-                res = scipy.optimize.minimize(
-                    _calcSkyResidualsDistortion,
+                res = _lstsqFit(
+                    _calcSkyResidualsDistortionVect,
                     self.y_poly_fwd,
-                    args=(self, jd, catalog_stars, img_stars, 'y'),
-                    method='Nelder-Mead',
-                    options={'maxiter': 10000, 'adaptive': True},
+                    (self, jd, catalog_stars, img_stars, 'y'),
                 )
 
                 # IMPORTANT NOTE - the X polynomial is used to store the fit parameters
@@ -1372,6 +1410,9 @@ class Platepar(object):
                             ransac_opts = opt_options_ransac_r5
                         else:
                             ransac_opts = opt_options_ransac_r7
+                        # Kept on Nelder-Mead: the NN cost is non-smooth (nearest-neighbour
+                        # assignment jumps as params move), so a gradient/least-squares method
+                        # is unreliable here. The smooth matched-pair paths use _lstsqFit.
                         res = scipy.optimize.minimize(
                             cost_func, start_params,
                             args=(self, jd, catalog_stars_fov, img_stars_subset),
@@ -1591,11 +1632,10 @@ class Platepar(object):
                         # Prototype: Levenberg-Marquardt least-squares on the vector residual.
                         # Converges in far fewer evals than Nelder-Mead and lands on the same
                         # (or lower-residual) least-squares minimum.
-                        res = scipy.optimize.least_squares(
+                        res = _lstsqFit(
                             _calcSkyResidualsAstroAndDistortionRadialVect,
                             p0,
-                            args=(self, jd, catalog_stars, img_stars),
-                            method='lm', ftol=1e-12, xtol=1e-12, gtol=1e-12,
+                            (self, jd, catalog_stars, img_stars),
                         )
                         fwd_status = "converged" if res.success else "stopped"
 
@@ -1622,11 +1662,10 @@ class Platepar(object):
                         # cameras with extreme distortion center offset where the optimizer
                         # can diverge when starting from zeros
                         rev_init = self.x_poly_fwd.copy()
-                        res_rev = scipy.optimize.least_squares(
+                        res_rev = _lstsqFit(
                             _calcImageResidualsDistortionVect,
                             rev_init,
-                            args=(self, jd, catalog_stars, img_stars, 'radial'),
-                            method='lm', ftol=1e-12, xtol=1e-12, gtol=1e-12,
+                            (self, jd, catalog_stars, img_stars, 'radial'),
                         )
                         rev_status = "converged" if res_rev.success else "stopped"
 

--- a/RMS/Formats/Platepar.py
+++ b/RMS/Formats/Platepar.py
@@ -1137,11 +1137,15 @@ class Platepar(object):
 
                 ### ###
 
-                # If this is the first fit of the distortion, set the forward parameters to be equal to the reverse
-                if first_platepar_fit:
-
-                    self.x_poly_fwd = np.array(self.x_poly_rev)
-                    self.y_poly_fwd = np.array(self.y_poly_rev)
+                # Always seed the forward fit from the freshly-fit reverse polynomial. The reverse
+                # fit is robust (pixel residual) and forward ~ reverse for the distortion, so this
+                # is a good starting point. Seeding from a stale/garbage x_poly_fwd (e.g. on a
+                # manual re-fit, or after a distortion-type change) can leave the forward fit stuck
+                # far from the solution because the sky-residual objective saturates -- producing a
+                # broken forward mapping (catalog overlay far off) while the reverse, and the RMSD,
+                # still look fine.
+                self.x_poly_fwd = np.array(self.x_poly_rev)
+                self.y_poly_fwd = np.array(self.y_poly_rev)
 
                 ### FORWARD MAPPING FIT ###
 

--- a/RMS/Formats/Platepar.py
+++ b/RMS/Formats/Platepar.py
@@ -1743,6 +1743,17 @@ class Platepar(object):
                     self.x_poly_rev = np.array(xf[4:])
                     self.updateRefAltAz()
 
+                    # The joint fit above moved the pointing, which leaves the forward distortion
+                    # (fit to the previous pointing) stale -- the forward and reverse mappings
+                    # would disagree (broken image<->sky round-trip). Re-fit the forward
+                    # distortion to the refined pointing so the two mappings stay consistent.
+                    res_fwd = _lstsqFit(
+                        _calcSkyResidualsDistortionVect,
+                        self.x_poly_fwd,
+                        (self, jd, catalog_stars, img_stars, 'radial'),
+                    )
+                    self.x_poly_fwd = res_fwd.x
+
                 ### ###
 
         else:

--- a/RMS/Formats/Platepar.py
+++ b/RMS/Formats/Platepar.py
@@ -158,6 +158,16 @@ def _lstsqFit(residual_func, x0, args):
         residual_func, x0, args=args, method=method, ftol=1e-12, xtol=1e-12, gtol=1e-12)
 
 
+def _raDecToUnitVectors(ra_deg, dec_deg):
+    """Convert RA/Dec arrays (degrees) to 3D unit vectors. Euclidean nearest-neighbour on unit
+    vectors gives the same result as angular nearest-neighbour, so a cKDTree of these vectors
+    replaces an O(N*M) angular-separation matrix with an O(N log M) query."""
+    ra = np.radians(ra_deg)
+    dec = np.radians(dec_deg)
+    cos_dec = np.cos(dec)
+    return np.column_stack([cos_dec*np.cos(ra), cos_dec*np.sin(ra), np.sin(dec)])
+
+
 class Platepar(object):
     def __init__(self, distortion_type="radial7-odd"):
         """Astrometric and photometric calibration plate parameters. Several distortion types are supported.
@@ -994,7 +1004,8 @@ class Platepar(object):
                 np.radians(ra_catalog), np.radians(dec_catalog),
             )
 
-        def _calcSkyResidualsAstroAndDistortionRadialNN(params, platepar, jd, catalog_stars, img_stars):
+        def _calcSkyResidualsAstroAndDistortionRadialNN(params, platepar, jd, catalog_stars, img_stars,
+                                                        cat_tree=None):
             """Like _calcSkyResidualsAstroAndDistortionRadial but uses nearest-neighbor matching.
 
             Instead of requiring pre-matched pairs, this finds the nearest catalog star for each
@@ -1030,18 +1041,24 @@ class Platepar(object):
             # Convert detected image positions to sky coordinates
             ra_det, dec_det = getPairedStarsSkyPositions(img_x, img_y, jd, pp_copy)
 
-            # Catalog is pre-filtered to FOV by caller - no need to re-filter here
-            ra_catalog, dec_catalog, _ = catalog_stars.T
+            if cat_tree is not None:
+                # Fast path: query a prebuilt KD-tree of catalog unit vectors. Same nearest
+                # neighbour as the matrix below, but O(N log M) instead of O(N*M) per eval.
+                chord_dist, _ = cat_tree.query(_raDecToUnitVectors(ra_det, dec_det), k=1)
+                nn_distances = 2.0*np.arcsin(np.clip(chord_dist/2.0, 0.0, 1.0))  # chord -> angle
+            else:
+                # Catalog is pre-filtered to FOV by caller - no need to re-filter here
+                ra_catalog, dec_catalog, _ = catalog_stars.T
 
-            # Vectorized NN: compute NxM angular separation matrix, then take row-wise min
-            ra_det_rad = np.radians(ra_det)[:, np.newaxis]  # (N, 1)
-            dec_det_rad = np.radians(dec_det)[:, np.newaxis]  # (N, 1)
-            ra_cat_rad = np.radians(ra_catalog)[np.newaxis, :]  # (1, M)
-            dec_cat_rad = np.radians(dec_catalog)[np.newaxis, :]  # (1, M)
+                # Vectorized NN: compute NxM angular separation matrix, then take row-wise min
+                ra_det_rad = np.radians(ra_det)[:, np.newaxis]  # (N, 1)
+                dec_det_rad = np.radians(dec_det)[:, np.newaxis]  # (N, 1)
+                ra_cat_rad = np.radians(ra_catalog)[np.newaxis, :]  # (1, M)
+                dec_cat_rad = np.radians(dec_catalog)[np.newaxis, :]  # (1, M)
 
-            # angularSeparation broadcasts to (N, M) separation matrix
-            sep_matrix = angularSeparation(ra_det_rad, dec_det_rad, ra_cat_rad, dec_cat_rad)
-            nn_distances = np.min(sep_matrix, axis=1)  # (N,)
+                # angularSeparation broadcasts to (N, M) separation matrix
+                sep_matrix = angularSeparation(ra_det_rad, dec_det_rad, ra_cat_rad, dec_cat_rad)
+                nn_distances = np.min(sep_matrix, axis=1)  # (N,)
             total_cost = np.sum(nn_distances ** 2)
 
             return total_cost
@@ -1413,9 +1430,14 @@ class Platepar(object):
                         # Kept on Nelder-Mead: the NN cost is non-smooth (nearest-neighbour
                         # assignment jumps as params move), so a gradient/least-squares method
                         # is unreliable here. The smooth matched-pair paths use _lstsqFit.
+                        # Speedup: build a catalog KD-tree once per iteration so each NN cost
+                        # eval is O(N log M) instead of rebuilding an N×M matrix (~80x fewer
+                        # ops/eval, identical nearest-neighbour result).
+                        ra_cat_fov, dec_cat_fov, _ = catalog_stars_fov.T
+                        cat_tree = cKDTree(_raDecToUnitVectors(ra_cat_fov, dec_cat_fov))
                         res = scipy.optimize.minimize(
                             cost_func, start_params,
-                            args=(self, jd, catalog_stars_fov, img_stars_subset),
+                            args=(self, jd, catalog_stars_fov, img_stars_subset, cat_tree),
                             method='Nelder-Mead', options=ransac_opts,
                         )
 

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -1853,26 +1853,12 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
 
         box.addWidget(QtWidgets.QLabel("Residuals:"))
 
-        # RMSD display label with color coding
+        # RMSD display label with color coding. Shows the simple px RMSD; the forward/reverse
+        # consistency and held-out overfitting checks run internally on every fit and turn this
+        # label red when either trips (the detailed numbers are printed to the console).
         self.rmsd_label = QtWidgets.QLabel("--")
         self.rmsd_label.setStyleSheet("font-weight: bold; font-size: 12pt;")
         box.addWidget(self.rmsd_label)
-
-        # Cross-validated (held-out) RMSD: honest generalisation / overfitting check. Opt-in
-        # (it runs several extra fits), so it is a button rather than automatic. The fit itself
-        # always uses all stars; this only measures how well that fit generalises.
-        self.check_overfit_button = QtWidgets.QPushButton("Check overfit (held-out RMSD)")
-        self.check_overfit_button.setToolTip(
-            "K-fold cross-validation: fit on subsets of the stars and measure RMSD on the "
-            "held-out stars. A held-out RMSD close to the in-sample RMSD means the fit is not "
-            "overfitting. Runs several extra fits, so it is not automatic.")
-        self.check_overfit_button.clicked.connect(self.gui.checkFitOverfit)
-        box.addWidget(self.check_overfit_button)
-
-        self.cv_rmsd_label = QtWidgets.QLabel("")
-        self.cv_rmsd_label.setStyleSheet("font-size: 9pt;")
-        self.cv_rmsd_label.setWordWrap(True)
-        box.addWidget(self.cv_rmsd_label)
 
         hbox = QtWidgets.QHBoxLayout()
         hbox.setSpacing(self.scaledSpacing(0.25))  # Reduce spacing between buttons
@@ -2382,13 +2368,18 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         # Update restore defaults button state
         self.updateRestoreDefaultsButton()
 
-    def updateRMSD(self, rmsd_img, rmsd_angular, angular_error_label, fwdrev_mismatch=False):
+    def updateRMSD(self, rmsd_img, rmsd_angular, angular_error_label, fwdrev_mismatch=False,
+                   overfit=False):
         """Update the RMSD display with color coding based on pixel RMSD.
 
-        rmsd_img is the reverse (catalog->image) residual in px -- its natural unit. rmsd_angular
-        is the forward (image->sky) residual in its natural angular unit. fwdrev_mismatch flags
-        that the two mappings disagree (a broken/inconsistent distortion mapping), which is shown
-        in red regardless of how good the reverse RMSD looks.
+        The label shows the plain RMSD (reverse residual in px and forward residual in angular
+        units). Two health checks run internally on every fit and, when either trips, override the
+        color to red so a good-looking RMSD can't hide a broken fit (the detailed numbers behind
+        both checks are printed to the console):
+            - fwdrev_mismatch: the forward and reverse distortion mappings disagree, so the catalog
+              overlay will be off even though the reverse RMSD looks fine.
+            - overfit: the held-out (cross-validated) RMSD is much worse than in-sample, i.e. the
+              model is fitting centroid noise rather than the true distortion.
 
         Thresholds are normalized to 1280x720 resolution:
             - < 0.2 px: Excellent (green)
@@ -2397,7 +2388,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
             - < 0.5 px: Marginal (orange)
             - >= 0.5 px: Poor (red)
         """
-        text = "{:.2f} px (rev), {:.2f} {:s} (fwd)".format(rmsd_img, rmsd_angular, angular_error_label)
+        text = "{:.2f} px, {:.2f} {:s}".format(rmsd_img, rmsd_angular, angular_error_label)
 
         # Scale thresholds by resolution (reference: 720p)
         scale = self.gui.platepar.Y_res / 720.0
@@ -2413,18 +2404,18 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         else:
             color = "#DC143C"  # Crimson - poor
 
-        # A forward/reverse mapping mismatch means the platepar is broken even if the reverse
-        # RMSD looks good -- override to red and say so.
+        # Internal health checks override the color to red regardless of how good the RMSD looks.
+        flags = []
         if fwdrev_mismatch:
-            text += "  MAPPING MISMATCH"
+            flags.append("MAPPING MISMATCH")
+        if overfit:
+            flags.append("OVERFIT")
+        if flags:
+            text += "  " + " / ".join(flags)
             color = "#DC143C"
 
         self.rmsd_label.setText(text)
         self.rmsd_label.setStyleSheet("font-weight: bold; font-size: 12pt; color: {};".format(color))
-
-        # A new fit invalidates any previous held-out (cross-validation) result
-        if hasattr(self, 'cv_rmsd_label'):
-            self.cv_rmsd_label.setText("")
 
     def onFitParametersChanged(self):
         # fit parameter object updates platepar by itself

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -3083,6 +3083,19 @@ class StarDetectionWidget(QtWidgets.QWidget, ScaledSizeHelper):
     def loadFromConfig(self, config):
         """Initialize sliders from config values."""
         if hasattr(config, 'intensity_threshold'):
+            # Give the threshold slider a bit-depth-appropriate maximum before setting the
+            # value, otherwise a high-bit-depth config threshold is silently clamped to the
+            # pre-existing default slider max (200, an arbitrary ceiling -- the 8-bit threshold
+            # range is nominally 0-255, with realistic values in the tens) at load, and the
+            # user has no headroom to adjust up without first running auto-tune. Raw-ADU
+            # thresholds scale with bit depth (~tens at 8-bit, hundreds-to-thousands at 16-bit),
+            # so use a gentle per-2-bit doubling (8->200, 12->800, 16->3200) and ensure headroom
+            # over the configured value. Never lower the existing max, so 8-bit keeps its 200.
+            bit_depth = getattr(config, 'bit_depth', 8)
+            bitdepth_default_max = 200*2**max(0, (bit_depth - 8)//2)
+            thr_max = max(self.intensity_threshold_slider.maximum(), bitdepth_default_max,
+                          int(config.intensity_threshold*3))
+            self.intensity_threshold_slider.setMaximum(thr_max)
             self.intensity_threshold_slider.setValue(config.intensity_threshold)
         if hasattr(config, 'neighborhood_size'):
             self.neighborhood_size_slider.setValue(config.neighborhood_size)

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -2382,13 +2382,13 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         # Update restore defaults button state
         self.updateRestoreDefaultsButton()
 
-    def updateRMSD(self, rmsd_img, rmsd_angular, angular_error_label, rmsd_fwd_px=None):
+    def updateRMSD(self, rmsd_img, rmsd_angular, angular_error_label, fwdrev_mismatch=False):
         """Update the RMSD display with color coding based on pixel RMSD.
 
-        rmsd_img is the reverse (catalog->image) RMSD. rmsd_fwd_px, if given, is the forward
-        (image->sky) RMSD expressed in px: when the distortion is healthy it matches rmsd_img;
-        a large mismatch means the forward and reverse mappings disagree (broken mapping), which
-        is shown in red regardless of how good the reverse RMSD looks.
+        rmsd_img is the reverse (catalog->image) residual in px -- its natural unit. rmsd_angular
+        is the forward (image->sky) residual in its natural angular unit. fwdrev_mismatch flags
+        that the two mappings disagree (a broken/inconsistent distortion mapping), which is shown
+        in red regardless of how good the reverse RMSD looks.
 
         Thresholds are normalized to 1280x720 resolution:
             - < 0.2 px: Excellent (green)
@@ -2397,7 +2397,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
             - < 0.5 px: Marginal (orange)
             - >= 0.5 px: Poor (red)
         """
-        text = "{:.2f} px, {:.2f} {:s}".format(rmsd_img, rmsd_angular, angular_error_label)
+        text = "{:.2f} px (rev), {:.2f} {:s} (fwd)".format(rmsd_img, rmsd_angular, angular_error_label)
 
         # Scale thresholds by resolution (reference: 720p)
         scale = self.gui.platepar.Y_res / 720.0
@@ -2413,12 +2413,11 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         else:
             color = "#DC143C"  # Crimson - poor
 
-        # Forward/reverse consistency check
-        if rmsd_fwd_px is not None:
-            text += " | fwd {:.2f} px".format(rmsd_fwd_px)
-            if rmsd_fwd_px > 2.0*rmsd_img + 0.3:
-                text += "  MAPPING MISMATCH"
-                color = "#DC143C"  # broken mapping overrides the (good-looking) reverse RMSD
+        # A forward/reverse mapping mismatch means the platepar is broken even if the reverse
+        # RMSD looks good -- override to red and say so.
+        if fwdrev_mismatch:
+            text += "  MAPPING MISMATCH"
+            color = "#DC143C"
 
         self.rmsd_label.setText(text)
         self.rmsd_label.setStyleSheet("font-weight: bold; font-size: 12pt; color: {};".format(color))

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -458,6 +458,14 @@ class ImageItem(pg.ImageItem):
         """
         self.img_handle = img_handle
 
+        # Display-LUT state. Replaces the old copy-pasted render() override that
+        #   reached into pyqtgraph internals (self._effectiveLut etc.), which broke on
+        #   pyqtgraph >= 0.13. _base_lut holds any LUT pushed by the histogram (None for
+        #   a plain grayscale gradient); gamma and inversion are composed on top of it.
+        self._base_lut = None
+        self._gamma = 1
+        self.invert_img = False
+
         if 'saturation_threshold' in kwargs:
             self.saturation_threshold = kwargs.pop('saturation_threshold')
         else:
@@ -492,6 +500,9 @@ class ImageItem(pg.ImageItem):
             self.flat_struct = kwargs['flat_struct']
         else:
             self.flat_struct = None
+
+        # Apply the initial display LUT now that gamma/inversion are known
+        self._applyDisplayLut(update=False)
 
         if img_handle is not None:
             self.avepixel()
@@ -762,14 +773,14 @@ class ImageItem(pg.ImageItem):
         elif self._gamma > 10:
             self._gamma = old
 
-        self.updateImage()
+        self._applyDisplayLut()
 
     def updateGamma(self, factor):
         self.setGamma(self.gamma*factor)
 
     def invert(self):
         self.invert_img = not self.invert_img
-        self.updateImage()
+        self._applyDisplayLut()
 
     def autopan(self):
         self.autopan_chk = not self.autopan_chk
@@ -778,91 +789,47 @@ class ImageItem(pg.ImageItem):
         super().setLevels(levels, update)
         self.sigLevelsChanged.emit()
 
-    def render(self):
-        # THIS WAS COPY PASTED FROM SOURCE CODE AND WAS SLIGHTLY
-        # CHANGED TO IMPLEMENT GAMMA AND INVERT
+    def setLookupTable(self, lut, update=True):
+        # The histogram pushes its gradient LUT here (None for a plain grayscale
+        #   gradient). Keep it as the base so gamma/inversion can be re-composed on top
+        #   whenever they change, then hand pyqtgraph the effective LUT.
+        self._base_lut = lut
+        super().setLookupTable(self._composeDisplayLut(lut), update=update)
 
-        # Convert data to QImage for display.
+    def _applyDisplayLut(self, update=True):
+        """ Rebuild and apply the effective display LUT from the current base LUT,
+            gamma and inversion. Used instead of overriding render(), so we no longer
+            depend on pyqtgraph render internals. """
+        super().setLookupTable(self._composeDisplayLut(self._base_lut), update=update)
 
-        profile = pg.debug.Profiler()
-        if self.image is None or self.image.size == 0:
-            return
-        if callable(self.lut):
-            lut = self.lut(self.image)
+    def _composeDisplayLut(self, base_lut):
+        """ Build the grayscale lookup table that bakes in gamma and inversion.
+
+        The old render() applied gamma to the post-levels 8-bit luminance and forced
+        R = G = B. pyqtgraph maps levels -> LUT index, so a 256-entry grayscale ramp
+        carrying gamma/inversion reproduces gamma(rescale(value)) exactly (for 8-bit the
+        LUT index equals the rescaled value). An optional base LUT (e.g. a non-trivial
+        histogram gradient) is composed underneath.
+        """
+        if base_lut is None:
+            n = 256
+            rgb = np.repeat(np.linspace(0, 255, n)[:, None], 3, axis=1)
+            alpha = None
         else:
-            lut = self.lut
+            base_lut = np.asarray(base_lut)
+            rgb = base_lut[:, :3].astype(float)
+            alpha = base_lut[:, 3:4] if base_lut.shape[1] == 4 else None
 
-        if self.autoDownsample:
-            # reduce dimensions of image based on screen resolution
-            o = self.mapToDevice(pg.QtCore.QPointF(0, 0))
-            x = self.mapToDevice(pg.QtCore.QPointF(1, 0))
-            y = self.mapToDevice(pg.QtCore.QPointF(0, 1))
-            w = pg.Point(x - o).length()
-            h = pg.Point(y - o).length()
-            if w == 0 or h == 0:
-                self.qimage = None
-                return
-            xds = max(1, int(1.0/w))
-            yds = max(1, int(1.0/h))
-            axes = [1, 0] if self.axisOrder == 'row-major' else [0, 1]
-            image = pgfn.downsample(self.image, xds, axis=axes[0])
-            image = pgfn.downsample(image, yds, axis=axes[1])
-            self._lastDownsample = (xds, yds)
-        else:
-            image = self.image
-
-        # if the image data is a small int, then we can combine levels + lut
-        # into a single lut for better performance
-        levels = self.levels
-
-        if (levels is not None) and (levels.ndim == 1) and (image.dtype in (np.ubyte, np.uint16)):
-
-            if self._effectiveLut is None:
-
-                eflsize = 2**(image.itemsize*8)
-                ind = np.arange(eflsize)
-                minlev, maxlev = levels
-                levdiff = maxlev - minlev
-                levdiff = 1 if levdiff == 0 else levdiff  # don't allow division by 0
-
-                if lut is None:
-                    efflut = pgfn.rescaleData(ind, scale=255./levdiff,
-                                               offset=minlev, dtype=np.ubyte)
-                else:
-                    lutdtype = np.min_scalar_type(lut.shape[0] - 1)
-                    efflut = pgfn.rescaleData(ind, scale=(lut.shape[0] - 1)/levdiff, \
-                                               offset=minlev, dtype=lutdtype, clip=(0, lut.shape[0] - 1))
-                    efflut = lut[efflut]
-
-                self._effectiveLut = efflut
-
-            lut = self._effectiveLut
-            levels = None
-
-
-        # Assume images are in column-major order for backward compatibility
-        # (most images are in row-major order)
-
-        if self.axisOrder == 'col-major':
-            image = image.transpose((1, 0, 2)[:image.ndim])
-
-        # Make an RGB image
-        argb, alpha = pgfn.makeARGB(image, lut=lut, levels=levels)
-        
-        # Perform gamma correction on only one channel to speed things up
-        argb[:, :, 0] = np.clip(np.power(argb[:, :, 0]/255, 1/self._gamma)*255, 0, 255)
-        argb[:, :, 1] = argb[:, :, 0]
-        argb[:, :, 2] = argb[:, :, 0]
-
-        
-        # Invert image colors
+        # Gamma on the displayed luminance, then optional inversion
+        out = np.clip(np.power(rgb/255.0, 1.0/self._gamma)*255.0, 0, 255)
         if self.invert_img:
-            argb[:, :, 0] = 255 - argb[:, :, 0]
-            argb[:, :, 1] = argb[:, :, 0]
-            argb[:, :, 2] = argb[:, :, 0]
+            out = 255.0 - out
+        out = out.astype(np.ubyte)
 
+        if alpha is not None:
+            out = np.concatenate([out, alpha.astype(np.ubyte)], axis=1)
 
-        self.qimage = pgfn.makeQImage(argb, alpha, transpose=False)
+        return out
 
 
 class CursorItem(pg.GraphicsObject):

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -2382,8 +2382,13 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         # Update restore defaults button state
         self.updateRestoreDefaultsButton()
 
-    def updateRMSD(self, rmsd_img, rmsd_angular, angular_error_label):
+    def updateRMSD(self, rmsd_img, rmsd_angular, angular_error_label, rmsd_fwd_px=None):
         """Update the RMSD display with color coding based on pixel RMSD.
+
+        rmsd_img is the reverse (catalog->image) RMSD. rmsd_fwd_px, if given, is the forward
+        (image->sky) RMSD expressed in px: when the distortion is healthy it matches rmsd_img;
+        a large mismatch means the forward and reverse mappings disagree (broken mapping), which
+        is shown in red regardless of how good the reverse RMSD looks.
 
         Thresholds are normalized to 1280x720 resolution:
             - < 0.2 px: Excellent (green)
@@ -2407,6 +2412,13 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
             color = "#FF8C00"  # Dark orange - marginal
         else:
             color = "#DC143C"  # Crimson - poor
+
+        # Forward/reverse consistency check
+        if rmsd_fwd_px is not None:
+            text += " | fwd {:.2f} px".format(rmsd_fwd_px)
+            if rmsd_fwd_px > 2.0*rmsd_img + 0.3:
+                text += "  MAPPING MISMATCH"
+                color = "#DC143C"  # broken mapping overrides the (good-looking) reverse RMSD
 
         self.rmsd_label.setText(text)
         self.rmsd_label.setStyleSheet("font-weight: bold; font-size: 12pt; color: {};".format(color))

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -1858,6 +1858,22 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         self.rmsd_label.setStyleSheet("font-weight: bold; font-size: 12pt;")
         box.addWidget(self.rmsd_label)
 
+        # Cross-validated (held-out) RMSD: honest generalisation / overfitting check. Opt-in
+        # (it runs several extra fits), so it is a button rather than automatic. The fit itself
+        # always uses all stars; this only measures how well that fit generalises.
+        self.check_overfit_button = QtWidgets.QPushButton("Check overfit (held-out RMSD)")
+        self.check_overfit_button.setToolTip(
+            "K-fold cross-validation: fit on subsets of the stars and measure RMSD on the "
+            "held-out stars. A held-out RMSD close to the in-sample RMSD means the fit is not "
+            "overfitting. Runs several extra fits, so it is not automatic.")
+        self.check_overfit_button.clicked.connect(self.gui.checkFitOverfit)
+        box.addWidget(self.check_overfit_button)
+
+        self.cv_rmsd_label = QtWidgets.QLabel("")
+        self.cv_rmsd_label.setStyleSheet("font-size: 9pt;")
+        self.cv_rmsd_label.setWordWrap(True)
+        box.addWidget(self.cv_rmsd_label)
+
         hbox = QtWidgets.QHBoxLayout()
         hbox.setSpacing(self.scaledSpacing(0.25))  # Reduce spacing between buttons
         self.astrometry_button = QtWidgets.QPushButton('Astrometry')
@@ -2394,6 +2410,10 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
 
         self.rmsd_label.setText(text)
         self.rmsd_label.setStyleSheet("font-weight: bold; font-size: 12pt; color: {};".format(color))
+
+        # A new fit invalidates any previous held-out (cross-validation) result
+        if hasattr(self, 'cv_rmsd_label'):
+            self.cv_rmsd_label.setText("")
 
     def onFitParametersChanged(self):
         # fit parameter object updates platepar by itself

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -2658,6 +2658,12 @@ class PlateTool(QtWidgets.QMainWindow):
         self.load_state_action = QtWidgets.QAction("Load state")
         self.load_state_action.triggered.connect(self.findLoadState)
 
+        self.save_pairs_action = QtWidgets.QAction("Save matched pairs")
+        self.save_pairs_action.triggered.connect(self.savePairs)
+
+        self.load_pairs_action = QtWidgets.QAction("Load matched pairs")
+        self.load_pairs_action.triggered.connect(self.loadPairs)
+
         self.toggle_info_action = QtWidgets.QAction("Toggle Info")
         self.toggle_info_action.triggered.connect(self.toggleInfo)
         self.toggle_info_action.setShortcut('F1')
@@ -3498,6 +3504,8 @@ class PlateTool(QtWidgets.QMainWindow):
                                        self.save_state_platepar_action,
                                        self.quick_save_platepar_action,
                                        self.load_state_action])
+            self.file_menu.addSeparator()
+            self.file_menu.addActions([self.save_pairs_action, self.load_pairs_action])
             self.file_menu.addSeparator()
             self.file_menu.addAction(self.calibration_files_action)
 
@@ -8697,6 +8705,9 @@ class PlateTool(QtWidgets.QMainWindow):
             self.updateFitResiduals()
             self.residual_text.clear()
 
+            # Hint if this image has saved matched pairs available to load
+            self.pairsHint()
+
             # Clear satellite tracks when image changes (they're time-specific)
             self.clearSatelliteTracks()
             
@@ -8948,6 +8959,135 @@ class PlateTool(QtWidgets.QMainWindow):
             
         savePickle(dic, self.dir_path, 'skyFitMR_latest.state')
         print("Saved state to file")
+
+
+    def _pairsFilePath(self):
+        """ Path to the folder-level matched-pairs file (one file per data folder). """
+        return os.path.join(self.dir_path, 'skyfit_matched_pairs.json')
+
+
+    def _currentImageKey(self):
+        """ Stable identifier for the current image/chunk. Matched pairs are per-image (the
+            detected x,y belong to the displayed image), so saved pairs are keyed by this. """
+        try:
+            return str(self.img_handle.name())
+        except Exception:
+            return "unknown"
+
+
+    def savePairs(self):
+        """ Save the current image's matched star pairs into the folder-level pairs file,
+            keyed by image. Pairs saved for other images in the folder are preserved. """
+
+        if len(self.paired_stars) == 0:
+            qmessagebox(message="No matched pairs on the current image to save.",
+                        title="Save pairs", message_type="warning")
+            return
+
+        # Serialize current pairs (skip geo points - they reference external arrays and
+        # cannot be reconstructed standalone)
+        pairs = []
+        n_skipped = 0
+        for x, y, fwhm, intens_acc, obj, snr, saturated in self.paired_stars.paired_stars:
+            if getattr(obj, 'pick_type', 'star') == 'geopoint':
+                n_skipped += 1
+                continue
+            ra, dec, mag = obj.coords()
+            pairs.append({'x': float(x), 'y': float(y), 'fwhm': float(fwhm),
+                          'intens_acc': float(intens_acc), 'snr': float(snr),
+                          'saturated': bool(saturated),
+                          'ra': float(ra), 'dec': float(dec), 'mag': float(mag),
+                          'type': getattr(obj, 'pick_type', 'star')})
+
+        path = self._pairsFilePath()
+
+        # Merge into the existing folder-level file so other images' pairs are kept
+        data = {'format': 'skyfit_matched_pairs', 'version': 1, 'images': {}}
+        if os.path.isfile(path):
+            try:
+                with open(path) as f:
+                    existing = json.load(f)
+                if isinstance(existing, dict) and existing.get('format') == 'skyfit_matched_pairs':
+                    data = existing
+                    data.setdefault('images', {})
+            except Exception:
+                pass  # corrupt/unreadable - start fresh
+
+        key = self._currentImageKey()
+        try:
+            jd = date2JD(*self.img_handle.currentTime())
+        except Exception:
+            jd = None
+        data['images'][key] = {'jd': jd, 'pairs': pairs}
+
+        with open(path, 'w') as f:
+            json.dump(data, f, indent=1)
+
+        msg = "Saved {} matched pairs for '{}'".format(len(pairs), key)
+        if n_skipped:
+            msg += " ({} geo points skipped)".format(n_skipped)
+        print(msg)
+        self.status_bar.showMessage(msg)
+
+
+    def loadPairs(self):
+        """ Load matched pairs for the CURRENT image from the folder-level pairs file.
+            Pairs are per-image, so only the current image's saved entry is restored. """
+
+        path = self._pairsFilePath()
+        if not os.path.isfile(path):
+            qmessagebox(message="No saved pairs file in this folder.",
+                        title="Load pairs", message_type="warning")
+            return
+
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except Exception as e:
+            qmessagebox(message="Could not read pairs file:\n{}".format(e),
+                        title="Load pairs", message_type="warning")
+            return
+
+        images = data.get('images', {}) if isinstance(data, dict) else {}
+        key = self._currentImageKey()
+        if key not in images:
+            avail = ", ".join(sorted(images.keys())[:8])
+            qmessagebox(message="No saved pairs for the current image ('{}').\n\n"
+                                "Images with saved pairs: {}".format(key, avail or "none"),
+                        title="Load pairs", message_type="warning")
+            return
+
+        new_pairs = PairedStars()
+        for p in images[key].get('pairs', []):
+            star = CatalogStar(p['ra'], p['dec'], p['mag'])
+            new_pairs.addPair(p['x'], p['y'], p['fwhm'], p['intens_acc'], star,
+                              snr=p.get('snr', 0), saturated=p.get('saturated', False))
+
+        self.paired_stars = new_pairs
+        self.updatePairedStars()
+
+        msg = "Loaded {} matched pairs for '{}'".format(len(new_pairs), key)
+        print(msg)
+        self.status_bar.showMessage(msg)
+
+
+    def pairsHint(self):
+        """ If the folder pairs file has saved pairs for the current image, show a status-bar
+            hint. Called on image navigation; silent if there is nothing saved. """
+        try:
+            path = self._pairsFilePath()
+            if not os.path.isfile(path):
+                return
+            with open(path) as f:
+                data = json.load(f)
+            images = data.get('images', {}) if isinstance(data, dict) else {}
+            entry = images.get(self._currentImageKey())
+            if entry and len(entry.get('pairs', [])) > 0:
+                self.status_bar.showMessage(
+                    "{} saved matched pairs available for this image "
+                    "(File → Load matched pairs)".format(len(entry['pairs'])))
+        except Exception:
+            pass
 
 
     def findLoadState(self):

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -14830,6 +14830,119 @@ class PlateTool(QtWidgets.QMainWindow):
         return min_stars
 
 
+    def crossValidatedRMSD(self, n_folds=5, min_stars=50):
+        """ K-fold cross-validated, per-star image RMSD (px).
+
+        Splits the matched pairs into n_folds groups; for each group, fits the platepar on the
+        other folds and measures the per-star RMSD on the held-out group, then averages. This
+        is an honest "how well does the fit generalise to stars it was not fit on" number -- the
+        gap between it and the in-sample RMSD is a direct overfitting check (a flexible model
+        that fits centroid noise will show a large gap).
+
+        The live platepar is NOT modified. Interactive-tool feature only; the batch RMS pipeline
+        does not pay this cost. Returns (held_out_rmsd_px, n_folds_used) or None if there are too
+        few stars to split meaningfully.
+        """
+
+        import io as _io
+        import contextlib as _ctx
+
+        img_stars = np.array(self.paired_stars.imageCoords())
+        catalog_stars = np.array(self.paired_stars.skyCoords())
+        n = len(img_stars)
+
+        # Need enough stars that a fold still has plenty to fit and the held-out RMSD is stable
+        min_fit = self.getMinFitStars()
+        if (n < min_stars) or (n < (min_fit + 1)*2):
+            return None
+
+        n_folds = int(min(n_folds, n // max(min_fit + 1, 1)))
+        if n_folds < 2:
+            return None
+
+        jd = date2JD(*self.img_handle.currentTime())
+
+        rng = np.random.RandomState(0)  # deterministic across calls
+        folds = np.array_split(rng.permutation(n), n_folds)
+
+        held_sq = []
+        for k in range(n_folds):
+            test = folds[k]
+            train = np.concatenate([folds[j] for j in range(n_folds) if j != k])
+            if len(train) < min_fit:
+                return None
+
+            pp = copy.deepcopy(self.platepar)
+            try:
+                # Suppress the per-fit console spam from the fold fits
+                with _ctx.redirect_stdout(_io.StringIO()):
+                    pp.fitAstrometry(jd, img_stars[train], catalog_stars[train],
+                                     first_platepar_fit=False,
+                                     fit_only_pointing=self.fit_only_pointing,
+                                     fixed_scale=self.fixed_scale)
+            except Exception:
+                return None
+
+            cat_x, cat_y, _ = getCatalogStarsImagePositions(catalog_stars[test], jd, pp)
+            dx = cat_x - img_stars[test][:, 0]
+            dy = cat_y - img_stars[test][:, 1]
+            held_sq.extend((dx**2 + dy**2).tolist())
+
+        if not held_sq:
+            return None
+
+        return float(np.sqrt(np.mean(held_sq))), n_folds
+
+
+    def checkFitOverfit(self):
+        """ Compute and report the cross-validated (held-out) RMSD for the current matched pairs,
+            as an overfitting check. Triggered from the menu (it runs n_folds extra fits, so it is
+            not automatic after every fit). """
+
+        if len(self.paired_stars) == 0:
+            qmessagebox(message="No matched pairs to evaluate.", title="Held-out RMSD",
+                        message_type="warning")
+            return
+
+        self.status_bar.showMessage("Computing held-out RMSD (cross-validation)...")
+        QtWidgets.QApplication.processEvents()
+
+        result = self.crossValidatedRMSD()
+        if result is None:
+            msg = "Need more matched pairs for a stable held-out RMSD (have {}).".format(
+                len(self.paired_stars))
+            print(msg)
+            self.status_bar.showMessage(msg)
+            return
+
+        cv_rmsd, n_folds = result
+
+        # In-sample RMSD for comparison
+        img_stars = np.array(self.paired_stars.imageCoords())
+        catalog_stars = np.array(self.paired_stars.skyCoords())
+        jd = date2JD(*self.img_handle.currentTime())
+        cat_x, cat_y, _ = getCatalogStarsImagePositions(catalog_stars, jd, self.platepar)
+        in_sample = float(np.sqrt(np.mean((cat_x - img_stars[:, 0])**2 + (cat_y - img_stars[:, 1])**2)))
+
+        gap = cv_rmsd - in_sample
+        msg = ("Held-out RMSD ({:d}-fold CV): {:.3f} px   in-sample: {:.3f} px   gap: {:+.3f} px"
+               .format(n_folds, cv_rmsd, in_sample, gap))
+        print("\n" + msg)
+        overfit = gap > 0.5*in_sample + 0.05
+        if overfit:
+            print("  -> large gap: the fit may be OVERFITTING (model too flexible for this many stars).")
+        else:
+            print("  -> gap is small: the fit generalises well (not overfitting).")
+        self.status_bar.showMessage(msg)
+
+        # Show it in the Fit Parameters tab next to the in-sample RMSD
+        color = "#DC143C" if overfit else "#228B22"  # crimson if overfitting, green if clean
+        self.tab.param_manager.cv_rmsd_label.setText(
+            "Held-out ({}-fold): {:.3f} px   (gap {:+.3f} px)".format(n_folds, cv_rmsd, gap))
+        self.tab.param_manager.cv_rmsd_label.setStyleSheet(
+            "font-size: 9pt; font-weight: bold; color: {};".format(color))
+
+
     def fitPickedStars(self):
         """ Fit stars that are manually picked. The function first only estimates the astrometry parameters
             without the distortion, then just the distortion parameters, then all together.

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -5355,14 +5355,16 @@ class PlateTool(QtWidgets.QMainWindow):
             self.config.segment_radius = original_segment_radius
             self.config.max_stars = original_max_stars
 
-            # Update sliders to the optimal values. Raise the threshold slider's maximum
-            # first if needed: its default max (200) is an 8-bit-era value, so a high-bit
-            # -depth tuned threshold would otherwise be silently clamped, leaving the
-            # re-detect running at the wrong (clamped) threshold. Mirrors the max_stars
-            # slider handling below.
+            # Update sliders to the optimal values. The threshold slider's default max (200)
+            # is an arbitrary pre-existing ceiling (the 8-bit threshold range is nominally
+            # 0-255, with realistic values in the tens), so on high-bit-depth data the tuned
+            # threshold can exceed it and be silently clamped (leaving the re-detect at the
+            # wrong threshold). Raise the max with headroom *above* the tuned value so the user
+            # can still override upward. Scale the headroom to the tuned value itself, since a
+            # reasonable ceiling differs greatly between 8-bit and 16-bit. Never lower the
+            # existing max, so 8-bit keeps its default 200.
             thr_slider = self.tab.star_detection.intensity_threshold_slider
-            if best_threshold > thr_slider.maximum():
-                thr_slider.setMaximum(int(best_threshold))
+            thr_slider.setMaximum(max(thr_slider.maximum(), int(best_threshold*3)))
             thr_slider.setValue(int(best_threshold))
             self.tab.star_detection.segment_radius_slider.setValue(best_segment)
 

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -5219,7 +5219,17 @@ class PlateTool(QtWidgets.QMainWindow):
             # Phase 2: Sweep intensity threshold from high to low with best segment
             # Continue until we see clear degradation, then analyze all results
             print(f"\n  Phase 2: Intensity threshold sweep (segment_radius={best_segment})")
-            intensity_values = list(range(40, 2, -1))  # 40 down to 3
+
+            # Scale the 8-bit sweep range (40..3) to the camera's working threshold so it
+            # brackets the usable range on high-bit-depth data. A fixed 8-bit sweep lands
+            # below the noise on 16-bit, floods the candidate list past max_stars, and aborts
+            # on the first step. 8-bit configs are unchanged (scale = 1, sweep = 40..3).
+            if getattr(self.config, 'bit_depth', 8) > 8:
+                thr_scale = max(1.0, self.config.intensity_threshold/20.0)
+            else:
+                thr_scale = 1.0
+            intensity_values = sorted({max(3, int(round(v*thr_scale))) for v in range(40, 2, -1)},
+                                      reverse=True)  # high -> low
 
             # Collect results - we'll analyze the full curve to find optimal point
             results = []  # (threshold, n_true_pos, n_false_pos, n_detected)
@@ -5345,8 +5355,15 @@ class PlateTool(QtWidgets.QMainWindow):
             self.config.segment_radius = original_segment_radius
             self.config.max_stars = original_max_stars
 
-            # Update sliders to the optimal values
-            self.tab.star_detection.intensity_threshold_slider.setValue(best_threshold)
+            # Update sliders to the optimal values. Raise the threshold slider's maximum
+            # first if needed: its default max (200) is an 8-bit-era value, so a high-bit
+            # -depth tuned threshold would otherwise be silently clamped, leaving the
+            # re-detect running at the wrong (clamped) threshold. Mirrors the max_stars
+            # slider handling below.
+            thr_slider = self.tab.star_detection.intensity_threshold_slider
+            if best_threshold > thr_slider.maximum():
+                thr_slider.setMaximum(int(best_threshold))
+            thr_slider.setValue(int(best_threshold))
             self.tab.star_detection.segment_radius_slider.setValue(best_segment)
 
             # Update catalog LM and reload catalog
@@ -5536,31 +5553,46 @@ class PlateTool(QtWidgets.QMainWindow):
             (best_segment, n_true_pos, fp_ratio): Tuple of optimal segment radius,
                 true positive count and false positive ratio from validation.
         """
-        # Use a generous segment_radius (12) and high threshold to detect bright stars
-        # segment=12 is large enough for almost any stellar PSF
+        # Use a generous segment_radius (12) to detect bright stars; segment=12 is large
+        # enough for almost any stellar PSF.
         probe_segment = 12
-        high_threshold = 25
+
+        # Probe for bright stars. A hardcoded 8-bit threshold (25) lands far below the noise
+        # on high-bit-depth data, flooding the candidate list past max_stars so extractStars
+        # returns nothing. Start at least at the camera's configured threshold and escalate
+        # until a workable detection comes back. 8-bit configs (threshold ~18-25) are
+        # unaffected -- they start at 25 exactly as before.
+        base_threshold = max(25, self.config.intensity_threshold)
+        probe_thresholds = [base_threshold, 2*base_threshold, 4*base_threshold, 8*base_threshold]
 
         try:
             # Save and set config
             orig_intensity = self.config.intensity_threshold
             orig_segment = self.config.segment_radius
-            self.config.intensity_threshold = high_threshold
             self.config.segment_radius = probe_segment
             self.config.max_feature_ratio = self.override_max_feature_ratio
             self.config.roundness_threshold = self.override_roundness_threshold
 
-            star_list = extractStarsFF(
-                self.dir_path, ff_name, config=self.config,
-                flat_struct=self.flat_struct, dark=self.dark, mask=self.mask
-            )
+            # Escalate the threshold until extractStarsFF returns stars. An empty result
+            # means either too many candidates (extractStars bails) or none detected;
+            # raising the threshold resolves the former, the high-bit-depth failure mode.
+            star_list = None
+            high_threshold = base_threshold
+            for high_threshold in probe_thresholds:
+                self.config.intensity_threshold = high_threshold
+                star_list = extractStarsFF(
+                    self.dir_path, ff_name, config=self.config,
+                    flat_struct=self.flat_struct, dark=self.dark, mask=self.mask
+                )
+                if star_list and len(star_list) >= 2 and len(star_list[1]) > 0:
+                    break
 
             self.config.intensity_threshold = orig_intensity
             self.config.segment_radius = orig_segment
 
             if not star_list or len(star_list[1]) == 0:
-                print(f"    No bright stars detected with threshold={high_threshold}, "
-                      f"segment={probe_segment}")
+                print(f"    No bright stars detected (probed thresholds "
+                      f"{base_threshold}..{probe_thresholds[-1]}, segment={probe_segment})")
                 print(f"    Using default segment_radius=4")
                 return 4, 0, 1.0
 

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -15107,9 +15107,18 @@ class PlateTool(QtWidgets.QMainWindow):
                 )
 
 
-        # Compute RMSD errors
+        # Compute RMSD errors.
+        #   rmsd_img    = reverse residual (catalog sky -> image, via x_poly_rev), in px
+        #   rmsd_angular= forward residual (image -> sky, via x_poly_fwd), in arcmin
         rmsd_angular = 60*RMSD([entry[4] for entry in residuals])
         rmsd_img = RMSD([entry[3] for entry in residuals])
+
+        # Forward residual expressed in px so it is directly comparable to the reverse RMSD.
+        # When the distortion is healthy the two agree; a large mismatch means the forward and
+        # reverse mappings disagree (e.g. a diverged forward polynomial) -- the catalog overlay
+        # will be off even though the (reverse) RMSD looks fine.
+        rmsd_fwd_px = RMSD([entry[4] for entry in residuals])*self.platepar.F_scale
+        fwdrev_mismatch = rmsd_fwd_px > 2.0*rmsd_img + 0.3
 
         # If the average angular error is larger than 60 arc minutes, report it in degrees
         if rmsd_angular > 60:
@@ -15124,10 +15133,16 @@ class PlateTool(QtWidgets.QMainWindow):
             angular_error_label = 'arcsec'
 
 
-        print('RMSD: {:.2f} px, {:.2f} {:s}'.format(rmsd_img, rmsd_angular, angular_error_label))
+        print('RMSD: {:.2f} px (reverse), {:.2f} px (forward), {:.2f} {:s}'.format(
+            rmsd_img, rmsd_fwd_px, rmsd_angular, angular_error_label))
+        if fwdrev_mismatch:
+            print('  WARNING: forward/reverse mapping mismatch (reverse {:.2f} px vs forward {:.2f} px) -- '
+                  'the distortion mapping is inconsistent and the catalog overlay will be off.'.format(
+                      rmsd_img, rmsd_fwd_px))
 
         # Update RMSD display in the Fit Parameters tab
-        self.tab.param_manager.updateRMSD(rmsd_img, rmsd_angular, angular_error_label)
+        self.tab.param_manager.updateRMSD(rmsd_img, rmsd_angular, angular_error_label,
+                                          rmsd_fwd_px=rmsd_fwd_px)
 
         # Update fit residuals in the station tab when geopoints are used
         if self.geo_points_obj is not None:

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -15113,12 +15113,14 @@ class PlateTool(QtWidgets.QMainWindow):
         rmsd_angular = 60*RMSD([entry[4] for entry in residuals])
         rmsd_img = RMSD([entry[3] for entry in residuals])
 
-        # Forward residual expressed in px so it is directly comparable to the reverse RMSD.
-        # When the distortion is healthy the two agree; a large mismatch means the forward and
-        # reverse mappings disagree (e.g. a diverged forward polynomial) -- the catalog overlay
-        # will be off even though the (reverse) RMSD looks fine.
-        rmsd_fwd_px = RMSD([entry[4] for entry in residuals])*self.platepar.F_scale
-        fwdrev_mismatch = rmsd_fwd_px > 2.0*rmsd_img + 0.3
+        # Forward/reverse consistency check. The two residuals live in different spaces (reverse
+        # is px, forward is angular), so to compare them we convert the forward to a px-equivalent
+        # with the reference plate scale (F_scale). That conversion is approximate -- the true
+        # scale varies across the FOV by the distortion amount -- but it is plenty for detecting a
+        # gross mismatch (a diverged forward mapping is off by huge factors). Used only for the
+        # flag below; the reported numbers stay in their natural units.
+        rmsd_fwd_px_approx = RMSD([entry[4] for entry in residuals])*self.platepar.F_scale
+        fwdrev_mismatch = rmsd_fwd_px_approx > 2.0*rmsd_img + 0.3
 
         # If the average angular error is larger than 60 arc minutes, report it in degrees
         if rmsd_angular > 60:
@@ -15132,17 +15134,17 @@ class PlateTool(QtWidgets.QMainWindow):
             rmsd_angular *= 60
             angular_error_label = 'arcsec'
 
-
-        print('RMSD: {:.2f} px (reverse), {:.2f} px (forward), {:.2f} {:s}'.format(
-            rmsd_img, rmsd_fwd_px, rmsd_angular, angular_error_label))
+        # reverse residual in its natural unit (px), forward residual in its natural unit (angular)
+        print('RMSD: {:.2f} px (reverse), {:.2f} {:s} (forward)'.format(
+            rmsd_img, rmsd_angular, angular_error_label))
         if fwdrev_mismatch:
-            print('  WARNING: forward/reverse mapping mismatch (reverse {:.2f} px vs forward {:.2f} px) -- '
-                  'the distortion mapping is inconsistent and the catalog overlay will be off.'.format(
-                      rmsd_img, rmsd_fwd_px))
+            print('  WARNING: forward/reverse mapping mismatch (forward ~{:.2f} px-equivalent vs reverse '
+                  '{:.2f} px) -- the distortion mapping is inconsistent; the catalog overlay will be off.'.format(
+                      rmsd_fwd_px_approx, rmsd_img))
 
         # Update RMSD display in the Fit Parameters tab
         self.tab.param_manager.updateRMSD(rmsd_img, rmsd_angular, angular_error_label,
-                                          rmsd_fwd_px=rmsd_fwd_px)
+                                          fwdrev_mismatch=fwdrev_mismatch)
 
         # Update fit residuals in the station tab when geopoints are used
         if self.geo_points_obj is not None:

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -14904,43 +14904,50 @@ class PlateTool(QtWidgets.QMainWindow):
                         message_type="warning")
             return
 
+        # Disable the button while computing so a queued second click can't re-run it
+        button = self.tab.param_manager.check_overfit_button
+        button.setEnabled(False)
         self.status_bar.showMessage("Computing held-out RMSD (cross-validation)...")
         QtWidgets.QApplication.processEvents()
 
-        result = self.crossValidatedRMSD()
-        if result is None:
-            msg = "Need more matched pairs for a stable held-out RMSD (have {}).".format(
-                len(self.paired_stars))
-            print(msg)
+        try:
+            result = self.crossValidatedRMSD()
+            if result is None:
+                msg = "Need more matched pairs for a stable held-out RMSD (have {}).".format(
+                    len(self.paired_stars))
+                print(msg)
+                self.status_bar.showMessage(msg)
+                return
+
+            cv_rmsd, n_folds = result
+
+            # In-sample RMSD for comparison
+            img_stars = np.array(self.paired_stars.imageCoords())
+            catalog_stars = np.array(self.paired_stars.skyCoords())
+            jd = date2JD(*self.img_handle.currentTime())
+            cat_x, cat_y, _ = getCatalogStarsImagePositions(catalog_stars, jd, self.platepar)
+            in_sample = float(np.sqrt(np.mean((cat_x - img_stars[:, 0])**2 + (cat_y - img_stars[:, 1])**2)))
+
+            gap = cv_rmsd - in_sample
+            msg = ("Held-out RMSD ({:d}-fold CV): {:.3f} px   in-sample: {:.3f} px   gap: {:+.3f} px"
+                   .format(n_folds, cv_rmsd, in_sample, gap))
+            print("\n" + msg)
+            overfit = gap > 0.5*in_sample + 0.05
+            if overfit:
+                print("  -> large gap: the fit may be OVERFITTING (model too flexible for this many stars).")
+            else:
+                print("  -> gap is small: the fit generalises well (not overfitting).")
             self.status_bar.showMessage(msg)
-            return
 
-        cv_rmsd, n_folds = result
+            # Show it in the Fit Parameters tab next to the in-sample RMSD
+            color = "#DC143C" if overfit else "#228B22"  # crimson if overfitting, green if clean
+            self.tab.param_manager.cv_rmsd_label.setText(
+                "Held-out ({}-fold): {:.3f} px   (gap {:+.3f} px)".format(n_folds, cv_rmsd, gap))
+            self.tab.param_manager.cv_rmsd_label.setStyleSheet(
+                "font-size: 9pt; font-weight: bold; color: {};".format(color))
 
-        # In-sample RMSD for comparison
-        img_stars = np.array(self.paired_stars.imageCoords())
-        catalog_stars = np.array(self.paired_stars.skyCoords())
-        jd = date2JD(*self.img_handle.currentTime())
-        cat_x, cat_y, _ = getCatalogStarsImagePositions(catalog_stars, jd, self.platepar)
-        in_sample = float(np.sqrt(np.mean((cat_x - img_stars[:, 0])**2 + (cat_y - img_stars[:, 1])**2)))
-
-        gap = cv_rmsd - in_sample
-        msg = ("Held-out RMSD ({:d}-fold CV): {:.3f} px   in-sample: {:.3f} px   gap: {:+.3f} px"
-               .format(n_folds, cv_rmsd, in_sample, gap))
-        print("\n" + msg)
-        overfit = gap > 0.5*in_sample + 0.05
-        if overfit:
-            print("  -> large gap: the fit may be OVERFITTING (model too flexible for this many stars).")
-        else:
-            print("  -> gap is small: the fit generalises well (not overfitting).")
-        self.status_bar.showMessage(msg)
-
-        # Show it in the Fit Parameters tab next to the in-sample RMSD
-        color = "#DC143C" if overfit else "#228B22"  # crimson if overfitting, green if clean
-        self.tab.param_manager.cv_rmsd_label.setText(
-            "Held-out ({}-fold): {:.3f} px   (gap {:+.3f} px)".format(n_folds, cv_rmsd, gap))
-        self.tab.param_manager.cv_rmsd_label.setStyleSheet(
-            "font-size: 9pt; font-weight: bold; color: {};".format(color))
+        finally:
+            button.setEnabled(True)
 
 
     def fitPickedStars(self):

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -14894,60 +14894,38 @@ class PlateTool(QtWidgets.QMainWindow):
         return float(np.sqrt(np.mean(held_sq))), n_folds
 
 
-    def checkFitOverfit(self):
-        """ Compute and report the cross-validated (held-out) RMSD for the current matched pairs,
-            as an overfitting check. Triggered from the menu (it runs n_folds extra fits, so it is
-            not automatic after every fit). """
+    def reportOverfit(self, in_sample_rmsd):
+        """ Run the held-out (cross-validated) RMSD overfitting check and print the breakdown to
+            the console. Runs automatically as part of every fit (see fitPickedStars).
 
-        if len(self.paired_stars) == 0:
-            qmessagebox(message="No matched pairs to evaluate.", title="Held-out RMSD",
-                        message_type="warning")
-            return
+        Arguments:
+            in_sample_rmsd: [float] The in-sample reverse-mapping RMSD (px) of the current fit, used
+                as the reference the held-out RMSD is compared against.
 
-        # Disable the button while computing so a queued second click can't re-run it
-        button = self.tab.param_manager.check_overfit_button
-        button.setEnabled(False)
-        self.status_bar.showMessage("Computing held-out RMSD (cross-validation)...")
-        QtWidgets.QApplication.processEvents()
+        Returns:
+            bool: True if the fit looks like it is overfitting (held-out RMSD much worse than
+                in-sample), False otherwise -- including when there are too few stars to evaluate,
+                in which case nothing is flagged.
+        """
 
-        try:
-            result = self.crossValidatedRMSD()
-            if result is None:
-                msg = "Need more matched pairs for a stable held-out RMSD (have {}).".format(
-                    len(self.paired_stars))
-                print(msg)
-                self.status_bar.showMessage(msg)
-                return
+        result = self.crossValidatedRMSD()
+        if result is None:
+            print("  Overfitting check: not enough matched pairs for a stable held-out RMSD "
+                  "(have {}).".format(len(self.paired_stars)))
+            return False
 
-            cv_rmsd, n_folds = result
+        cv_rmsd, n_folds = result
+        gap = cv_rmsd - in_sample_rmsd
+        overfit = gap > 0.5*in_sample_rmsd + 0.05
 
-            # In-sample RMSD for comparison
-            img_stars = np.array(self.paired_stars.imageCoords())
-            catalog_stars = np.array(self.paired_stars.skyCoords())
-            jd = date2JD(*self.img_handle.currentTime())
-            cat_x, cat_y, _ = getCatalogStarsImagePositions(catalog_stars, jd, self.platepar)
-            in_sample = float(np.sqrt(np.mean((cat_x - img_stars[:, 0])**2 + (cat_y - img_stars[:, 1])**2)))
+        print("  Held-out RMSD ({:d}-fold CV): {:.3f} px   in-sample: {:.3f} px   gap: {:+.3f} px"
+              .format(n_folds, cv_rmsd, in_sample_rmsd, gap))
+        if overfit:
+            print("  -> large gap: the fit may be OVERFITTING (model too flexible for this many stars).")
+        else:
+            print("  -> gap is small: the fit generalises well (not overfitting).")
 
-            gap = cv_rmsd - in_sample
-            msg = ("Held-out RMSD ({:d}-fold CV): {:.3f} px   in-sample: {:.3f} px   gap: {:+.3f} px"
-                   .format(n_folds, cv_rmsd, in_sample, gap))
-            print("\n" + msg)
-            overfit = gap > 0.5*in_sample + 0.05
-            if overfit:
-                print("  -> large gap: the fit may be OVERFITTING (model too flexible for this many stars).")
-            else:
-                print("  -> gap is small: the fit generalises well (not overfitting).")
-            self.status_bar.showMessage(msg)
-
-            # Show it in the Fit Parameters tab next to the in-sample RMSD
-            color = "#DC143C" if overfit else "#228B22"  # crimson if overfitting, green if clean
-            self.tab.param_manager.cv_rmsd_label.setText(
-                "Held-out ({}-fold): {:.3f} px   (gap {:+.3f} px)".format(n_folds, cv_rmsd, gap))
-            self.tab.param_manager.cv_rmsd_label.setStyleSheet(
-                "font-size: 9pt; font-weight: bold; color: {};".format(color))
-
-        finally:
-            button.setEnabled(True)
+        return overfit
 
 
     def fitPickedStars(self):
@@ -15134,17 +15112,26 @@ class PlateTool(QtWidgets.QMainWindow):
             rmsd_angular *= 60
             angular_error_label = 'arcsec'
 
-        # reverse residual in its natural unit (px), forward residual in its natural unit (angular)
-        print('RMSD: {:.2f} px (reverse), {:.2f} {:s} (forward)'.format(
-            rmsd_img, rmsd_angular, angular_error_label))
+        # The GUI shows the plain RMSD; the console carries the full breakdown and the two health
+        # checks (forward/reverse consistency and held-out overfitting) that, if tripped, turn the
+        # GUI label red.
+        print('RMSD: {:.2f} px, {:.2f} {:s}'.format(rmsd_img, rmsd_angular, angular_error_label))
+
+        # Forward/reverse mapping consistency (console detail)
         if fwdrev_mismatch:
             print('  WARNING: forward/reverse mapping mismatch (forward ~{:.2f} px-equivalent vs reverse '
                   '{:.2f} px) -- the distortion mapping is inconsistent; the catalog overlay will be off.'.format(
                       rmsd_fwd_px_approx, rmsd_img))
+        else:
+            print('  forward/reverse mapping consistent (forward ~{:.2f} px-equivalent vs reverse '
+                  '{:.2f} px).'.format(rmsd_fwd_px_approx, rmsd_img))
 
-        # Update RMSD display in the Fit Parameters tab
+        # Overfitting check via held-out cross-validation (console detail). Runs on every fit.
+        overfit = self.reportOverfit(rmsd_img)
+
+        # Update RMSD display in the Fit Parameters tab (red on either health-check failure)
         self.tab.param_manager.updateRMSD(rmsd_img, rmsd_angular, angular_error_label,
-                                          fwdrev_mismatch=fwdrev_mismatch)
+                                          fwdrev_mismatch=fwdrev_mismatch, overfit=overfit)
 
         # Update fit residuals in the station tab when geopoints are used
         if self.geo_points_obj is not None:

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -5534,6 +5534,105 @@ class PlateTool(QtWidgets.QMainWindow):
             return 0, 0, 0
 
 
+    def _extractStarsCurrentImage(self, ff_name, extra_info=None):
+        """ Extract stars from the currently displayed image. Uses extractStarsFF for FF files,
+            and extractStars (raw image) for everything else (video, images, etc.).
+
+        Arguments:
+            ff_name: [str] Name of the current file.
+
+        Keyword arguments:
+            extra_info: [dict] Optional dict to receive extra extraction info.
+
+        Return:
+            star_data: [list] List of star tuples in CALSTARS format:
+                [(y, x, intensity, amplitude, fwhm, background, snr, saturated_count), ...]
+                Empty list if no stars detected.
+        """
+
+        from RMS.ExtractStars import extractStars
+
+        if self.img_handle.input_type == 'ff':
+            # For FF files, use the dedicated FF extraction (reads from disk)
+            star_list = extractStarsFF(
+                self.dir_path,
+                ff_name,
+                config=self.config,
+                flat_struct=self.flat_struct if hasattr(self, 'flat_struct') else None,
+                dark=self.dark if hasattr(self, 'dark') else None,
+                mask=self.mask if hasattr(self, 'mask') else None,
+                extra_info=extra_info
+            )
+
+            if not star_list or len(star_list) < 2:
+                return []
+
+            # extractStarsFF returns: (ff_name, x_arr, y_arr, amplitude, intensity, fwhm, bg, snr, sat)
+            ff_name_ret, x_arr, y_arr, amplitude, intensity, fwhm, background, snr, saturated_count = star_list
+
+            # Construct CALSTARS format: Y(0) X(1) IntensSum(2) Ampltd(3) FWHM(4) BgLvl(5) SNR(6) NSatPx(7)
+            star_data = list(zip(y_arr, x_arr, intensity, amplitude, fwhm, background, snr, saturated_count))
+            return star_data
+
+        else:
+            # For video/images/etc., extract stars directly from the currently displayed avepixel
+            ff = self.img_handle.ff
+            if ff is None:
+                print("  No image data loaded")
+                return []
+
+            # Get the average pixel image (this is the currently displayed stack)
+            img = ff.avepixel.copy().astype(np.float32)
+
+            # Apply dark frame
+            if hasattr(self, 'dark') and self.dark is not None:
+                from RMS.Routines.Image import applyDark
+                img = applyDark(img, self.dark)
+
+            # Apply flat field
+            if hasattr(self, 'flat_struct') and self.flat_struct is not None:
+                from RMS.Routines.Image import applyFlat
+                img = applyFlat(img, self.flat_struct)
+
+            # Get the median
+            img_median = np.median(img)
+
+            # Check if image is too bright (scale the cutoff to the image bit depth, matching
+            # extractStarsFF/extractStarsImgHandle so high-bit-depth data is not wrongly skipped)
+            bit_depth = getattr(self.config, 'bit_depth', 8)
+            max_global_intensity = getattr(self.config, 'max_global_intensity', 150)*(2**(bit_depth - 8))
+            if img_median > max_global_intensity:
+                print(f"  Image too bright (median={img_median:.1f} > {max_global_intensity})")
+                return []
+
+            # Get mask
+            mask = self.mask if hasattr(self, 'mask') else None
+
+            # Run star extraction directly on the image
+            status = extractStars(
+                img, img_median=img_median,
+                mask=mask, gamma=self.config.gamma,
+                max_star_candidates=self.config.max_stars,
+                border=getattr(self.config, 'border', 10),
+                neighborhood_size=self.config.neighborhood_size,
+                intensity_threshold=self.config.intensity_threshold,
+                segment_radius=self.config.segment_radius,
+                roundness_threshold=self.config.roundness_threshold,
+                max_feature_ratio=self.config.max_feature_ratio,
+                bit_depth=getattr(self.config, 'bit_depth', 8),
+                extra_info=extra_info
+            )
+
+            if status is False:
+                return []
+
+            x_arr, y_arr, amplitude, intensity, fwhm, background, snr, saturated_count = status
+
+            # Construct CALSTARS format
+            star_data = list(zip(y_arr, x_arr, intensity, amplitude, fwhm, background, snr, saturated_count))
+            return star_data
+
+
     def _findSegmentRadiusFromFWHM(self, ff_name, visible_cat_x, visible_cat_y):
         """
         Determine the optimal segment_radius by measuring the FWHM of bright stars.
@@ -5575,30 +5674,31 @@ class PlateTool(QtWidgets.QMainWindow):
             self.config.max_feature_ratio = self.override_max_feature_ratio
             self.config.roundness_threshold = self.override_roundness_threshold
 
-            # Escalate the threshold until extractStarsFF returns stars. An empty result
-            # means either too many candidates (extractStars bails) or none detected;
-            # raising the threshold resolves the former, the high-bit-depth failure mode.
-            star_list = None
+            # Escalate the threshold until extractStars returns stars. An empty result means
+            # either too many candidates (extractStars bails) or none detected; raising the
+            # threshold resolves the former, which is the high-bit-depth failure mode.
+            star_data = []
             high_threshold = base_threshold
             for high_threshold in probe_thresholds:
                 self.config.intensity_threshold = high_threshold
-                star_list = extractStarsFF(
-                    self.dir_path, ff_name, config=self.config,
-                    flat_struct=self.flat_struct, dark=self.dark, mask=self.mask
-                )
-                if star_list and len(star_list) >= 2 and len(star_list[1]) > 0:
+                star_data = self._extractStarsCurrentImage(ff_name)
+                if star_data:
                     break
 
             self.config.intensity_threshold = orig_intensity
             self.config.segment_radius = orig_segment
 
-            if not star_list or len(star_list[1]) == 0:
+            if not star_data or len(star_data) == 0:
                 print(f"    No bright stars detected (probed thresholds "
                       f"{base_threshold}..{probe_thresholds[-1]}, segment={probe_segment})")
                 print(f"    Using default segment_radius=4")
                 return 4, 0, 1.0
 
-            _, x_arr, y_arr, amplitude, intensity, fwhm_arr, background, snr, saturated = star_list
+            # CALSTARS format: Y(0) X(1) IntensSum(2) Ampltd(3) FWHM(4) BgLvl(5) SNR(6) NSatPx(7)
+            star_data_arr = np.array(star_data)
+            x_arr = star_data_arr[:, 1].astype(float)
+            y_arr = star_data_arr[:, 0].astype(float)
+            fwhm_arr = star_data_arr[:, 4].astype(float)
             n_detected = len(x_arr)
 
             # Identify true positives (match to catalog)
@@ -5658,8 +5758,7 @@ class PlateTool(QtWidgets.QMainWindow):
             return best_segment, n_true_pos, fp_ratio
 
         except Exception as e:
-            print(f"    FWHM measurement error: {e}")
-            import traceback
+            print(f"    FWHM measurement error: {type(e).__name__}: {e}")
             traceback.print_exc()
             return 4, 0, 1.0
 


### PR DESCRIPTION
Summary: Speeds up platepar autofit (~5x), adds fit‑quality diagnostics, and fixes calibration on high‑bit‑depth (16‑bit) images.

Autofit performance
- NN RANSAC autofit uses a KD‑tree nearest‑neighbour lookup instead of an N×M matrix
- Shallow‑copy in fit residuals
- least_squares (LM) for radial forward/reverse distortion fit, extended to all smooth distortion‑fit paths

Fit accuracy & diagnostics
- Held‑out (cross‑validated) RMSD button; disabled while computing
- Report forward and reverse RMSD in px (catches broken mappings); reverse in px, forward in arcsec
- Overfit check; plain RMSD shown, flagged red on problems
- Fix forward/reverse mapping consistency and broken forward distortion after poly re‑fit; recover pixel‑residual accuracy after least_squares radial fit

High‑bit‑depth (16‑bit) fixes
- Fix star‑detection tuning and bright‑star PSF fit on high‑bit‑depth images
- Bit‑depth‑appropriate detection‑threshold slider max at config load, with headroom above the tuned value

Other
- Render image gamma/invert via LUT instead of overriding pyqtgraph's render()
- Save/load matched star pairs (per‑image, folder‑level file)