### PR TITLE
Fix failed reboot silently starting a second parallel capture in continuous mode

### DIFF
--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -1264,7 +1264,13 @@ if __name__ == "__main__":
 
                     # Reboot the computer (script needs sudo privileges, works only on Linux)
                     try:
-                        os.system('sudo shutdown -r now')
+                        exit_status = os.system('sudo shutdown -r now')
+
+                        # os.system returns a wait status, not the exit code directly
+                        if exit_status != 0:
+                            log.error('Reboot command failed with exit code {}, '
+                                'giving up on rebooting'.format(exit_status >> 8))
+                            break
 
                     except Exception as e:
                         log.debug('Rebooting failed with message:\n' + repr(e))
@@ -1292,7 +1298,7 @@ if __name__ == "__main__":
 
             # If reboot didn't happen in continuous capture mode, reset so capture resumes normally
             if config.continuous_capture:
-                log.warning("Reboot failed after 4 hours of attempts, resuming capture")
+                log.warning("Reboot did not happen, resuming capture")
                 ran_once = False
 
 

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -919,6 +919,11 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
                 dropped_frames = bc.stopCapture()
                 log.info('Total number of late or dropped frames: ' + str(dropped_frames))
 
+                # Record the dropped frame count in the observation summary, same as the
+                # normal stop path above
+                obs_dict = getObservationSummaryDict(night_data_dir)
+                addObsParam(obs_dict, "dropped_frames", dropped_frames)
+
             break
 
         ran_once = True
@@ -1276,11 +1281,28 @@ if __name__ == "__main__":
                     try:
                         exit_status = os.system('sudo shutdown -r now')
 
-                        # os.system returns a wait status, not the exit code directly
-                        if exit_status != 0:
+                        if exit_status == 0:
+
+                            # The reboot command was accepted - wait in place for the system to go
+                            # down. Don't re-run the command, as a repeat invocation during the
+                            # shutdown can return non-zero and falsely report a failure
+                            log.info('Reboot command accepted, waiting for the system to go down...')
+                            time.sleep(300)
+                            log.error('System still running 5 minutes after the reboot command '
+                                'succeeded, giving up on rebooting')
+
+                        else:
+
+                            # os.system returns a wait status, not the exit code directly
+                            if hasattr(os, 'waitstatus_to_exitcode'):
+                                exit_code = os.waitstatus_to_exitcode(exit_status)
+                            else:
+                                exit_code = exit_status >> 8
+
                             log.error('Reboot command failed with exit code {}, '
-                                'giving up on rebooting'.format(exit_status >> 8))
-                            break
+                                'giving up on rebooting'.format(exit_code))
+
+                        break
 
                     except Exception as e:
                         log.debug('Rebooting failed with message:\n' + repr(e))

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -909,7 +909,17 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
         # Standard mode: need to run it all just once
         # Continuous mode: if the program just got done with nighttime processing and needs to reboot
         elif (not config.continuous_capture) or (not daytime_mode_prev and config.reboot_after_processing):
-            break 
+
+            # Continuous mode: stop the capture before returning for the reboot. If the reboot
+            # fails, the main loop calls runCapture again - the old capture must not be left
+            # running, or two captures will run in parallel and save every frame twice, with the
+            # old one stamping a stale day/night suffix (it holds the previous daytime_mode)
+            if config.continuous_capture:
+                log.info('Ending capture before reboot...')
+                dropped_frames = bc.stopCapture()
+                log.info('Total number of late or dropped frames: ' + str(dropped_frames))
+
+            break
 
         ran_once = True
 


### PR DESCRIPTION
reboot_after_processing runs os.system('sudo shutdown -r now') without checking the exit code. When the command fails (e.g. no sudo rights under a systemd service user), the failure is invisible and capture resumes — but runCapture had returned with the old BufferedCapture still running, so a second capture starts in parallel. Every frame is then saved twice, and the old capture (holding a stale daytime_mode) labels its copies with the wrong _d/_n suffix. The interleaved duplicates shatter timelapse block grouping into 1–2 frame blocks that fail the 10-image minimum, are never cleaned up, and get rescanned every night (observed on a live station: ~96k warnings and a 40 MB log per night).

Two changes:
- Check the reboot command's exit status; on failure log an error and give up instead of silently retrying 240 times.
- In continuous mode, stop the capture before runCapture returns for the reboot, so a failed reboot can never leave two captures running.