### PR TITLE
Fix SkyFit2 crash on older pyqtgraph (callable LUT)

### DIFF
--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -854,13 +854,25 @@ class ImageItem(pg.ImageItem):
         #   gradient). Keep it as the base so gamma/inversion can be re-composed on top
         #   whenever they change, then hand pyqtgraph the effective LUT.
         self._base_lut = lut
-        super().setLookupTable(self._composeDisplayLut(lut), update=update)
+        self._applyDisplayLut(update=update)
 
     def _applyDisplayLut(self, update=True):
         """ Rebuild and apply the effective display LUT from the current base LUT,
             gamma and inversion. Used instead of overriding render(), so we no longer
             depend on pyqtgraph render internals. """
-        super().setLookupTable(self._composeDisplayLut(self._base_lut), update=update)
+        base_lut = self._base_lut
+
+        # The base LUT may be a callable rather than an array: pyqtgraph <= 0.11
+        #   HistogramLUTItem.setImageItem() always passes its getLookupTable method, and
+        #   newer versions still do so for non-grayscale gradients. pyqtgraph resolves a
+        #   callable LUT at render time by calling it with the image, so wrap it and
+        #   compose gamma/inversion on whatever it returns.
+        if callable(base_lut):
+            effective_lut = lambda img: self._composeDisplayLut(base_lut(img))
+        else:
+            effective_lut = self._composeDisplayLut(base_lut)
+
+        super().setLookupTable(effective_lut, update=update)
 
     def _composeDisplayLut(self, base_lut):
         """ Build the grayscale lookup table that bakes in gamma and inversion.


### PR DESCRIPTION
## Problem

On pyqtgraph <= 0.11, launching SkyFit2 crashes immediately:

```
File "RMS/Routines/CustomPyqtgraphClasses.py", line 880, in _composeDisplayLut
    rgb = base_lut[:, :3].astype(float)
IndexError: too many indices for array: array is 0-dimensional, but 2 were indexed
```

Reported by Pete (US000G) on a Windows install running current prerelease; the env has pyqtgraph 0.11 (predates the `pyqtgraph>=0.12,<0.13` pin in requirements.txt).

## Cause

The gamma/invert LUT refactor (3a0fb690) assumed the histogram always pushes an array (or None) into `ImageItem.setLookupTable()`. But pyqtgraph <= 0.11 `HistogramLUTItem.setImageItem()` always passes its `getLookupTable` **method** ("send function pointer, not the result"), and newer versions still do so for non-grayscale gradients — so this was also a latent crash on 0.12.x if a user ever selected a color gradient. `np.asarray(<bound method>)` yields a 0-d object array and indexing it throws.

## Fix

When the pushed base LUT is callable, hand pyqtgraph a wrapper that resolves it at render time (exactly how pyqtgraph itself treats callable LUTs) and composes gamma/inversion on the result. Array/None paths are unchanged.

## Testing

Headless regression test exercising `ImageItem` with None, array, callable, and callable-returning-None base LUTs, plus gamma/invert re-compose and a full `render()`: reproduces Pete's exact IndexError on the unfixed code, all pass with the fix (verified on pyqtgraph 0.12.4, which uses the same callable render path as 0.11).