### PR TITLE
Make UDP buffer sizes persist across reboots

### DIFF
--- a/Scripts/UpdateBuffers.sh
+++ b/Scripts/UpdateBuffers.sh
@@ -107,6 +107,16 @@ echo "Created $SYSCTL_DROP_IN with:"
 echo "  net.core.rmem_max=$RECOMMENDED_SIZE"
 echo "  net.core.wmem_max=$RECOMMENDED_SIZE"
 
+# Comment out any rmem_max/wmem_max lines left in /etc/sysctl.conf.
+# It loads after our drop-in at boot and would otherwise override it.
+SYSCTL_CONF="/etc/sysctl.conf"
+if [ -f "$SYSCTL_CONF" ] && grep -Eq '^[[:space:]]*net\.core\.(rmem|wmem)_max[[:space:]]*=' "$SYSCTL_CONF"; then
+    echo -e "\nFound conflicting UDP buffer settings in $SYSCTL_CONF; disabling them so the drop-in wins at boot."
+    cp -n "$SYSCTL_CONF" "${SYSCTL_CONF}.rms.bak" && echo "Backed up to ${SYSCTL_CONF}.rms.bak"
+    sed -i -E 's@^([[:space:]]*net\.core\.(rmem|wmem)_max[[:space:]]*=.*)@# Disabled by UpdateBuffers.sh: \1@' "$SYSCTL_CONF"
+    echo "Commented out stale rmem_max/wmem_max lines in $SYSCTL_CONF"
+fi
+
 # Apply changes immediately
 echo "Applying changes..."
 sysctl -p "$SYSCTL_DROP_IN" >/dev/null 2>&1


### PR DESCRIPTION
## Problem
`UpdateBuffers.sh` writes UDP buffer sizes to `/etc/sysctl.d/99-rms-udp-buffers.conf`, but the values silently revert to the old default after a reboot.

Cause: `systemd-sysctl` applies config files in lexical filename order (last wins). `/etc/sysctl.conf` is loaded via the symlink `/etc/sysctl.d/99-sysctl.conf`, which sorts *after* `99-rms-udp-buffers.conf` (`s` > `r`). So any `rmem_max`/`wmem_max` line left in `/etc/sysctl.conf` (e.g. from an older version of this script that edited it directly) overrides the drop-in at every boot. The change only appears to work because the script also applies it live via `sysctl -p`.

## Fix
When `/etc/sysctl.conf` contains active `net.core.rmem_max`/`wmem_max` lines, the script now backs it up (`.rms.bak`) and comments them out, so the drop-in is the sole authority and the setting survives reboots. Idempotent and a no-op when there's nothing to heal.

## Compatibility
Raspberry Pi OS and Ubuntu — both are systemd-based Debian-family systems with the same sysctl load ordering and GNU userland (`grep -E`, `sed -E`, `cp -n`).