### PR TITLE
bugfix for #929 malformed kml file in some cases

### DIFF
--- a/Utils/FOVKML.py
+++ b/Utils/FOVKML.py
@@ -138,7 +138,10 @@ def fovKML(dir_path, platepar, mask=None, area_ht=100000, side_points=10, plot_s
             <LinearRing>
                 <coordinates>\n"""
 
-        # Add the polygon points to the KML
+        # KML polygon must be a closed loop with identical first and last points
+        if polygon_points[0] != polygon_points[-1]:
+            polygon_points.append(polygon_points[0])
+
         for p_lat, p_lon, p_elev in polygon_points:
             kml += "                    {:.6f},{:.6f},{:.0f}\n".format(p_lon, p_lat, p_elev)
 


### PR DESCRIPTION
## Description
Fix for issue https://github.com/CroatianMeteorNetwork/RMS/issues/929, malformed KML files being generated by some stations.
The underlying reason is something going wrong when hte mask is applied but a simple fix is to just check when writing the KML .

The change is to a single file, and could be applied directly to master (my preference unless prerelease is imminently going to be rolled out). 

## Testing
Tested on my multicam (UK0006/UK000F/UK002F) where UK0006 exhibited the bug and UK000F did not. 
Also tested on single-cam (UK001L) and Windows. 
As expected, this adds a single extra line to the coordinates block, if needed. 