### PR TITLE
Fix QueuedPool multiprocessing crash on Windows (spawn)

### DIFF
--- a/RMS/QueuedPool.py
+++ b/RMS/QueuedPool.py
@@ -194,6 +194,33 @@ class QueuedPool(object):
         self.print_state = print_state
 
 
+    def __getstate__(self):
+        """ Return a picklable snapshot of this instance for the 'spawn' start method
+            (Windows). On Linux (fork) this is never called, so the capture pipeline is
+            unaffected.
+
+            Under spawn, the Pool initializer (the bound method self._workerFunc) forces
+            the whole QueuedPool to be pickled and sent to each worker. The SyncManager
+            (self.manager) has no pickle reducer and holds a weakref -> "cannot pickle
+            'weakref' object"; workers never use it (they use the already-created Queue
+            proxies), so drop it. The live Pool handle (self.pool) also must not and need
+            not cross the process boundary. Everything else (Manager Queue proxies,
+            SafeValue Value/Lock counters, the kill Event, bkup_dict) reduces correctly
+            during a real spawn and is needed by the workers.
+        """
+        state = self.__dict__.copy()
+        state['manager'] = None
+        state['pool'] = None
+        return state
+
+
+    def __setstate__(self, state):
+        """ Restore state in a spawned worker. manager/pool stay None in the child; the
+            worker reconnects to the parent's manager server through the pickled Queue
+            proxies. """
+        self.__dict__.update(state)
+
+
     def printAndLog(self, *args):
         """ Print and log the given message. """
 


### PR DESCRIPTION
## What was broken

On Windows, running SkyFit2 on a folder with no CALSTARS file tries to generate one automatically. This crashed with:

```
ERROR: Star extraction failed: cannot pickle 'weakref' object
OSError: [WinError 6] The handle is invalid
```

and no CALSTARS file was saved.

## Why

Windows and Linux start worker processes differently:

- **Linux** uses `fork` — the child is a memory copy of the parent, so nothing needs to be sent across.
- **Windows** uses `spawn` — the child is a fresh process, so Python has to *pickle* (serialize) everything the worker needs and ship it over.

`QueuedPool` starts its pool using a bound method (`self._workerFunc`) as the initializer. Pickling a bound method pickles the **entire `QueuedPool` object**. That object holds a `multiprocessing.Manager`, which internally contains a `weakref` — and weakrefs can't be pickled. So on Windows the pool never even started.

This was never seen before because the capture pipeline runs on Linux (Raspberry Pi), where `fork` skips pickling entirely. Only the Windows desktop tools hit it: SkyFit2 CALSTARS generation, FluxBatch, and TrackStack.

## The fix

Add `__getstate__` / `__setstate__` to `QueuedPool` that leave out the two things that can't (and don't need to) be pickled: the `Manager` object and the live pool handle. The workers never use either — they talk to the queue proxies, which pickle fine. Everything else the workers need serializes correctly during a real spawn.

**No effect on Linux:** `fork` never pickles, so these methods are never called there. The 24/7 capture pipeline is completely untouched.

## Testing

- Emulated Windows `spawn` on Linux (`set_start_method('spawn', force=True)`) and ran a `QueuedPool` end to end:
  - **Before:** `cannot pickle 'weakref' object`
  - **After:** pool starts, all jobs processed, results returned.
- Still to confirm on real Windows 11 / Python 3.8 via SkyFit2 (multi-file folder → CALSTARS generated), plus FluxBatch and TrackStack.

## Files

- `RMS/QueuedPool.py` — added `__getstate__` / `__setstate__`. One file, ~27 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)