### PR TITLE
Add shared CLI helper and argparse to scripts with raw sys.argv

### DIFF
--- a/RMS/CLITools.py
+++ b/RMS/CLITools.py
@@ -1,0 +1,60 @@
+""" Shared helpers for command-line interfaces of RMS scripts.
+
+This module is intentionally lightweight (stdlib-only at import time) so that it can be imported at the
+top of any script without pulling in heavy dependencies.
+"""
+
+from __future__ import print_function, division, absolute_import
+
+
+def addConfigArgument(parser, help_text=None):
+    """ Register the standard -c/--config argument on an argparse parser.
+
+    Unlike the legacy nargs=1 pattern, the value is stored as a plain string, so scripts can pass
+    cml_args.config directly to loadConfig() without indexing.
+
+    Arguments:
+        parser: [argparse.ArgumentParser] Parser to add the argument to.
+
+    Keyword arguments:
+        help_text: [str] Custom help text. If None, a standard description is used.
+
+    """
+
+    if help_text is None:
+        help_text = ("Path to a config file which will be used instead of the default one."
+            " To load the .config file in the given data directory, use '.' as the value.")
+
+    parser.add_argument('-c', '--config', metavar='CONFIG_PATH', type=str, help=help_text)
+
+
+def loadConfig(cml_args_config, dir_path=None):
+    """ Load the RMS config given the value of the --config argument.
+
+    Accepts the value in any historical shape (None, a plain string, or the 1-element list produced by
+    the legacy nargs=1 pattern) and normalizes it before handing it to
+    RMS.ConfigReader.loadConfigFromDirectory, which expects a list.
+
+    Arguments:
+        cml_args_config: [None/str/list] Value of cml_args.config from argparse.
+
+    Keyword arguments:
+        dir_path: [str or list] Path to the working directory (or several). If None, the current
+            directory is used.
+
+    Return:
+        config: [Config instance] Loaded config.
+
+    """
+
+    # Deferred import so importing this module stays cheap
+    import RMS.ConfigReader as cr
+
+    if dir_path is None:
+        dir_path = '.'
+
+    # Normalize the config argument to the list shape loadConfigFromDirectory expects
+    if isinstance(cml_args_config, str):
+        cml_args_config = [cml_args_config]
+
+    return cr.loadConfigFromDirectory(cml_args_config, dir_path)

--- a/Utils/Grouping3DRunner.py
+++ b/Utils/Grouping3DRunner.py
@@ -2,14 +2,14 @@
 
 from __future__ import print_function, division, absolute_import
 
+from RMS.CLITools import addConfigArgument, loadConfig
 from RMS.VideoExtraction import Extractor
-import RMS.ConfigReader as cr
 import RMS.Formats.FFfile as FFfile
 from RMS.Routines.Grouping3D import find3DLines, getAllPoints
 
 
 import os
-import sys
+import argparse
 import time
 
 
@@ -27,11 +27,20 @@ pyximport.install(setup_args={'include_dirs':[np.get_include()]})
 
 if __name__ == "__main__":
 
-    # Extract the directory name from the given argument
-    bin_dir = sys.argv[1]
+    arg_parser = argparse.ArgumentParser(description="""Run the fireball extractor on FF files in the \
+given directory and show the detected points and lines as 3D plots.""")
+
+    arg_parser.add_argument('dir_path', metavar='DIR_PATH', type=str,
+        help='Path to the directory with FF files.')
+
+    addConfigArgument(arg_parser)
+
+    cml_args = arg_parser.parse_args()
+
+    bin_dir = cml_args.dir_path
 
     # Load config file
-    config = cr.parse(".config")
+    config = loadConfig(cml_args.config, bin_dir)
 
     print('Directory:', bin_dir)
 

--- a/Utils/PointsViewer.py
+++ b/Utils/PointsViewer.py
@@ -1,32 +1,41 @@
+""" Show points detected by the video extractor on a given FF file as a 3D plot. """
+
+from __future__ import print_function, division, absolute_import
+
+import os
+import argparse
+
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
-import sys
+
+from RMS.CLITools import addConfigArgument, loadConfig
 from RMS.Formats import FFfile
 from RMS import VideoExtraction
-import RMS.ConfigReader as cr
 
-def view(ff):
-    config = cr.parse(".config")
-    
+
+def view(dir_path, file_name, config):
+
+    ff = FFfile.read(dir_path, file_name, array=True)
+
     ve = VideoExtraction.Extractor(config)
     ve.frames = np.empty((256, ff.nrows, ff.ncols))
     ve.compressed = ff.array
