### PR TITLE
Always delete detection backups after a standalone reprocess (fixes #418)

### DIFF
--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -853,29 +853,35 @@ if __name__ == "__main__":
         # Run the external script
         runExternalScript(cml_args.dir_path[0], night_archive_dir, config)
 
-    # Upload the archive, if upload is enabled
-    if config.upload_enabled:
+    try:
 
-        # Add metadata archive first, so it might get uploaded first
-        files_to_add_list_unfiltered = [metadata_archive_name, imgdata_archive_name, archive_name]
-        files_to_add_list = [f for f in files_to_add_list_unfiltered if f is not None]
+        # Upload the archive, if upload is enabled
+        if config.upload_enabled:
 
-        # Init the upload manager
-        log.info('Starting the upload manager...')
+            # Add metadata archive first, so it might get uploaded first
+            files_to_add_list_unfiltered = [metadata_archive_name, imgdata_archive_name, archive_name]
+            files_to_add_list = [f for f in files_to_add_list_unfiltered if f is not None]
 
-        upload_manager = UploadManager(config)
-        upload_manager.start()
+            # Init the upload manager
+            log.info('Starting the upload manager...')
 
-        # Add file for upload
-        log.info(f'Adding files to upload list: {files_to_add_list}')
-        upload_manager.addFiles(files_to_add_list)
+            upload_manager = UploadManager(config)
+            upload_manager.start()
 
-        # Stop the upload manager
-        if upload_manager.is_alive():
-            upload_manager.stop()
-            log.info('Closing upload manager...')
+            # Add file for upload
+            log.info(f'Adding files to upload list: {files_to_add_list}')
+            upload_manager.addFiles(files_to_add_list)
 
+            # Stop the upload manager
+            if upload_manager.is_alive():
+                upload_manager.stop()
+                log.info('Closing upload manager...')
 
-        # Delete detection backup files
+    finally:
+
+        # Delete detection backup files. This has to happen whether or not uploading is enabled and
+        #   whether or not it succeeded: any rms_queue_bkup_*.pickle left in the captured directory
+        #   makes StartCapture treat the night as partially processed and reprocess it all over
+        #   again on the next start.
         if detector is not None:
             detector.deleteBackupFiles()

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -849,11 +849,15 @@ if __name__ == "__main__":
     night_archive_dir, archive_name, imgdata_archive_name, metadata_archive_name, detector =  \
                                                     processNight(cml_args.dir_path[0], config)
 
-    if cml_args.run_extl_script:
-        # Run the external script
-        runExternalScript(cml_args.dir_path[0], night_archive_dir, config)
+    upload_manager = None
 
+    # The night is fully processed by this point, so the steps below all have to be followed by the
+    #   backup cleanup in the finally block, whether they succeed or not
     try:
+
+        if cml_args.run_extl_script:
+            # Run the external script
+            runExternalScript(cml_args.dir_path[0], night_archive_dir, config)
 
         # Upload the archive, if upload is enabled
         if config.upload_enabled:
@@ -872,16 +876,24 @@ if __name__ == "__main__":
             log.info(f'Adding files to upload list: {files_to_add_list}')
             upload_manager.addFiles(files_to_add_list)
 
-            # Stop the upload manager
-            if upload_manager.is_alive():
-                upload_manager.stop()
-                log.info('Closing upload manager...')
-
     finally:
+
+        # Stop the upload manager. It is a non-daemon process which loops until told to exit, so
+        #   leaving it running on an error path would hang the script at interpreter shutdown
+        if (upload_manager is not None) and upload_manager.is_alive():
+            log.info('Closing upload manager...')
+            upload_manager.stop()
+
 
         # Delete detection backup files. This has to happen whether or not uploading is enabled and
         #   whether or not it succeeded: any rms_queue_bkup_*.pickle left in the captured directory
         #   makes StartCapture treat the night as partially processed and reprocess it all over
         #   again on the next start.
         if detector is not None:
-            detector.deleteBackupFiles()
+
+            # Never let a cleanup failure mask an exception which is already propagating
+            try:
+                detector.deleteBackupFiles()
+
+            except Exception as e:
+                log.error('Deleting the detection backup files failed with message:\n' + repr(e))


### PR DESCRIPTION
Fixes #418.

## The bug

In `RMS/Reprocess.py`, the detection-backup cleanup sits **inside** the `if config.upload_enabled:`
block, so a standalone `python -m RMS.Reprocess <dir>` on a station with uploading disabled never
deletes the `rms_queue_bkup_*.pickle` files it wrote into the captured directory.

Every other caller cleans up unconditionally — `StartCapture.py:862` (end of night),
`StartCapture.py:1004` (auto-reprocess), `DetectStarsAndMeteors.py:560`. The standalone script is
the odd one out. The nesting dates back to f89771c3 (Oct 2018), whose intent was to delay the delete
until after upload; it just landed one level too deep.

The leftovers then trip the auto-reprocess check on the next start (`StartCapture.py:951-977`):

```python
pickle_files = glob.glob("{:s}/rms_queue_bkup_*.pickle".format(captured_dir_path))
...
if any_pickle_files:
    run_reprocess = True
```

Any leftover pickle means "partially processed" regardless of the FTPdetectinfo being present, so
RMS reprocesses the night the user had just reprocessed by hand.

It is self-concealing: the duplicate run goes through `StartCapture`, which *does* clean up, so the
pickles are gone afterwards and the night never triggers again. That is why it reads as
irreproducible and why the same reporter hit it twice, two years apart.

## Confirmed from a station log

`log_USTEST_20260725_172751_001.log`, RMS master f441ef15:

```
17:27:51 DownloadMask - Can't contact the server: RSA private key file not found.
17:27:53 StartCapture-line:983 - Found partially-processed data in .../USTEST_20260725_024335_309988
17:28:17 QueuedPool-line:204  - Loaded 3157 backed up results...
...
17:59:06 StartCapture-line:1008 - Folder .../USTEST_20260725_024335_309988 reprocessed with success!
```

- No `UploadManager` line anywhere in the run, and `StartCapture.py:1195-1200` only constructs one
  when `config.upload_enabled` is set — so uploading is off on this station.
- 3157 backups loaded is one per FF file for the full 9.021 hr night, i.e. the manual run left its
  *entire* backup set, not a partial failure.
- The manual run had finished cleanly 36 minutes earlier (`reprocess_log_USTEST_20260725_152745_001.log`,
  15:27:45 -> last entry 16:51:07), so this is not a race with a still-running job.
- The duplicate cost ~31 minutes of the pre-capture window. Detection was cheap (results came from
  the backups) but the ML filter, calibration, thumbnails, both stacks and archiving all re-ran.

## The change

Move the cleanup out of the `upload_enabled` branch and into a `finally`, so it runs whether or not
uploading is enabled and whether or not it raised. Ordering is preserved: the delete still happens
after the upload manager is stopped, which was the point of f89771c3.

## Testing

Verified structurally that the call is no longer gated on `upload_enabled` and now sits in
`Try.finalbody`, and that removing the `rms_queue_bkup_*.pickle` files flips `StartCapture`'s
`run_reprocess` decision from True to False with the FTPdetectinfo left in place. Not run on a live
station.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
