### PR TITLE
Only consider real kernel module trees when detecting the latest kernel

### DIFF
--- a/Scripts/MultiCamLinux/GRMSUpdater.sh
+++ b/Scripts/MultiCamLinux/GRMSUpdater.sh
@@ -125,7 +125,17 @@ should_reboot() {
         # Fallback: compare running kernel to latest installed (works on RPi OS / Debian).
         local running latest last_target
         running="$(uname -r)"
-        latest="$(ls /lib/modules/ | sort -V | tail -1)"
+        # /lib/modules/ is not only kernel version directories: the NVIDIA driver
+        # packages own a literal /lib/modules/kernel/, and purged kernels can leave
+        # a version-shaped directory behind. Keep only entries that start with a
+        # digit and carry a modules.dep (written by depmod for every installed
+        # kernel), otherwise "kernel" sorts last and every run reports a mismatch.
+        latest="$(for d in /lib/modules/*/; do
+                      d="${d%/}"; d="${d##*/}"
+                      [[ "$d" =~ ^[0-9] ]] || continue
+                      [[ -f "/lib/modules/$d/modules.dep" ]] || continue
+                      echo "$d"
+                  done | sort -V | tail -1)"
         if [[ -n "$latest" && "$running" != "$latest" ]]; then
             # Loop guard: if the latest installed kernel never becomes the running one
             # (unbootable kernel, bootloader pinned to an older version, RPi

--- a/Scripts/MultiCamLinux/GRMSUpdater.sh
+++ b/Scripts/MultiCamLinux/GRMSUpdater.sh
@@ -123,20 +123,29 @@ should_reboot() {
             return 0
         fi
         # Fallback: compare running kernel to latest installed (works on RPi OS / Debian).
-        local running latest last_target
+        local running latest last_target flavour d f
         running="$(uname -r)"
-        # /lib/modules/ is not only kernel version directories: the NVIDIA driver
-        # packages own a literal /lib/modules/kernel/, and purged kernels can leave
-        # a version-shaped directory behind. Keep only entries that start with a
-        # digit and carry a modules.dep (written by depmod for every installed
-        # kernel), otherwise "kernel" sorts last and every run reports a mismatch.
-        latest="$(for d in /lib/modules/*/; do
-                      d="${d%/}"; d="${d##*/}"
-                      [[ "$d" =~ ^[0-9] ]] || continue
-                      [[ -f "/lib/modules/$d/modules.dep" ]] || continue
+        # /lib/modules/ is not a clean list of kernel version directories. The NVIDIA
+        # driver packages own a literal /lib/modules/kernel/, purged kernels can leave a
+        # version-shaped directory behind, and every installed *flavour* gets its own
+        # tree (Raspberry Pi OS 64-bit ships both rpi-v8 and rpi-2712; Ubuntu can carry
+        # generic alongside lowlatency). Only a same-flavour, fully installed kernel is a
+        # valid reboot target: without the version/modules.dep filters "kernel" sorts
+        # last, and without the flavour filter a Pi 5 running rpi-2712 would compare
+        # itself against the rpi-v8 tree - both report a mismatch on every run.
+        # modules.dep is written by depmod for every properly installed kernel.
+        flavour=""
+        [[ "$running" =~ ^[0-9][^-]*(-[0-9]+)?-(.+)$ ]] && flavour="${BASH_REMATCH[2]}"
+        latest="$(for f in /lib/modules/[0-9]*/modules.dep; do
+                      [[ -f "$f" ]] || continue
+                      d="${f%/modules.dep}"; d="${d##*/}"
+                      [[ -z "$flavour" || "$d" == *"-$flavour" ]] || continue
                       echo "$d"
                   done | sort -V | tail -1)"
-        if [[ -n "$latest" && "$running" != "$latest" ]]; then
+        # Require the candidate to be strictly newer, so a purged running-kernel tree
+        # (leaving only older versions behind) cannot trigger a "downgrade" reboot.
+        if [[ -n "$latest" && "$running" != "$latest" \
+              && "$(printf '%s\n%s\n' "$running" "$latest" | sort -V | tail -1)" == "$latest" ]]; then
             # Loop guard: if the latest installed kernel never becomes the running one
             # (unbootable kernel, bootloader pinned to an older version, RPi
             # firmware/modules mismatch), an unattended cron run would otherwise reboot


### PR DESCRIPTION
### Problem

`should_reboot()` picked the newest installed kernel with:

```bash
latest="$(ls /lib/modules/ | sort -V | tail -1)"
```

Not every entry in `/lib/modules/` is a kernel version directory. On Ubuntu 24.04 with the NVIDIA driver packages installed, a literal `kernel/` directory exists there and is owned by dpkg:

```
$ ls /lib/modules/
6.14.0-37-generic  6.17.0-23-generic  6.17.0-35-generic
6.17.0-40-generic  7.0.0-28-generic   kernel

$ dpkg -S /lib/modules/kernel
linux-modules-nvidia-595-open-6.17.0-40-generic,
linux-modules-nvidia-595-open-7.0.0-28-generic: /lib/modules/kernel
```

Since `k` sorts after digits, `sort -V | tail -1` returns `kernel`, so the comparison on the next line always reports a mismatch. Observed on a live station with nothing actually pending (no `/var/run/reboot-required`, running kernel already the newest installed):

```
Jul 26 05:00:02 rms_updater: Kernel mismatch: running 7.0.0-28-generic, installed kernel
```

`/var/run/reboot-required` masks this on Ubuntu, so the fallback only misfires when that file is absent, i.e. exactly on the RPi OS / Debian systems the fallback exists to serve. On a machine with working passwordless `sudo shutdown` the consequence is one spurious reboot, after which `do_reboot()` stamps `kernel` into the stamp file, `last_target == latest` holds forever, and the loop guard permanently disables the fallback. One unnecessary reboot, then silent loss of the feature.

Deleting `/lib/modules/kernel` is not a fix — dpkg owns it and it returns on the next NVIDIA driver update.

### Fix

Consider only entries that are version-shaped *and* contain a `modules.dep`, which `depmod` writes into every genuinely installed kernel's directory. `sort -V` ordering is unchanged, and the loop-guard/stamp logic is untouched — it behaves correctly once `latest` is right.

The `modules.dep` guard also filters half-removed kernels, which are version-shaped and would otherwise trigger the same spurious reboot. Against a directory containing both `kernel/` and a purged-kernel leftover:

| filter | result |
| --- | --- |
| current (`ls | sort -V | tail -1`) | `kernel` |
| `^[0-9]` only | `7.1.0-1-generic` (the leftover) |
| `^[0-9]` + `modules.dep` | `7.0.0-28-generic` |

### Testing

- `bash -n` passes; `shellcheck` reports nothing new (the two existing SC2155/SC2106 warnings are elsewhere in the file and pre-existing).
- The repo has no shell-script test harness, so `should_reboot()` was exercised out-of-line with `/lib/modules`, `/var/run/reboot-required` and `uname` redirected at a fixture directory containing the layout above:
  - `reboot-required` present -> returns 0
  - running == newest installed -> returns 1 (this is the reported bug; previously returned 0)
  - running older than newest -> returns 0 with target `7.0.0-28-generic`
  - same, with the stamp already holding that kernel -> returns 1 (loop guard intact)
  - empty `/lib/modules` -> returns 1