-    
-    points = np.array(ve.findPoints())
-    
-    plot(points, ff.nrows//config.f, ff.ncols//config.f)
 
-def plot(points, y_dim, x_dim):
+    points = np.array(ve.findPoints())
+
+    plot(points, ff.nrows//config.f, ff.ncols//config.f, file_name)
+
+def plot(points, y_dim, x_dim, name):
     fig = plt.figure()
-    
+
     ax = fig.add_subplot(111, projection='3d')
     plt.title(name)
-    
+
     y = points[:,0]
     x = points[:,1]
     z = points[:,2]
-    
+
     # Plot points in 3D
     ax.scatter(x, y, z)
 
@@ -34,15 +43,28 @@ def plot(points, y_dim, x_dim):
     ax.set_zlim(0, 255)
     plt.xlim([0, x_dim])
     plt.ylim([0, y_dim])
-    
+
     ax.set_ylabel("Y")
     ax.set_xlabel("X")
     ax.set_zlabel("Time")
-    
+
     plt.show()
 
 
 if __name__ == "__main__":
-    ff = FFfile.read(sys.argv[1], sys.argv[2], array=True)
-    
-    view(ff)
+
+    arg_parser = argparse.ArgumentParser(description="""Show points detected by the video extractor \
+on the given FF file as a 3D plot.""")
+
+    arg_parser.add_argument('ff_path', metavar='FF_PATH', type=str,
+        help='Path to the FF file to inspect.')
+
+    addConfigArgument(arg_parser)
+
+    cml_args = arg_parser.parse_args()
+
+    dir_path, file_name = os.path.split(os.path.abspath(cml_args.ff_path))
+
+    config = loadConfig(cml_args.config, dir_path)
+
+    view(dir_path, file_name, config)

--- a/Utils/SaturationSimulation.py
+++ b/Utils/SaturationSimulation.py
@@ -3,6 +3,8 @@
 
 from __future__ import print_function, division, absolute_import
 
+import argparse
+
 import numpy as np
 
 import matplotlib.pyplot as plt
@@ -139,13 +141,30 @@ def findUnsaturatedMagnitude(app_mag, photom_offset, bg_val, fps, ang_vel, gauss
 
 if __name__ == "__main__":
 
+    arg_parser = argparse.ArgumentParser(description="""Simulate the saturation of a moving meteor \
+modelled as a moving Gaussian, and plot the apparent vs actual magnitude for a range of PSF sizes.""")
 
-    photom_offset = 10.7
+    arg_parser.add_argument('-p', '--photomoffset', metavar='PHOTOM_OFFSET', type=float, default=10.7,
+        help='Photometric offset. Default: 10.7.')
 
+    arg_parser.add_argument('-b', '--background', metavar='BACKGROUND_LVL', type=float, default=60,
+        help='Background level (0-255). Default: 60.')
 
-    background_lvl = 60
-    fps = 25
-    ang_vel = 250 # px/s
+    arg_parser.add_argument('-f', '--fps', metavar='FPS', type=float, default=25,
+        help='Frames per second of the simulated camera. Default: 25.')
+
+    arg_parser.add_argument('-a', '--angvel', metavar='ANG_VEL', type=float, default=250,
+        help='Angular velocity of the meteor in px/s. Default: 250.')
+
+    arg_parser.add_argument('-s', '--stddevs', metavar='GAUSS_STDDEV', type=float, nargs='+',
+        default=[1.5, 1.3, 1.15], help='Gaussian PSF standard deviations to simulate. Default: 1.5 1.3 1.15.')
+
+    cml_args = arg_parser.parse_args()
+
+    photom_offset = cml_args.photomoffset
+    background_lvl = cml_args.background
+    fps = cml_args.fps
+    ang_vel = cml_args.angvel # px/s
 
 
     #print(findUnsaturatedMagnitude(-0.5, photom_offset, 50, 25, 100, 1))
@@ -156,8 +175,8 @@ if __name__ == "__main__":
     app_mag_range = np.append(np.linspace(-0.5, 2, 1000), np.linspace(2, 6, 10))
 
 
-    # Generate a range of gaussian stddevs
-    gauss_stddevs = [1.5, 1.3, 1.15]
+    # Range of gaussian stddevs to simulate
+    gauss_stddevs = cml_args.stddevs
 
 
 

--- a/Utils/SetCameraAddress.py
+++ b/Utils/SetCameraAddress.py
@@ -1,3 +1,4 @@
+import argparse
 import struct
 import json
 import hashlib
@@ -232,30 +233,35 @@ class DVRIPCam(object):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 3:
-        print("This script allows you to set your Camera's IP address.")
-        print('')
-        print('To use the script, your camera must be attached to your home network')
-        print('and acessible via its default IP address. If you are not sure what')
-        print('what that is, you may be able to find out from your home router. Most routers')
-        print("have a page that displys connected clients. Look for one named 'HostName',")
-        print('and make a note of its address. Alternatively you can use free tools like ')
-        print('Advanced IP-Scanner to scan your network for the same name. ')
-        print('')
-        print('You will also need to know the address you want your camera to have.')
-        print('Normally this will be 192.168.42.10')
-        print('')
-        print('Once you have this information and the camera is on your network')
-        print('call this module again with two arguments, the CURRENT and DESIRED address, eg:')
-        print('')
-        print('   python -m Utils.SetCameraAddress 192.168.1.100 192.168.42.10')
-        print('')
-        print('replacing the two addresses as needed')
-        print('')
-        exit(0)
 
-    ipaddr = sys.argv[1]
-    newaddr = sys.argv[2]
+    arg_parser = argparse.ArgumentParser(
+        description="Set your camera's IP address.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""To use the script, your camera must be attached to your home network
+and accessible via its default IP address. If you are not sure what
+that is, you may be able to find out from your home router. Most routers
+have a page that displays connected clients. Look for one named 'HostName',
+and make a note of its address. Alternatively you can use free tools like
+Advanced IP-Scanner to scan your network for the same name.
+
+You will also need to know the address you want your camera to have.
+Normally this will be 192.168.42.10
+
+Example:
+
+   python -m Utils.SetCameraAddress 192.168.1.100 192.168.42.10
+""")
+
+    arg_parser.add_argument('current_address', metavar='CURRENT_IP', type=str,
+        help='Current IP address of the camera.')
+
+    arg_parser.add_argument('new_address', metavar='NEW_IP', type=str,
+        help='Desired new IP address of the camera, e.g. 192.168.42.10.')
+
+    cml_args = arg_parser.parse_args()
+
+    ipaddr = cml_args.current_address
+    newaddr = cml_args.new_address
 
     if not checkValidIPAddr(ipaddr) or not checkValidIPAddr(newaddr):
         print('')

--- a/Utils/setAllCameraParams.py
+++ b/Utils/setAllCameraParams.py
@@ -1,3 +1,4 @@
+import argparse
 import struct
 import json
 import hashlib
@@ -279,7 +280,15 @@ def setCameraParam(cam, opts):
 
 if __name__ == '__main__':
 
-    ipaddr = sys.argv[1]
+    arg_parser = argparse.ArgumentParser(description="""Apply the standard set of RMS camera parameters \
+(video encoding, color, exposure, gain) to an IMX291-style IP camera over the DVRIP protocol.""")
+
+    arg_parser.add_argument('ip_address', metavar='CAMERA_IP', type=str,
+        help='IP address of the camera, e.g. 192.168.42.10.')
+
+    cml_args = arg_parser.parse_args()
+
+    ipaddr = cml_args.ip_address
 
     if not checkValidIPAddr(ipaddr):
         print('ipaddress invalid')


### PR DESCRIPTION
## Summary
- New `RMS/CLITools.py` with `addConfigArgument()` and `loadConfig()` — a standard way to register `-c/--config` (plain string, no legacy `nargs=1` + `[0]` indexing) and load the config via `loadConfigFromDirectory`, accepting the value as `None`, string, or 1-element list.
- Converts the five scripts that still parsed `sys.argv` by hand to argparse, so all tools now support `-h/--help`:
  - `Utils/PointsViewer.py` — also fixes a `NameError` crash (`plt.title(name)` with `name` undefined) and removes the hardcoded `.config` path
  - `Utils/Grouping3DRunner.py` — also removes hardcoded `.config`
  - `Utils/setAllCameraParams.py`
  - `Utils/SetCameraAddress.py` — previous manual usage text preserved as the `--help` epilog
  - `Utils/SaturationSimulation.py` — previously had no CLI at all; the hardcoded demo parameters are now flags with the old values as defaults

Existing scripts using `nargs=1` are unchanged and can migrate to the helper opportunistically.

## Testing
- `python -m Utils.<X> -h` prints proper usage for all five scripts
- `loadConfig()` tested with string path, 1-element list, `'.'` (config from data dir), and `None` (default config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)