### PR TITLE
Decide auto-reprocessing from the observation summary, not leftover backups

### DIFF
--- a/.config
+++ b/.config
@@ -367,6 +367,17 @@ slideshow_enable: false
 ; Auto-reprocess broken capture directories after power cuts or crashes
 auto_reprocess: true
 
+; Give up on a capture directory after this many failed auto-reprocess attempts, so a night which
+; fails every time does not eat the pre-capture window on every start. Set to 0 to retry forever
+auto_reprocess_max_attempts: 3
+
+; Also reprocess nights which look processed but have no directory in ArchivedFiles. Leave this off
+; unless you know you need it: retention (arch_dirs_to_keep, capt_dirs_to_keep) and quota management
+; delete ArchivedFiles independently of CapturedFiles, so on a space-constrained station a missing
+; archive usually means it was purged, not that the night was never processed. With this enabled
+; such nights are reprocessed once each, up to auto_reprocess_max_attempts
+reprocess_if_archive_missing: false
+
 ; Flag file to load processed files on capture resume
 capture_resume_flag_file: .capture_resuming
 

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -385,8 +385,9 @@ class Config:
         #   of CapturedFiles, so a missing archive does not reliably mean the night is unprocessed
         self.reprocess_if_archive_missing = False
 
-        # File in the captured directory which counts failed auto-reprocess attempts
-        self.reprocess_attempts_file = ".rms_reprocess_attempts"
+        # File in the captured directory which records how far processing got and how many
+        #   auto-reprocess attempts have failed
+        self.processing_status_file = ".rms_processing_status"
 
         # Flag file which indicates that the previously processed files are loaded during capture resume
         self.capture_resume_flag_file = ".capture_resuming"

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -376,6 +376,18 @@ class Config:
         # Automatically reprocess broken capture directories
         self.auto_reprocess = True
 
+        # Give up on a capture directory after this many failed auto-reprocess attempts. 0 disables
+        #   the guard and retries forever
+        self.auto_reprocess_max_attempts = 3
+
+        # Also auto-reprocess nights which look processed but have no directory in ArchivedFiles.
+        #   Off by default because retention and quota management delete ArchivedFiles independently
+        #   of CapturedFiles, so a missing archive does not reliably mean the night is unprocessed
+        self.reprocess_if_archive_missing = False
+
+        # File in the captured directory which counts failed auto-reprocess attempts
+        self.reprocess_attempts_file = ".rms_reprocess_attempts"
+
         # Flag file which indicates that the previously processed files are loaded during capture resume
         self.capture_resume_flag_file = ".capture_resuming"
 
@@ -1246,6 +1258,18 @@ def parseCapture(config, parser):
     # Enable/disable auto reprocessing
     if parser.has_option(section, "auto_reprocess"):
         config.auto_reprocess = parser.getboolean(section, "auto_reprocess")
+
+    # Load the cap on failed auto-reprocess attempts per capture directory
+    if parser.has_option(section, "auto_reprocess_max_attempts"):
+        config.auto_reprocess_max_attempts = int(parser.get(section, "auto_reprocess_max_attempts"))
+
+        if config.auto_reprocess_max_attempts < 0:
+            config.auto_reprocess_max_attempts = 0
+
+    # Enable/disable reprocessing nights whose ArchivedFiles directory is missing
+    if parser.has_option(section, "reprocess_if_archive_missing"):
+        config.reprocess_if_archive_missing = parser.getboolean(section,
+            "reprocess_if_archive_missing")
 
     # Load name of the capture resume flag file
     if parser.has_option(section, "capture_resume_flag_file"):

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -7,6 +7,7 @@ from __future__ import print_function, division, absolute_import
 import os
 import sys
 import glob
+import json
 import collections
 import traceback
 import argparse
@@ -671,10 +672,19 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
 
     log.info('Archiving detections to ' + night_archive_dir)
-    
+
+    # Record that archiving is under way. archiveDetections creates the destination directory before
+    #   it finishes copying into it, so the directory existing is not proof the night was archived -
+    #   this is what tells a later run that an interrupted archive has to be redone
+    updateProcessingStatus(config, night_data_dir, archiving='started')
+
     # Archive the detections
     archive_name, imgdata_archive_name, metadata_archive_name = archiveDetections(night_data_dir,
                                             night_archive_dir, ff_detected, config, extra_files=extra_files)
+
+    # Processing is complete. Nothing after this point can leave the night needing a reprocess
+    updateProcessingStatus(config, night_data_dir, archiving='completed',
+        completed_utc=RmsDateTime.utcnow().strftime("%Y-%m-%d %H:%M:%S"))
 
 
     return night_archive_dir, archive_name, imgdata_archive_name, metadata_archive_name, detector
