### PR TITLE
Fix NaN photometric offsets crashing the recalibration plot and killing capture

### DIFF
--- a/RMS/Astrometry/ApplyAstrometry.py
+++ b/RMS/Astrometry/ApplyAstrometry.py
@@ -67,6 +67,11 @@ if sys.version_info.major == 3:
     unicode = str
 
 
+# The minimum number of stars that has to remain in the robust photometric fit. Rejecting below this
+#   number makes the fit degenerate (the standard deviation of a fit on 0 or 1 stars is not defined)
+MIN_PHOTOM_FIT_STARS = 3
+
+
 def limitVignettingCoefficient(x_res, y_res, vignetting_coeff, delta_mag=2.5):
     """ Limit the vignetting coefficient so that the drop in brightness in the corner of the image is not
         does not exceed delta_mag magnitudes.
@@ -445,12 +450,30 @@ def photometryFitRobust(px_intens_list, radius_list, catalog_mags, fixed_vignett
         # Skip the rejection in the last iteration
         if i < reject_iters - 1:
 
+            # If the fit is degenerate (e.g. a single star, or a perfect fit), the rejection threshold is
+            #   zero or undefined and would reject every star, leaving nothing to fit in the next
+            #   iteration (which produces a NaN standard deviation). Keep the current fit instead.
+            if (not np.isfinite(fit_stddev)) or (fit_stddev <= 0):
+                break
+
             # Reject all 2 sigma residuals and all larger than 1.0 mag, and re-fit the photometry
             filter_indices = (np.abs(fit_resid) < 2*fit_stddev) & (np.abs(fit_resid) < 1.0)
+
+            # Don't reject if too few stars would remain for a meaningful fit
+            if np.count_nonzero(filter_indices) < min(MIN_PHOTOM_FIT_STARS, len(px_intens_list)):
+                break
+
             px_intens_list = px_intens_list[filter_indices]
             radius_list = radius_list[filter_indices]
             catalog_mags = catalog_mags[filter_indices]
 
+
+    # Make sure that a non-finite standard deviation is never returned, as it would poison every
+    #   computation downstream (e.g. the photometric offset plots and the averaging of the offset
+    #   between neighbouring FF files). A zero standard deviation is treated as "not calibrated"
+    #   by the callers, which is the correct interpretation of a degenerate fit.
+    if not np.isfinite(fit_stddev):
+        fit_stddev = 0.0
 
     return photom_params, fit_stddev, fit_resid, px_intens_list, radius_list, catalog_mags
 

--- a/RMS/Astrometry/ApplyRecalibrate.py
+++ b/RMS/Astrometry/ApplyRecalibrate.py
@@ -11,6 +11,7 @@ import json
 import os
 import shutil
 import sys
+import traceback
 import logging
 from collections import OrderedDict
 
@@ -974,9 +975,25 @@ def recalibrateIndividualFFsAndApplyAstrometry(
                         if ff_name_tmp in recalibrated_platepars:
 
                             # Get the computed photometric offset and stddev
-                            photom_offset_tmp_list.append(recalibrated_platepars[ff_name_tmp].mag_lev)
-                            photom_offset_std_tmp_list.append(recalibrated_platepars[ff_name_tmp].mag_lev_stddev)
+                            mag_lev_tmp = recalibrated_platepars[ff_name_tmp].mag_lev
+                            mag_lev_stddev_tmp = recalibrated_platepars[ff_name_tmp].mag_lev_stddev
+
+                            # Only use neighbours with a usable photometric solution. Averaging in a
+                            #   non-finite value would make the average non-finite and, as the average is
+                            #   written back to all neighbours, the non-finite value would spread to all
+                            #   FF files of the night through overlapping neighbourhoods
+                            if not (np.isfinite(mag_lev_tmp) and np.isfinite(mag_lev_stddev_tmp)):
+                                continue
+
+                            photom_offset_tmp_list.append(mag_lev_tmp)
+                            photom_offset_std_tmp_list.append(mag_lev_stddev_tmp)
                             neighboring_ffs.append(ff_name_tmp)
+
+                # If no neighbour had a usable photometric solution, keep the individual values as they are
+                if len(photom_offset_tmp_list) == 0:
+                    log.warning('No finite photometric offsets among the neighbours of {:s}, skipping the '
+                                'photometric offset averaging!'.format(ff_name))
+                    continue
 
                 # Compute the new photometric offset and improved standard deviation (assume equal sample size)
                 #   Source: https://stats.stackexchange.com/questions/55999/is-it-possible-to-find-the-combined-standard-deviation
@@ -1152,84 +1169,115 @@ def recalibrateIndividualFFsAndApplyAstrometry(
         photom_offset_std_list.append(pp_temp.mag_lev_stddev)
 
 
+    # The plots are only informative, so a failure to generate them must never abort the processing of
+    #   the night (the astrometry has already been applied and the recalibrated platepars written out)
     if generate_plot:
 
-        # Generate the name the plots
-        plot_name = os.path.basename(ftpdetectinfo_path).replace('FTPdetectinfo_', '').replace('.txt', '')
+        try:
 
-        ### Plot difference from reference platepar in angular distance from (0, 0) vs rotation ###
+            # Generate the name the plots
+            plot_name = os.path.basename(ftpdetectinfo_path).replace('FTPdetectinfo_', '').replace('.txt', '')
 
-        plt.figure(figsize=(6, 5))
+            ### Plot difference from reference platepar in angular distance from (0, 0) vs rotation ###
 
-        plt.scatter(0, 0, marker='o', edgecolor='k', label='Reference platepar', s=100, c='none', zorder=3)
+            plt.figure(figsize=(6, 5))
 
-        plt.scatter(ang_dists, rot_angles, c=hour_list, zorder=3)
-        plt.colorbar(label="Hours from first FF file")
+            plt.scatter(0, 0, marker='o', edgecolor='k', label='Reference platepar', s=100, c='none', \
+                zorder=3)
 
-        plt.xlabel("Angular distance from reference (arcmin)")
-        plt.ylabel("Rotation from reference (arcmin)")
+            plt.scatter(ang_dists, rot_angles, c=hour_list, zorder=3)
+            plt.colorbar(label="Hours from first FF file")
 
-        plt.title("FOV centre drift starting at {:s}".format(first_dt.strftime("%Y/%m/%d %H:%M:%S")))
+            plt.xlabel("Angular distance from reference (arcmin)")
+            plt.ylabel("Rotation from reference (arcmin)")
 
-        plt.grid()
-        plt.legend()
+            plt.title("FOV centre drift starting at {:s}".format(first_dt.strftime("%Y/%m/%d %H:%M:%S")))
 
-        # Scale the aspect ratio so X and Y units are the same but the plot is not too narrow
-        plt.axis('scaled')
+            plt.grid()
+            plt.legend()
 
-        # Make the plot square by adjusting the limits to the maximum
-        min_lim = min(plt.xlim()[0], plt.ylim()[0])
-        max_lim = max(plt.xlim()[1], plt.ylim()[1])
-        abs_lim = max_lim - min_lim
-        plt.xlim(-0.1*abs_lim, 0.9*abs_lim)
-        plt.ylim(min_lim, max_lim)
+            # Scale the aspect ratio so X and Y units are the same but the plot is not too narrow
+            plt.axis('scaled')
+
+            # Make the plot square by adjusting the limits to the maximum
+            min_lim = min(plt.xlim()[0], plt.ylim()[0])
+            max_lim = max(plt.xlim()[1], plt.ylim()[1])
+            abs_lim = max_lim - min_lim
+            plt.xlim(-0.1*abs_lim, 0.9*abs_lim)
+            plt.ylim(min_lim, max_lim)
 
 
-        plt.tight_layout()
+            plt.tight_layout()
 
-        plt.savefig(os.path.join(dir_path, plot_name + '_calibration_variation.png'), dpi=150)
+            plt.savefig(os.path.join(dir_path, plot_name + '_calibration_variation.png'), dpi=150)
 
-        # plt.show()
+            # plt.show()
 
-        plt.clf()
-        plt.close()
+            plt.clf()
+            plt.close()
 
-        ### ###
+            ### ###
 
-        ### Plot the photometric offset variation ###
+            ### Plot the photometric offset variation ###
 
-        plt.figure()
+            # Skip the plot if there are not enough points (platepars which failed the fit are skipped
+            #   above, so fewer points can remain than there are recalibrated platepars)
+            if len(dt_list) < 2:
 
-        plt.errorbar(
-            dt_list,
-            photom_offset_list,
-            yerr=photom_offset_std_list,
-            fmt="o",
-            ecolor='lightgray',
-            elinewidth=2,
-            capsize=0,
-            ms=2,
-        )
+                log.info('Less than 2 photometric offsets available, skipping the photometry plot...')
 
-        # Format datetimes
-        plt.gca().xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
+            else:
 
-        # rotate and align the tick labels so they look better
-        plt.gcf().autofmt_xdate()
+                # Sanitize the error bars. Non-finite values break the error bar plotting in older
+                #   versions of matplotlib (they raise a StopIteration), so replace them with zeros and
+                #   omit the error bars completely if none of the values are usable
+                photom_offset_std_arr = np.array(photom_offset_std_list, dtype=np.float64)
+                if np.any(np.isfinite(photom_offset_std_arr)):
+                    yerr = np.where(np.isfinite(photom_offset_std_arr), photom_offset_std_arr, 0.0)
 
-        plt.xlabel("UTC time")
-        plt.ylabel("Photometric offset")
+                else:
+                    yerr = None
 
-        plt.title("Photometric offset variation")
+                plt.figure()
 
-        plt.grid()
+                plt.errorbar(
+                    dt_list,
+                    photom_offset_list,
+                    yerr=yerr,
+                    fmt="o",
+                    ecolor='lightgray',
+                    elinewidth=2,
+                    capsize=0,
+                    ms=2,
+                )
 
-        plt.tight_layout()
+                # Format datetimes
+                plt.gca().xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
 
-        plt.savefig(os.path.join(dir_path, plot_name + '_photometry_variation.png'), dpi=150)
+                # rotate and align the tick labels so they look better
+                plt.gcf().autofmt_xdate()
 
-        plt.clf()
-        plt.close()
+                plt.xlabel("UTC time")
+                plt.ylabel("Photometric offset")
+
+                plt.title("Photometric offset variation")
+
+                plt.grid()
+
+                plt.tight_layout()
+
+                plt.savefig(os.path.join(dir_path, plot_name + '_photometry_variation.png'), dpi=150)
+
+                plt.clf()
+                plt.close()
+
+        except Exception as e:
+
+            log.warning('Generating the recalibration plots failed with the message:\n' + repr(e))
+            log.debug(repr(traceback.format_exception(*sys.exc_info())))
+
+            # Close any half-built figure so that it doesn't leak into the plots generated later
+            plt.close('all')
 
     ### ###
 

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -438,6 +438,9 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
     # Initialize the detector
     detector = None
 
+    # Path to the archive directory of the processed night (stays None if the night was never processed)
+    night_archive_dir = None
+
     # Loop to handle both continuous and standard capture modes
     while True:
 
@@ -838,28 +841,46 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
                 detection_results = []
 
             # Save detection to disk and archive detection
-            night_archive_dir, archive_name, imgdata_archive_name, metadata_archive_name, _ =  \
-                processNight(night_data_dir, config, detection_results=detection_results, nodetect=nodetect)
+            #   Never let a failure here propagate, as it would terminate the capture loop and no
+            #   further nights would be captured until RMS is restarted. The detection backup files are
+            #   kept on failure, so the night is automatically reprocessed on the next startup
+            night_archive_dir = None
+            night_processed = False
+            try:
+                night_archive_dir, archive_name, imgdata_archive_name, metadata_archive_name, _ =  \
+                    processNight(night_data_dir, config, detection_results=detection_results, \
+                        nodetect=nodetect)
 
-            files_to_add_list_unfiltered = [archive_name, metadata_archive_name, imgdata_archive_name]
-            files_to_add_list = [f for f in files_to_add_list_unfiltered if f is not None]
+                night_processed = True
 
-            # Put the archive up for upload
-            if upload_manager is not None:
-                log.info(f"Adding files to upload list: {files_to_add_list}")
-                upload_manager.addFiles(files_to_add_list)
-                if files_to_add_list:
-                    if len(files_to_add_list) == 1:
-                        log.info("File added.")
-                    else:
-                        log.info("Files added.")
+            except Exception as e:
+                log.error("An error occurred when processing the night directory {:s}!".format(
+                    night_data_dir))
+                log.error(repr(e))
+                log.error(repr(traceback.format_exception(*sys.exc_info())))
 
-                # optional delay (minutes in .config, converted to seconds)
-                upload_manager.delayNextUpload(delay=60*config.upload_delay)
 
-            # Delete detector backup files
-            if detector is not None:
-                detector.deleteBackupFiles()
+            if night_processed:
+
+                files_to_add_list_unfiltered = [archive_name, metadata_archive_name, imgdata_archive_name]
+                files_to_add_list = [f for f in files_to_add_list_unfiltered if f is not None]
+
+                # Put the archive up for upload
+                if upload_manager is not None:
+                    log.info(f"Adding files to upload list: {files_to_add_list}")
+                    upload_manager.addFiles(files_to_add_list)
+                    if files_to_add_list:
+                        if len(files_to_add_list) == 1:
+                            log.info("File added.")
+                        else:
+                            log.info("Files added.")
+
+                    # optional delay (minutes in .config, converted to seconds)
+                    upload_manager.delayNextUpload(delay=60*config.upload_delay)
+
+                # Delete detector backup files
+                if detector is not None:
+                    detector.deleteBackupFiles()
 
 
             # frames -> timelapse(s) -> archive(s) -> upload
@@ -884,8 +905,13 @@ def runCapture(config, duration=None, video_file=None, nodetect=False, detect_en
                         log.exception("Frames upload failed")
 
 
-            # Run the external script
-            runExternalScript(night_data_dir, night_archive_dir, config)
+            # Run the external script (skip it if the night was not archived, as it takes the archive
+            #   directory as an argument)
+            if night_archive_dir is not None:
+                runExternalScript(night_data_dir, night_archive_dir, config)
+
+            else:
+                log.warning("Skipping the external script, the night was not successfully processed!")
 
 
         # If capture is terminated manually, or the disk is full, exit program


### PR DESCRIPTION
## Problem

A station reported that capture gets stuck after a night of processing and only recovers after a reboot. The log shows an uncaught `StopIteration` from matplotlib inside `recalibrateIndividualFFsAndApplyAstrometry`:

```
File ".../RMS/Astrometry/ApplyRecalibrate.py", line 1127, in recalibrateIndividualFFsAndApplyAstrometry
  plt.errorbar(
File ".../matplotlib/cbook/__init__.py", line 1715, in _safe_first_finite
  return next(val for val in obj if safe_isfinite(val))
StopIteration
```

## Chain of causation

1. **NaN is produced by the robust photometry fit.** `photometryFitRobust()` rejected outliers with `|resid| < 2*fit_stddev`. For a degenerate fit (a single matched star, or a perfect fit) `fit_stddev` is zero, so the mask rejected *every* star; the next iteration fitted an empty array, giving `fit_stddev = sqrt(0/0) = nan` and a photometric offset equal to the Nelder-Mead initial guess. Reproduced: 1 star in → `offset 10.0, stddev nan, 0 stars left`.

2. **The NaN cascaded over the whole night.** The averaging of the photometric offset between neighbouring FF files did not filter non-finite values, and wrote the average back to *all* neighbours. Overlapping neighbourhoods then spread a single degenerate fit across the night.

3. **All-NaN error bars crash old matplotlib.** In matplotlib < 3.9, `_safe_first_finite` is a bare `next(...)` with no default and raises `StopIteration` when nothing is finite. Stations run older versions (`requirements.txt` only asks for `matplotlib>=2.1.1`), so the fix belongs in RMS, not in a version bump.

4. **The crash killed the capture daemon.** `processNight()` was not wrapped in a try/except in `runCapture()`, so the exception propagated out of the nightly loop and exited the process — no upload, and no further capture until reboot.

## Changes

- **`RMS/Astrometry/ApplyAstrometry.py`** — `photometryFitRobust()` stops rejecting when the fit is degenerate (`fit_stddev` non-finite or `<= 0`) or when fewer than `MIN_PHOTOM_FIT_STARS = 3` stars would remain, and never returns a non-finite standard deviation.
- **`RMS/Astrometry/ApplyRecalibrate.py`** — the photometric offset averaging skips neighbours without a finite solution and keeps the individual values if no neighbour is usable.
- **`RMS/Astrometry/ApplyRecalibrate.py`** — plot generation is wrapped in a try/except (the plots are only informative; the astrometry and the recalibrated platepars are already written at that point), the photometry plot is skipped when fewer than two points are available, and the error bars are sanitized before plotting.
- **`RMS/StartCapture.py`** — a failure in `processNight()` is caught and logged. The detection backup files are kept in that case, so the existing auto-reprocess path picks the night up on the next startup, and the capture loop keeps running instead of exiting. `runExternalScript` is skipped when the night was not archived.

## Verification

- **Crash reproduced, then fixed.** A harness drives the real `recalibrateIndividualFFsAndApplyAstrometry` with all-NaN photometric stddevs, with `cbook._safe_first_finite` monkeypatched back to the pre-3.9 raising implementation (the local matplotlib is 3.9.1 and tolerates NaN). Against the pre-fix code it reproduces the exact station traceback; against this branch both plots are written and the function returns normally.
- **Root cause.** `photometryFitRobust` now returns a finite stddev for 1, 2, 3, 4, 5, 6 and 20 stars (was `nan` for 1 star), and outlier rejection still works (20 stars with an injected outlier → 14 kept).
- **No regression on normal nights.** 30 randomized realistic fits (10–120 stars with seeded outliers) give identical offset, stddev and kept-star counts before and after the change; only the degenerate single-star case differs.
- `pyflakes` clean on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)