### PR TITLE
Add Kht.pyxbld so the KHT wrapper can rebuild via pyximport

### DIFF
--- a/RMS/Routines/Kht.pyxbld
+++ b/RMS/Routines/Kht.pyxbld
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+
+def make_ext(modname, pyxfilename):
+    """ Build the KHT Cython wrapper as a C++ extension for the pyximport fallback.
+
+    setup.py already builds RMS.Routines.Kht correctly (language="c++" plus the
+    Native/Hough C++ sources). This mirrors that recipe so that when the compiled
+    binary is missing or ABI-stale, pyximport can rebuild the module instead of
+    trying to compile the generated C++ as plain C and failing on `extern "C"`.
+    """
+
+    import os
+    from distutils.extension import Extension
+    from RMS.Misc import getRmsRootDir
+
+    root = getRmsRootDir()
+    hough_dir = os.path.join(root, "Native", "Hough")
+
+    # The KHT C++ implementation, compiled and linked together with the wrapper.
+    cpp_sources = [
+        os.path.join(hough_dir, "{:s}.cpp".format(name)) for name in
+        ("kht", "buffer_2d", "eigen", "linking", "peak_detection", "subdivision", "voting")
+    ]
+
+    ext = Extension(
+        name=modname,
+        sources=[pyxfilename] + cpp_sources,
+        include_dirs=[hough_dir],
+        language="c++",
+        extra_compile_args=["-O3"],
+    )
+
+    return ext
+
+
+def make_setup_args():
+    return dict(script_args=["--verbose"])


### PR DESCRIPTION
Kht.pyx (added in #912) only builds via setup.py. When the compiled .so is missing  — e.g. a fresh Python env, or a git pull/checkout that skipped RMS_Update's rebuild — the import in Detection.py falls back to pyximport, which builds with C defaults and dies compiling the generated Kht.c:
```
Kht.c: error: expected identifier or '(' before string constant
  extern "C" size_t kht_wrapper(...)
```
It's the only Cython module without a .pyxbld, so it's the only one whose pyximport fallback can't build. This adds Kht.pyxbld mirroring the setup.py recipe.

Tested by moving the prebuilt .so aside and forcing a pyximport rebuild — compiles and imports cleanly.

Fixes the KHT build failure reported on prerelease.