@@ -688,26 +698,98 @@ NIGHT_INCOMPLETE = 'incomplete'
 
 
 NightProcessingState = collections.namedtuple('NightProcessingState',
-    ['state', 'has_final_summary', 'has_working_summary', 'has_ftpdetectinfo', 'pickle_files',
-     'has_archive_dir'])
+    ['state', 'archiving', 'has_final_summary', 'has_working_summary', 'has_ftpdetectinfo',
+     'pickle_files', 'has_archive_dir'])
+
+
+
+def readProcessingStatus(config, captured_dir_path):
+    """ Read the processing status record from a captured night directory.
+
+    Arguments:
+        config: [Config obj]
+        captured_dir_path: [str] Full path to the directory in CapturedFiles.
+
+    Return:
+        [dict] The record, or an empty dict if it is missing or unreadable.
+    """
+
+    status_path = os.path.join(captured_dir_path, config.processing_status_file)
+
+    try:
+        with open(status_path) as f:
+            status = json.load(f)
+
+        if isinstance(status, dict):
+            return status
+
+    # A missing, truncated or corrupt record simply means nothing is known about this night
+    except Exception:
+        pass
+
+    return {}
+
+
+
+def updateProcessingStatus(config, captured_dir_path, **entries):
+    """ Merge entries into the processing status record of a captured night directory.
+
+    The record is written to a temporary file and moved into place, so a crash midway cannot leave
+    a half-written record behind.
+
+    Arguments:
+        config: [Config obj]
+        captured_dir_path: [str] Full path to the directory in CapturedFiles.
+        entries: Key/value pairs to merge into the record.
+
+    Return:
+        [dict] The record as written, or the unmodified record if writing failed.
+    """
+
+    status_path = os.path.join(captured_dir_path, config.processing_status_file)
+
+    status = readProcessingStatus(config, captured_dir_path)
+    status.update(entries)
+
+    try:
+        tmp_path = status_path + '.tmp'
+        with open(tmp_path, 'w') as f:
+            json.dump(status, f, indent=4, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+
+        os.replace(tmp_path, status_path)
+
+    # Never let the bookkeeping break the processing it is tracking. A night whose status cannot be
+    #   written looks unprocessed, which is the safe direction
+    except Exception as e:
+        log.error('Writing the processing status to {:s} failed with message:\n{:s}'\
+            .format(status_path, repr(e)))
+
+    return status
 
 
 
 def nightProcessingState(config, captured_dir_path):
     """ Determine how far processing got on a captured night directory.
 
-    The authoritative marker is the observation summary. startObservationSummaryReport() writes
-    the working JSON when processing begins, and finalizeObservationSummary() replaces it with the
-    final JSON at the end of processNight(). Both live in the captured directory, so unlike the
-    ArchivedFiles directory they are not removed by retention or quota management.
+    The authoritative marker is the processing status record that processNight() writes into the
+    captured directory: 'started' before archiveDetections() and 'completed' once it returns.
+    Archiving is the last step which can leave a night needing another run, and archiveDetections()
+    creates its destination directory before it finishes writing into it, so neither the observation
+    summary nor the presence of an ArchivedFiles directory is sufficient on its own. The record
+    lives with the captured data, so unlike ArchivedFiles it is not removed by retention or quota
+    management.
+
+    Nights processed before this record existed are recognised from the observation summary, or
+    failing that an FTPdetectinfo, so that upgrading does not reprocess every captured directory
+    already on disk. For those the archive cannot be told apart from one deleted by retention,
+    which is why acting on a missing archive is left to reprocess_if_archive_missing.
 
     Detection backups (rms_queue_bkup_*.pickle) are deliberately NOT treated as evidence of
     incomplete processing. They are a resume aid for detection, and a caller which finishes the
     night but fails to delete them would otherwise make a complete night look partial - this was
     the cause of issue #418.
-
-    Note that the summary is finalized before archiveDetections() runs, so a 'processed' night is
-    one which completed detection and the summary, not necessarily one which was archived.
 
     Arguments:
         config: [Config obj]
@@ -715,12 +797,15 @@ def nightProcessingState(config, captured_dir_path):
 
     Return:
         [NightProcessingState] Named tuple with the individual observations and a derived state of
-            'processed', 'legacy_processed' (finished before this marker existed) or 'incomplete'.
+            'processed', 'legacy_processed' (finished before the record existed) or 'incomplete'.
     """
 
     night_dir_name = os.path.basename(os.path.abspath(captured_dir_path))
 
-    # Check for the observation summary written at the end of processNight
+    # Read how far processNight got, if it left a record
+    archiving = readProcessingStatus(config, captured_dir_path).get('archiving')
+
+    # Check for the observation summary written near the end of processNight
     has_final_summary = os.path.isfile(
         getRMSStyleFileName(captured_dir_path, OBSERVATION_SUMMARY_NAME_JSON))
 
@@ -736,27 +821,33 @@ def nightProcessingState(config, captured_dir_path):
 
     # Check whether the night was archived. Retention and quota management delete ArchivedFiles
     #   independently of CapturedFiles, so a missing archive does not on its own mean the night was
-    #   never processed
+    #   never processed - and a present one does not mean archiving finished
     has_archive_dir = os.path.isdir(
         os.path.join(config.data_dir, config.archived_dir, night_dir_name))
 
 
-    if has_final_summary:
+    # processNight ran to the end
+    if archiving == 'completed':
         state = NIGHT_PROCESSED
 
-    # Nights processed before the summary existed, or by a version which did not write it, only
-    #   have their detection outputs to go on. Treating them as incomplete would reprocess every
-    #   captured directory on the first start after upgrading
-    elif (not has_working_summary) and has_ftpdetectinfo:
+    # processNight started archiving and did not come back, so the archive is incomplete no matter
+    #   what the summary says or whether the destination directory exists
+    elif archiving is not None:
+        state = NIGHT_INCOMPLETE
+
+    # No record: a night from before this was written. Fall back to the outputs it does have, so
+    #   upgrading does not reprocess every captured directory on the first start
+    elif has_final_summary or ((not has_working_summary) and has_ftpdetectinfo):
         state = NIGHT_LEGACY_PROCESSED
 
     else:
         state = NIGHT_INCOMPLETE
 
 
-    return NightProcessingState(state=state, has_final_summary=has_final_summary,
-        has_working_summary=has_working_summary, has_ftpdetectinfo=has_ftpdetectinfo,
-        pickle_files=pickle_files, has_archive_dir=has_archive_dir)
+    return NightProcessingState(state=state, archiving=archiving,
+        has_final_summary=has_final_summary, has_working_summary=has_working_summary,
+        has_ftpdetectinfo=has_ftpdetectinfo, pickle_files=pickle_files,
+        has_archive_dir=has_archive_dir)
 
 
 

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -183,6 +183,16 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
     # Extract the name of the night
     night_data_dir_name = os.path.basename(os.path.abspath(night_data_dir))
 
+    # Mark the night as being processed before any real work starts. The record has to exist on disk
+    #   before the observation summary is finalized: if the 'started' write were left until just
+    #   before archiving (a full disk being the obvious cause of it failing) and archiving then also
+    #   failed, the night would be left with a final summary and no record, and a later start would
+    #   mistake that for a pre-record legacy night and never retry it. Writing it here means the
+    #   absence of a record reliably means "legacy". Only 'completed' (set once archiveDetections
+    #   returns) counts as processed - archiveDetections creates its destination directory before it
+    #   finishes copying, so that directory existing is not proof the night was archived either.
+    updateProcessingStatus(config, night_data_dir, archiving='started')
+
     platepar = None
     kml_files = []
     recalibrated_platepars = None
@@ -673,11 +683,6 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
     log.info('Archiving detections to ' + night_archive_dir)
 
-    # Record that archiving is under way. archiveDetections creates the destination directory before
-    #   it finishes copying into it, so the directory existing is not proof the night was archived -
-    #   this is what tells a later run that an interrupted archive has to be redone
-    updateProcessingStatus(config, night_data_dir, archiving='started')
-
     # Archive the detections
     archive_name, imgdata_archive_name, metadata_archive_name = archiveDetections(night_data_dir,
                                             night_archive_dir, ff_detected, config, extra_files=extra_files)
@@ -1066,9 +1071,10 @@ if __name__ == "__main__":
 
 
         # Delete detection backup files. This has to happen whether or not uploading is enabled and
-        #   whether or not it succeeded: any rms_queue_bkup_*.pickle left in the captured directory
-        #   makes StartCapture treat the night as partially processed and reprocess it all over
-        #   again on the next start.
+        #   whether or not it succeeded: any rms_queue_bkup_*.pickle left in the captured directory is
+        #   dead weight once the night is archived, so tidy it up defensively. The auto-reprocess
+        #   decision no longer keys off these backups (it uses the processing status record), but
+        #   leaving them behind still wastes space and was the original cause of issue #418.
         if detector is not None:
 
             # Never let a cleanup failure mask an exception which is already propagating

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -6,6 +6,8 @@ from __future__ import print_function, division, absolute_import
 
 import os
 import sys
+import glob
+import collections
 import traceback
 import argparse
 import random
@@ -42,8 +44,10 @@ from Utils.PlotTimeIntervals import plotFFTimeIntervals
 from RMS.Formats.ObservationSummary import addObsParam, getObservationSummaryDict, saveObservationSummaryDict, \
     startObservationSummaryReport
 from RMS.Formats.ObservationSummary import serialize, finalizeObservationSummary
+from RMS.Formats.ObservationSummary import OBSERVATION_SUMMARY_NAME_JSON, \
+    OBSERVATION_SUMMARY_WORKING_NAME_JSON
 from Utils.AuditConfig import compareConfigs
-from RMS.Misc import RmsDateTime, tarWithProgress
+from RMS.Misc import RmsDateTime, tarWithProgress, getRMSStyleFileName
 from RMS.RunExternalScript import runExternalScript
 
 # Get the logger from the main module
@@ -674,6 +678,86 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
 
 
     return night_archive_dir, archive_name, imgdata_archive_name, metadata_archive_name, detector
+
+
+
+# Processing states reported by nightProcessingState()
+NIGHT_PROCESSED = 'processed'
+NIGHT_LEGACY_PROCESSED = 'legacy_processed'
+NIGHT_INCOMPLETE = 'incomplete'
+
+
+NightProcessingState = collections.namedtuple('NightProcessingState',
+    ['state', 'has_final_summary', 'has_working_summary', 'has_ftpdetectinfo', 'pickle_files',
+     'has_archive_dir'])
+
+
+
+def nightProcessingState(config, captured_dir_path):
+    """ Determine how far processing got on a captured night directory.
+
+    The authoritative marker is the observation summary. startObservationSummaryReport() writes
+    the working JSON when processing begins, and finalizeObservationSummary() replaces it with the
+    final JSON at the end of processNight(). Both live in the captured directory, so unlike the
+    ArchivedFiles directory they are not removed by retention or quota management.
+
+    Detection backups (rms_queue_bkup_*.pickle) are deliberately NOT treated as evidence of
+    incomplete processing. They are a resume aid for detection, and a caller which finishes the
+    night but fails to delete them would otherwise make a complete night look partial - this was
+    the cause of issue #418.
+
+    Note that the summary is finalized before archiveDetections() runs, so a 'processed' night is
+    one which completed detection and the summary, not necessarily one which was archived.
+
+    Arguments:
+        config: [Config obj]
+        captured_dir_path: [str] Full path to the directory in CapturedFiles.
+
+    Return:
+        [NightProcessingState] Named tuple with the individual observations and a derived state of
+            'processed', 'legacy_processed' (finished before this marker existed) or 'incomplete'.
+    """
+
+    night_dir_name = os.path.basename(os.path.abspath(captured_dir_path))
+
+    # Check for the observation summary written at the end of processNight
+    has_final_summary = os.path.isfile(
+        getRMSStyleFileName(captured_dir_path, OBSERVATION_SUMMARY_NAME_JSON))
+
+    # Check for the working summary written when processing starts
+    has_working_summary = os.path.isfile(
+        getRMSStyleFileName(captured_dir_path, OBSERVATION_SUMMARY_WORKING_NAME_JSON))
+
+    # Check for detection outputs
+    has_ftpdetectinfo = len(glob.glob(os.path.join(captured_dir_path, 'FTPdetectinfo_*.txt'))) > 0
+
+    # Collect any leftover detection backups
+    pickle_files = sorted(glob.glob(os.path.join(captured_dir_path, 'rms_queue_bkup_*.pickle')))
+
+    # Check whether the night was archived. Retention and quota management delete ArchivedFiles
+    #   independently of CapturedFiles, so a missing archive does not on its own mean the night was
+    #   never processed
+    has_archive_dir = os.path.isdir(
+        os.path.join(config.data_dir, config.archived_dir, night_dir_name))
+
+
+    if has_final_summary:
+        state = NIGHT_PROCESSED
+
+    # Nights processed before the summary existed, or by a version which did not write it, only
+    #   have their detection outputs to go on. Treating them as incomplete would reprocess every
+    #   captured directory on the first start after upgrading
+    elif (not has_working_summary) and has_ftpdetectinfo:
+        state = NIGHT_LEGACY_PROCESSED
+
+    else:
+        state = NIGHT_INCOMPLETE
+
+
+    return NightProcessingState(state=state, has_final_summary=has_final_summary,
+        has_working_summary=has_working_summary, has_ftpdetectinfo=has_ftpdetectinfo,
+        pickle_files=pickle_files, has_archive_dir=has_archive_dir)
+
 
 
 def cleanupTempArtifacts(config):

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -18,7 +18,6 @@ from __future__ import print_function, absolute_import
 
 import os
 import sys
-import glob
 import argparse
 import time
 import datetime
@@ -48,7 +47,8 @@ from RMS.DetectStarsAndMeteors import detectStarsAndMeteors
 from RMS.Formats.FFfile import validFFName
 from RMS.Misc import mkdirP, RmsDateTime, UTCFromTimestamp
 from RMS.QueuedPool import QueuedPool
-from RMS.Reprocess import getPlatepar, processNight, processFramesFiles
+from RMS.Reprocess import getPlatepar, processNight, processFramesFiles, nightProcessingState, \
+    NIGHT_PROCESSED, NIGHT_LEGACY_PROCESSED
 from RMS.RunExternalScript import runExternalScript
 from RMS.UploadManager import UploadManager
 from RMS.EventMonitor import EventMonitor
@@ -918,6 +918,71 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
 
 
 
+def getReprocessAttempts(config, captured_dir_path):
+    """ Read how many times auto-reprocessing has already been attempted on a captured directory.
+
+    Arguments:
+        config: [config object] Configuration read from the .config file.
+        captured_dir_path: [str] Full path to the directory in CapturedFiles.
+
+    Return:
+        [int] Number of previous attempts, 0 if unknown.
+    """
+
+    attempts_path = os.path.join(captured_dir_path, config.reprocess_attempts_file)
+
+    try:
+        with open(attempts_path) as f:
+            return max(0, int(f.read().strip()))
+
+    # A missing or unreadable stamp just means no attempts are on record
+    except Exception:
+        return 0
+
+
+
+def setReprocessAttempts(config, captured_dir_path, attempts):
+    """ Record the number of auto-reprocess attempts made on a captured directory.
+
+    Arguments:
+        config: [config object] Configuration read from the .config file.
+        captured_dir_path: [str] Full path to the directory in CapturedFiles.
+        attempts: [int] Number of attempts to record.
+    """
+
+    attempts_path = os.path.join(captured_dir_path, config.reprocess_attempts_file)
+
+    try:
+        with open(attempts_path, 'w') as f:
+            f.write("{:d}\n".format(attempts))
+
+    # Never let the guard's own bookkeeping stop the reprocessing it guards
+    except Exception as e:
+        log.error("Could not record the reprocess attempt count in {:s}: {:s}"\
+            .format(attempts_path, repr(e)))
+
+
+
+def clearReprocessAttempts(config, captured_dir_path):
+    """ Remove the auto-reprocess attempt stamp after a successful reprocess.
+
+    Arguments:
+        config: [config object] Configuration read from the .config file.
+        captured_dir_path: [str] Full path to the directory in CapturedFiles.
+    """
+
+    attempts_path = os.path.join(captured_dir_path, config.reprocess_attempts_file)
+
+    try:
+        if os.path.isfile(attempts_path):
+            os.remove(attempts_path)
+
+    except Exception as e:
+        log.error("Could not remove the reprocess attempt stamp {:s}: {:s}"\
+            .format(attempts_path, repr(e)))
+
+
+
 def processIncompleteCaptures(config, upload_manager):
     """ Reprocess broken capture folders.
     Arguments:
@@ -953,37 +1018,53 @@ def processIncompleteCaptures(config, upload_manager):
         captured_dir_path = os.path.join(config.data_dir, config.captured_dir, captured_subdir)
         log.debug("Checking folder: {:s}".format(captured_subdir))
 
-        # Check if there are any backup pickle files in the capture directory
-        pickle_files = glob.glob("{:s}/rms_queue_bkup_*.pickle".format(captured_dir_path))
-        any_pickle_files = False
-        if len(pickle_files) > 0:
-            any_pickle_files = True
+        # Work out how far processing got on this night. The observation summary is the marker,
+        #   not the detection backups - a night which finished but failed to delete its backups
+        #   used to be reprocessed all over again (issue #418)
+        night_state = nightProcessingState(config, captured_dir_path)
 
-        # Check if there is an FTPdetectinfo file in the directory, indicating the folder was fully
-        #   processed
-        FTPdetectinfo_files = glob.glob('{:s}/FTPdetectinfo_*.txt'.format(captured_dir_path))
-        any_ftpdetectinfo_files = False
-        if len(FTPdetectinfo_files) > 0:
-            any_ftpdetectinfo_files = True
+        if night_state.state in (NIGHT_PROCESSED, NIGHT_LEGACY_PROCESSED):
 
-        # Auto reprocess criteria:
-        #   - Any backup pickle files
-        #   - No pickle and no FTPdetectinfo files
+            # Detection backups left behind by a run which did finish. They are only a resume aid
+            #   for detection, so remove them instead of reprocessing a completed night
+            if night_state.pickle_files:
+                log.info("Removing {:d} stale detection backup(s) from the processed folder {:s}"\
+                    .format(len(night_state.pickle_files), captured_subdir))
 
-        run_reprocess = False
-        if any_pickle_files:
-            run_reprocess = True
-        else:
-            if not any_ftpdetectinfo_files:
-                run_reprocess = True
+                for pickle_file in night_state.pickle_files:
+                    try:
+                        os.remove(pickle_file)
 
-        # Skip the folder if it doesn't need to be reprocessed
-        if not run_reprocess:
-            log.debug("    ... fully processed!")
+                    except Exception as e:
+                        log.error("Could not remove the stale detection backup {:s}: {:s}"\
+                            .format(pickle_file, repr(e)))
+
+            # A missing ArchivedFiles directory only counts as unprocessed if the station asked for
+            #   that, as retention and quota management delete archives on their own schedule
+            if night_state.has_archive_dir or (not config.reprocess_if_archive_missing):
+                log.debug("    ... fully processed!")
+                continue
+
+            log.warning("Folder {:s} looks processed but has no directory in {:s} - reprocessing "
+                "because reprocess_if_archive_missing is enabled"\
+                .format(captured_subdir, config.archived_dir))
+
+
+        # Stop retrying a folder which keeps failing, so it cannot eat the pre-capture window on
+        #   every single start
+        attempts = getReprocessAttempts(config, captured_dir_path)
+        if config.auto_reprocess_max_attempts and (attempts >= config.auto_reprocess_max_attempts):
+            log.warning("Folder {:s} already failed to reprocess {:d} time(s) - skipping. Fix the "
+                "underlying problem and delete {:s} in that folder to retry."\
+                .format(captured_subdir, attempts, config.reprocess_attempts_file))
             continue
 
 
         log.info("Found partially-processed data in {:s}".format(captured_dir_path))
+
+        # Count the attempt up front, so a hard crash during reprocessing is counted too
+        setReprocessAttempts(config, captured_dir_path, attempts + 1)
+
         try:
 
             # Reprocess the night
@@ -1010,9 +1091,13 @@ def processIncompleteCaptures(config, upload_manager):
 
             log.info("Folder {:s} reprocessed with success!".format(captured_dir_path))
 
+            # The night is done, so the failure count is no longer meaningful
+            clearReprocessAttempts(config, captured_dir_path)
+
 
         except Exception as e:
-            log.error("An error occurred when trying to reprocess partially processed data!")
+            log.error("An error occurred when trying to reprocess partially processed data in {:s} "
+                "(attempt {:d})!".format(captured_dir_path, attempts + 1))
             log.error(repr(e))
             log.error(repr(traceback.format_exception(*sys.exc_info())))
 

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -48,7 +48,7 @@ from RMS.Formats.FFfile import validFFName
 from RMS.Misc import mkdirP, RmsDateTime, UTCFromTimestamp
 from RMS.QueuedPool import QueuedPool
 from RMS.Reprocess import getPlatepar, processNight, processFramesFiles, nightProcessingState, \
-    NIGHT_PROCESSED, NIGHT_LEGACY_PROCESSED
+    readProcessingStatus, updateProcessingStatus, NIGHT_PROCESSED, NIGHT_LEGACY_PROCESSED
 from RMS.RunExternalScript import runExternalScript
 from RMS.UploadManager import UploadManager
 from RMS.EventMonitor import EventMonitor
@@ -929,14 +929,13 @@ def getReprocessAttempts(config, captured_dir_path):
         [int] Number of previous attempts, 0 if unknown.
     """
 
-    attempts_path = os.path.join(captured_dir_path, config.reprocess_attempts_file)
+    attempts = readProcessingStatus(config, captured_dir_path).get('failed_reprocess_attempts', 0)
 
     try:
-        with open(attempts_path) as f:
-            return max(0, int(f.read().strip()))
+        return max(0, int(attempts))
 
-    # A missing or unreadable stamp just means no attempts are on record
-    except Exception:
+    # A record written by hand or by a future version could hold anything
+    except (TypeError, ValueError):
         return 0
 
 
@@ -950,36 +949,7 @@ def setReprocessAttempts(config, captured_dir_path, attempts):
         attempts: [int] Number of attempts to record.
     """
 
-    attempts_path = os.path.join(captured_dir_path, config.reprocess_attempts_file)
-
-    try:
-        with open(attempts_path, 'w') as f:
-            f.write("{:d}\n".format(attempts))
-
-    # Never let the guard's own bookkeeping stop the reprocessing it guards
-    except Exception as e:
-        log.error("Could not record the reprocess attempt count in {:s}: {:s}"\
-            .format(attempts_path, repr(e)))
-
-
-
-def clearReprocessAttempts(config, captured_dir_path):
-    """ Remove the auto-reprocess attempt stamp after a successful reprocess.
-
-    Arguments:
-        config: [config object] Configuration read from the .config file.
-        captured_dir_path: [str] Full path to the directory in CapturedFiles.
-    """
-
-    attempts_path = os.path.join(captured_dir_path, config.reprocess_attempts_file)
-
-    try:
-        if os.path.isfile(attempts_path):
-            os.remove(attempts_path)
-
-    except Exception as e:
-        log.error("Could not remove the reprocess attempt stamp {:s}: {:s}"\
-            .format(attempts_path, repr(e)))
+    updateProcessingStatus(config, captured_dir_path, failed_reprocess_attempts=attempts)
 
 
 
@@ -1056,7 +1026,7 @@ def processIncompleteCaptures(config, upload_manager):
         if config.auto_reprocess_max_attempts and (attempts >= config.auto_reprocess_max_attempts):
             log.warning("Folder {:s} already failed to reprocess {:d} time(s) - skipping. Fix the "
                 "underlying problem and delete {:s} in that folder to retry."\
-                .format(captured_subdir, attempts, config.reprocess_attempts_file))
+                .format(captured_subdir, attempts, config.processing_status_file))
             continue
 
 
@@ -1091,8 +1061,9 @@ def processIncompleteCaptures(config, upload_manager):
 
             log.info("Folder {:s} reprocessed with success!".format(captured_dir_path))
 
-            # The night is done, so the failure count is no longer meaningful
-            clearReprocessAttempts(config, captured_dir_path)
+            # The night is done, so the failure count is no longer meaningful. processNight has
+            #   already marked the night complete, so this only tidies the record
+            setReprocessAttempts(config, captured_dir_path, 0)
 
 
         except Exception as e:


### PR DESCRIPTION
Fixes #944.

## The problem

`processIncompleteCaptures()` (`RMS/StartCapture.py`) judged a captured night from two facts inside the captured directory — are there `rms_queue_bkup_*.pickle` files, is there an FTPdetectinfo — and never consulted `ArchivedFiles`. Wrong in both directions, and both halves are in @peschman's #418 report:

- **B, false positive.** `if any_pickle_files` was tested *before* the FTPdetectinfo check, so one stale backup outweighed a complete set of outputs. #942 fixes one producer of leftovers; a crash, a `kill -9`, or any future caller that skips `deleteBackupFiles()` reproduces it.
- **C, retry storm.** A failed reprocess was logged and skipped with the backups left in place, so a night failing deterministically was retried on every start.
- **A, false negative.** A night whose `ArchivedFiles` directory is gone is not detected at all — this is the part of the original report that led him to run the manual reprocess in the first place.

## The change

**Record the archiving phase explicitly.** `processNight()` writes `archiving: started` into a small JSON status file in the captured directory before `archiveDetections()`, and `archiving: completed` once it returns. Only `completed` counts as processed. New `nightProcessingState()` in `RMS/Reprocess.py` reports `processed` / `legacy_processed` / `incomplete` plus the raw observations.

Archiving is the last step that can leave a night needing another run, and neither of the obvious cheaper markers is sufficient: the observation summary is finalized *before* `archiveDetections()`, and `archiveDir()` creates its destination directory before it finishes copying into it, so a partial archive looks like a real one. The record lives with the captured data, so unlike `ArchivedFiles` it survives retention and quota deletion, and it is written atomically via a temp file and `os.replace`.

`legacy_processed` — an observation summary, or failing that an FTPdetectinfo, with no status record — exists so upgrading does not reprocess every captured directory already on disk on the first start.

**B:** a processed night has its stale backups deleted instead of being reprocessed. This closes it for *every* leftover source rather than one caller at a time.

**C:** attempts are counted in the same per-night status record and capped by `auto_reprocess_max_attempts` (default 3, 0 = retry forever, i.e. today's behaviour). The count is written *before* `processNight` runs so a hard crash counts too, and cleared on success. Same shape as the reboot loop guard in `GRMSUpdater.sh`. The failure log now names the folder and the attempt number.

**A:** behind `reprocess_if_archive_missing`, **off by default**. This is the part worth arguing with, so the reasoning in full: `arch_dirs_to_keep` (20) and `capt_dirs_to_keep` (8) are independent, `deleteOldDirs` purges each on its own count, and `deleteByQuota` applies `arch_dir_quota` and `bz2_files_quota` separately from the captured allowance. On a space-constrained station a missing archive usually means it was purged, not that the night was never processed — so a default-on rule would drag old nights into a re-run on every start, which is worse than the bug being fixed. With the flag on, such a night is reprocessed and the attempt guard bounds it.

Limitation worth stating: for legacy nights the archive cannot be told apart from one deleted by retention, which is exactly why acting on a missing archive is left to `reprocess_if_archive_missing`. A night whose status record cannot be written looks unprocessed, which is the safe direction.

## Testing

Full results below. 25 checks over `nightProcessingState()` and `processIncompleteCaptures()`, the latter driven against fixture data directories with `processNight` stubbed.

```
--- nightProcessingState() ---
ok   archiving completed -> processed
ok   completed + stale backups -> still processed
ok   archive dir absence is reported, not decided on
ok   archiving started, never finished -> incomplete
ok     ... even though the summary and archive dir both exist
ok   working summary + backups (crashed mid-run) -> incomplete
ok   FTPdetectinfo only (pre-record night) -> legacy_processed
ok   summary but no record (pre-record night) -> legacy_processed
ok   bare FF files -> incomplete
ok   working summary present -> not legacy, still incomplete
ok   archive dir detected when present

--- processIncompleteCaptures() ---
ok   complete night + stale backup -> not reprocessed
ok   complete night + stale backup -> backup deleted
ok   crashed night -> reprocessed
ok   legacy night (no summary, has FTPdetectinfo) -> not reprocessed
ok   failing night retried exactly auto_reprocess_max_attempts times   tried 3 times
ok   attempt stamp written to the captured dir
ok   auto_reprocess_max_attempts = 0 retries forever                   tried 4 times
ok   successful reprocess clears the attempt count
ok   archive missing, flag off -> not reprocessed (default)
ok   archive missing, flag on -> reprocessed
ok   archive missing, flag on -> guard stops the repeat
ok   archive missing, flag on -> settles after a successful run
ok   archiving died after the summary -> reprocessed
ok   archiving died after the summary -> backups still there to resume from

all 25 passed
```

Also checked against a real `python -m RMS.Reprocess` run on a station directory (`AU0001`, real `.config`, platepar, mask, FF file, uploading off). The run wrote the status record, and — being on `prerelease`, i.e. without #942 — left a `rms_queue_bkup_*.pickle` behind, which is #418 happening again:

```
$ cat .rms_processing_status
{
    "archiving": "completed",
    "completed_utc": "2026-07-27 21:14:49"
}

after real reprocess: processed | archiving: completed | pickles: 1
with stray pickle   : processed
```

The leftover no longer changes the verdict, which is the whole point. `py_compile` clean on all three changed modules; config defaults and `.config` parsing verified.

**Not covered here:** the full `StartCapture` startup path on a live station — reprocess a real captured night by hand, restart capture, confirm it is not re-run. Everything above stubs `processNight` or stops at the criterion.

Test script attached below if it is worth having in the repo; I left it out of the commit since `Tests/` is a collection of scripts rather than a runner.

One thing noticed but not touched: `StartCapture.py` binds the module-level `log` only inside `if __name__ == "__main__":`, so importing the module leaves every function in it without a logger. Harmless today because they are only called from the main path, but it makes the module awkward to test — the script below has to inject one.

<details>
<summary>Test script</summary>

```python
""" Tests for the auto-reprocess criterion: nightProcessingState() and processIncompleteCaptures().

processIncompleteCaptures() is driven against a fixture data_dir with processNight() and the
upload manager stubbed out, so the selection logic, the stale-backup cleanup and the attempt guard
are all exercised without running any real processing.
"""

from __future__ import print_function

import os
import sys
import shutil
import logging
import tempfile

import RMS.ConfigReader as cr
import RMS.StartCapture as sc

# StartCapture binds the module-level `log` only when run as __main__ (StartCapture.py:1167), so
#   importing it for tests leaves the functions without one
sc.log = logging.getLogger('test_autoreprocess')
sc.log.addHandler(logging.NullHandler())
from RMS.Reprocess import nightProcessingState, updateProcessingStatus, NIGHT_PROCESSED, \
    NIGHT_LEGACY_PROCESSED, NIGHT_INCOMPLETE
from RMS.Formats.ObservationSummary import OBSERVATION_SUMMARY_NAME_JSON, \
    OBSERVATION_SUMMARY_WORKING_NAME_JSON
from RMS.Misc import getRMSStyleFileName


STATION = 'XX0001'
NIGHT = STATION + '_20260101_000000_000000'

results = []


def check(name, cond, detail=''):
    results.append((name, bool(cond), detail))
    print('{:s} {:<60s} {:s}'.format('ok  ' if cond else 'FAIL', name, detail))


def makeConfig(data_dir, **overrides):
    config = cr.Config()
    config.stationID = STATION
    config.data_dir = data_dir
    config.captured_dir = 'CapturedFiles'
    config.archived_dir = 'ArchivedFiles'
    config.continuous_capture = True     # skip the captureDuration break at the end of the loop
    config.external_script_run = False
    config.auto_reprocess_external_script_run = False
    for k, v in overrides.items():
        setattr(config, k, v)
    return config


def makeNight(data_dir, night=NIGHT, ff=True, ftpdetectinfo=False, final_summary=False,
              working_summary=False, pickles=0, archive=False, archiving=None, config=None):
    """ Build a captured directory in the requested state. Returns its path. """

    night_dir = os.path.join(data_dir, 'CapturedFiles', night)
    if not os.path.isdir(night_dir):
        os.makedirs(night_dir)

    if ff:
        open(os.path.join(night_dir, 'FF_{:s}_20260101_010203_456_0000000.fits'.format(STATION)),
             'w').close()

    if ftpdetectinfo:
        open(os.path.join(night_dir, 'FTPdetectinfo_{:s}.txt'.format(night)), 'w').close()

    if final_summary:
        open(getRMSStyleFileName(night_dir, OBSERVATION_SUMMARY_NAME_JSON), 'w').close()

    if working_summary:
        open(getRMSStyleFileName(night_dir, OBSERVATION_SUMMARY_WORKING_NAME_JSON), 'w').close()

    for i in range(pickles):
        open(os.path.join(night_dir, 'rms_queue_bkup_{:d}.pickle'.format(i)), 'w').close()

    if archive:
        arch = os.path.join(data_dir, 'ArchivedFiles', night)
        if not os.path.isdir(arch):
            os.makedirs(arch)

    if archiving is not None:
        updateProcessingStatus(config if config is not None else makeConfig(data_dir), night_dir,
                               archiving=archiving)

    return night_dir


# ================================================================================================
print('--- nightProcessingState() ---')

tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp)

d = makeNight(tmp, night=STATION + '_a', final_summary=True, ftpdetectinfo=True, archive=True,
              archiving='completed', config=cfg)
check('archiving completed -> processed', nightProcessingState(cfg, d).state == NIGHT_PROCESSED)

d = makeNight(tmp, night=STATION + '_b', final_summary=True, ftpdetectinfo=True, pickles=2,
              archiving='completed', config=cfg)
st = nightProcessingState(cfg, d)
check('completed + stale backups -> still processed',
      st.state == NIGHT_PROCESSED and len(st.pickle_files) == 2)
check('archive dir absence is reported, not decided on', st.has_archive_dir is False)

# The case codex raised on #945: archiving died after the summary was finalized, leaving a
#   partial archive directory behind
d = makeNight(tmp, night=STATION + '_h', final_summary=True, ftpdetectinfo=True, pickles=1,
              archive=True, archiving='started', config=cfg)
st = nightProcessingState(cfg, d)
check('archiving started, never finished -> incomplete', st.state == NIGHT_INCOMPLETE)
check('  ... even though the summary and archive dir both exist',
      st.has_final_summary and st.has_archive_dir)

d = makeNight(tmp, night=STATION + '_c', working_summary=True, pickles=3)
check('working summary + backups (crashed mid-run) -> incomplete',
      nightProcessingState(cfg, d).state == NIGHT_INCOMPLETE)

d = makeNight(tmp, night=STATION + '_d', ftpdetectinfo=True)
check('FTPdetectinfo only (pre-record night) -> legacy_processed',
      nightProcessingState(cfg, d).state == NIGHT_LEGACY_PROCESSED)

d = makeNight(tmp, night=STATION + '_i', final_summary=True, ftpdetectinfo=True, archive=True)
check('summary but no record (pre-record night) -> legacy_processed',
      nightProcessingState(cfg, d).state == NIGHT_LEGACY_PROCESSED)

d = makeNight(tmp, night=STATION + '_e')
check('bare FF files -> incomplete', nightProcessingState(cfg, d).state == NIGHT_INCOMPLETE)

d = makeNight(tmp, night=STATION + '_f', working_summary=True, ftpdetectinfo=True)
check('working summary present -> not legacy, still incomplete',
      nightProcessingState(cfg, d).state == NIGHT_INCOMPLETE)

d = makeNight(tmp, night=STATION + '_g', final_summary=True, archive=True,
              archiving='completed', config=cfg)
check('archive dir detected when present', nightProcessingState(cfg, d).has_archive_dir is True)

shutil.rmtree(tmp)


# ================================================================================================
print()
print('--- processIncompleteCaptures() ---')

_orig_processNight = sc.processNight


def runScan(config, fail=False, seen_pickles=None):
    """ Run processIncompleteCaptures with processNight stubbed. Returns the dirs it processed.

    seen_pickles: [list] If given, filled with the backups present when processNight was called.
    """

    processed = []

    def fakeProcessNight(captured_dir_path, config_arg):
        processed.append(os.path.basename(captured_dir_path))
        if seen_pickles is not None:
            seen_pickles.extend(f for f in os.listdir(captured_dir_path)
                                if f.startswith('rms_queue_bkup_'))
        if fail:
            # The real processNight marks archiving as started before it can fail there
            updateProcessingStatus(config_arg, captured_dir_path, archiving='started')
            raise RuntimeError('simulated processing failure')

        # Mimic a successful run: mark archiving, write the final summary, drop the backups
        updateProcessingStatus(config_arg, captured_dir_path, archiving='completed')
        open(getRMSStyleFileName(captured_dir_path, OBSERVATION_SUMMARY_NAME_JSON), 'w').close()
        for p in [f for f in os.listdir(captured_dir_path) if f.startswith('rms_queue_bkup_')]:
            os.remove(os.path.join(captured_dir_path, p))
        arch = os.path.join(config_arg.data_dir, config_arg.archived_dir,
                            os.path.basename(captured_dir_path))
        if not os.path.isdir(arch):
            os.makedirs(arch)
        return arch, None, None, None, None

    sc.processNight = fakeProcessNight
    try:
        sc.processIncompleteCaptures(config, None)
    finally:
        sc.processNight = _orig_processNight

    return processed


# The #418 shape: a complete night with one leftover backup
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp)
d = makeNight(tmp, final_summary=True, ftpdetectinfo=True, pickles=1, archive=True,
              archiving='completed', config=cfg)
processed = runScan(cfg)
leftover = [f for f in os.listdir(d) if f.startswith('rms_queue_bkup_')]
check('complete night + stale backup -> not reprocessed', processed == [], str(processed))
check('complete night + stale backup -> backup deleted', leftover == [], str(leftover))
shutil.rmtree(tmp)

# A genuinely incomplete night is still picked up
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp)
makeNight(tmp, working_summary=True, pickles=2)
check('crashed night -> reprocessed', runScan(cfg) == [NIGHT])
shutil.rmtree(tmp)

# A legacy night is left alone
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp)
makeNight(tmp, ftpdetectinfo=True)
check('legacy night (no summary, has FTPdetectinfo) -> not reprocessed', runScan(cfg) == [])
shutil.rmtree(tmp)

# Attempt guard: a night which always fails is tried exactly max_attempts times
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp, auto_reprocess_max_attempts=3)
makeNight(tmp, working_summary=True)
tries = sum(len(runScan(cfg, fail=True)) for _ in range(6))
check('failing night retried exactly auto_reprocess_max_attempts times', tries == 3,
      'tried {:d} times'.format(tries))
stamp = os.path.join(tmp, 'CapturedFiles', NIGHT, cfg.processing_status_file)
check('attempt stamp written to the captured dir', os.path.isfile(stamp))
shutil.rmtree(tmp)

# max_attempts = 0 keeps the old retry-forever behaviour
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp, auto_reprocess_max_attempts=0)
makeNight(tmp, working_summary=True)
tries = sum(len(runScan(cfg, fail=True)) for _ in range(4))
check('auto_reprocess_max_attempts = 0 retries forever', tries == 4, 'tried {:d} times'.format(tries))
shutil.rmtree(tmp)

# A successful reprocess clears the stamp
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp, auto_reprocess_max_attempts=3)
makeNight(tmp, working_summary=True)
runScan(cfg, fail=True)
runScan(cfg)
check('successful reprocess clears the attempt count',
      sc.getReprocessAttempts(cfg, os.path.join(tmp, 'CapturedFiles', NIGHT)) == 0)
shutil.rmtree(tmp)

# reprocess_if_archive_missing off: complete night with no archive is left alone
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp, reprocess_if_archive_missing=False)
makeNight(tmp, final_summary=True, ftpdetectinfo=True, archive=False, archiving='completed',
          config=cfg)
check('archive missing, flag off -> not reprocessed (default)', runScan(cfg) == [])
shutil.rmtree(tmp)

# reprocess_if_archive_missing on: reprocessed once, then blocked by the guard
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp, reprocess_if_archive_missing=True, auto_reprocess_max_attempts=1)
makeNight(tmp, final_summary=True, ftpdetectinfo=True, archive=False, archiving='completed',
          config=cfg)
first = runScan(cfg, fail=True)
second = runScan(cfg, fail=True)
check('archive missing, flag on -> reprocessed', first == [NIGHT], str(first))
check('archive missing, flag on -> guard stops the repeat', second == [], str(second))
shutil.rmtree(tmp)

# ...and a successful run restores the archive, so it settles
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp, reprocess_if_archive_missing=True)
makeNight(tmp, final_summary=True, ftpdetectinfo=True, archive=False, archiving='completed',
          config=cfg)
runScan(cfg)
check('archive missing, flag on -> settles after a successful run', runScan(cfg) == [])
shutil.rmtree(tmp)

# The codex #945 case, end to end: a night whose archiving died must be retried, and its backups
# must survive so detection can resume from them
tmp = tempfile.mkdtemp()
cfg = makeConfig(tmp)
d = makeNight(tmp, final_summary=True, ftpdetectinfo=True, pickles=2, archive=True,
              archiving='started', config=cfg)
seen = []
processed = runScan(cfg, seen_pickles=seen)
check('archiving died after the summary -> reprocessed', processed == [NIGHT], str(processed))
check('archiving died after the summary -> backups still there to resume from', len(seen) == 2,
      str(seen))
shutil.rmtree(tmp)


print()
failed = [n for n, ok, _ in results if not ok]
if failed:
    print('{:d} FAILED, {:d} passed'.format(len(failed), len(results) - len(failed)))
    sys.exit(1)
print('all {:d} passed'.format(len(results)))
```

</details>
