### PR TITLE
Save only the tuned catalog LM, and show what a config save writes

### DIFF
--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -4296,6 +4296,10 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
         # Sync with Star Detection panel
         self.gui.tab.star_detection.setCatalogLM(self.gui.cat_lim_mag)
 
+        # The LM is part of what Save Config writes, so refresh the save button and the
+        #   File Manager's unsaved indicator
+        self.gui._updateConfigSaveButtonState()
+
     def populateCatalogList(self):
         """Populate the catalog combo box with available catalogs."""
         import os

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -4335,9 +4335,6 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
         # Sync with Star Detection panel
         self.gui.tab.star_detection.setCatalogLM(self.gui.cat_lim_mag)
 
-        # The LM is saved to the config, so refresh the unsaved indicators
-        self.gui._updateConfigSaveButtonState()
-
     def populateCatalogList(self):
         """Populate the catalog combo box with available catalogs."""
         import os

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -4296,8 +4296,7 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
         # Sync with Star Detection panel
         self.gui.tab.star_detection.setCatalogLM(self.gui.cat_lim_mag)
 
-        # The LM is part of what Save Config writes, so refresh the save button and the
-        #   File Manager's unsaved indicator
+        # The LM is saved to the config, so refresh the unsaved indicators
         self.gui._updateConfigSaveButtonState()
 
     def populateCatalogList(self):

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1874,7 +1874,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
 
 
     def _addConfigPreview(self, layout):
-        """ List the values a config save will write, as old -> new.
+        """ Tabulate the values a config save will write, as current -> new.
 
         The tuned catalog limiting magnitude gets a checkbox of its own, as it is only written on
         request. Returns that checkbox, or None if the LM was not tuned in this session.
@@ -1882,9 +1882,43 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
         pt = self.plate_tool
 
         group = QtWidgets.QGroupBox("Values written to the config")
-        group_layout = QtWidgets.QVBoxLayout(group)
+        grid = QtWidgets.QGridLayout(group)
+        grid.setHorizontalSpacing(10)
+        grid.setColumnStretch(4, 1)
+
+        for col, title in [(0, "Parameter"), (1, "Current"), (3, "New")]:
+            header = QtWidgets.QLabel(title)
+            header.setFont(self._boldFont(header))
+            if col == 1:
+                header.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight
+                                    | QtCore.Qt.AlignmentFlag.AlignVCenter)
+            grid.addWidget(header, 0, col)
+
+        def addRow(row, name_widget, old_str, new_str, note=""):
+            """ Fill one table row, bolding the new value when it differs from the current one. """
+
+            grid.addWidget(name_widget, row, 0)
+
+            old_label = QtWidgets.QLabel(old_str)
+            old_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight
+                                   | QtCore.Qt.AlignmentFlag.AlignVCenter)
+            grid.addWidget(old_label, row, 1)
+
+            # Unchanged values are written too, but showing "400 -> 400" is only noise
+            if old_str != new_str:
+                grid.addWidget(QtWidgets.QLabel("->"), row, 2)
+
+                new_label = QtWidgets.QLabel(new_str)
+                new_label.setFont(self._boldFont(new_label))
+                grid.addWidget(new_label, row, 3)
+
+            if note:
+                note_label = QtWidgets.QLabel(note)
+                note_label.setFont(self._italicFont(note_label))
+                grid.addWidget(note_label, row, 4)
 
         # Star extraction parameters, always written
+        row = 1
         for key, new_value in [
                 ("intensity_threshold", pt.override_intensity_threshold),
                 ("segment_radius", pt.override_segment_radius),
@@ -1893,20 +1927,15 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                 ("max_feature_ratio", pt.override_max_feature_ratio),
                 ("roundness_threshold", pt.override_roundness_threshold)]:
 
-            # Compare the strings that end up in the file, not the numbers
-            old_str = str(getattr(pt.config, key, "?"))
-            new_str = str(new_value)
-
-            if old_str == new_str:
-                text = "{}: {} (unchanged)".format(key, new_str)
-            else:
-                text = "{}: {} -> {}".format(key, old_str, new_str)
-
             # Say so when the floor, rather than the tuning, set the value
+            note = ""
             if key == "max_stars" and pt.override_max_stars < MIN_CONFIG_MAX_STARS:
-                text += " (raised to the minimum for processing)"
+                note = "raised to the minimum for processing"
 
-            group_layout.addWidget(QtWidgets.QLabel(text))
+            # Compare the strings that end up in the file, not the numbers
+            addRow(row, QtWidgets.QLabel(key), str(getattr(pt.config, key, "?")), str(new_value),
+                   note=note)
+            row += 1
 
         # The catalog LM is only offered when the tuner found one. Everything else that moves the LM
         #   (the spinboxes, the R/F keys, plate fitting) is a working value that must not be saved,
@@ -1914,16 +1943,33 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
         lm_checkbox = None
         if getattr(pt, 'catalog_lm_tuned', False) and hasattr(pt, 'tuned_cat_lim_mag'):
 
-            lm_checkbox = QtWidgets.QCheckBox("catalog_mag_limit: {} -> {:.1f} (tuned)".format(
-                getattr(pt.config, 'catalog_mag_limit', "?"), pt.tuned_cat_lim_mag))
+            lm_checkbox = QtWidgets.QCheckBox("catalog_mag_limit")
             lm_checkbox.setChecked(True)
             lm_checkbox.setToolTip("Recalibration matches stars down to this magnitude. "
                                    "Uncheck to keep the value already in the config.")
-            group_layout.addWidget(lm_checkbox)
+
+            addRow(row, lm_checkbox, str(getattr(pt.config, 'catalog_mag_limit', "?")),
+                   "{:.1f}".format(pt.tuned_cat_lim_mag), note="tuned")
 
         layout.addWidget(group)
 
         return lm_checkbox
+
+
+    @staticmethod
+    def _boldFont(widget):
+        """ Return the widget's font, in bold. """
+        font = widget.font()
+        font.setBold(True)
+        return font
+
+
+    @staticmethod
+    def _italicFont(widget):
+        """ Return the widget's font, in italics. """
+        font = widget.font()
+        font.setItalic(True)
+        return font
 
 
     def _saveFile(self, ftype, target_dirs, save_lm=False):

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1891,6 +1891,11 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                     pt.config.segment_radius = pt.override_segment_radius
                     pt.config.max_feature_ratio = pt.override_max_feature_ratio
                     pt.config.roundness_threshold = pt.override_roundness_threshold
+                    # Sync the LM to the value actually written, not to pt.cat_lim_mag: the
+                    #   file holds it to one decimal, and isConfigModified() compares against
+                    #   this attribute, so storing the unrounded value would report the config
+                    #   as modified again the moment it was saved
+                    pt.config.catalog_mag_limit = config_catalog_lm
                     pt._updateConfigSaveButtonState()
                     results.append("Config saved to: " + dest)
                 except Exception as e:
@@ -4749,6 +4754,13 @@ class PlateTool(QtWidgets.QMainWindow):
             or self.override_segment_radius != getattr(cfg, 'segment_radius', self.override_segment_radius)
             or abs(self.override_max_feature_ratio - getattr(cfg, 'max_feature_ratio', self.override_max_feature_ratio)) > 1e-6
             or abs(self.override_roundness_threshold - getattr(cfg, 'roundness_threshold', self.override_roundness_threshold)) > 1e-6
+            # The catalog LM is written to the config too, so a tuned or hand-set LM has to
+            #   count as an unsaved change - otherwise Save Config stays disabled and there is
+            #   no way to persist it. Compared at the precision it is written with (one
+            #   decimal), so the rounding in _writeStarDetectionConfig cannot leave the config
+            #   looking permanently modified after a save.
+            or abs(getattr(self, 'cat_lim_mag', 0.0)
+                   - getattr(cfg, 'catalog_mag_limit', getattr(self, 'cat_lim_mag', 0.0))) > 0.05
         )
 
     def _updateConfigSaveButtonState(self):
@@ -4769,6 +4781,10 @@ class PlateTool(QtWidgets.QMainWindow):
 
         self.updateLeftLabels()
         self.updateStars()
+
+        # The LM is part of what Save Config writes, so refresh the save button and the
+        #   File Manager's unsaved indicator
+        self._updateConfigSaveButtonState()
 
 
     def toggleStarDetectionOverride(self):
@@ -5328,6 +5344,11 @@ class PlateTool(QtWidgets.QMainWindow):
             # Store tuned LM for restoration after fitting (balancing may change it)
             self.tuned_cat_lim_mag = best_lm
             self.catalog_lm_tuned = True
+
+            # The tuned LM is an unsaved config change in its own right. It usually rides
+            #   along with the tuned segment_radius, but flag it explicitly so a tune that
+            #   only moves the LM still offers to save.
+            self._updateConfigSaveButtonState()
 
             # Count visible catalog stars at new LM (filter to FOV first to prevent back-projection)
             _, catalog_in_fov = self.filterCatalogStarsInsideFOV(self.catalog_stars)

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1883,17 +1883,13 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                 try:
                     src = pt.config.config_file_name
                     dest = os.path.join(target_dir, os.path.basename(src))
-                    # Write the tuned catalog LM as is. ApplyRecalibrate reads the catalog one
-                    #   magnitude deeper than this, but it matches stars down to the raw
-                    #   catalog_mag_limit, so nothing has to be subtracted here.
-                    config_catalog_lm = max(3.0, pt.cat_lim_mag)
                     if os.path.realpath(src) != os.path.realpath(dest):
                         # Copy the config to the target, then write overrides into the copy
                         shutil.copy2(src, dest)
-                        pt._writeStarDetectionConfig(dest, config_catalog_lm)
+                        pt._writeStarDetectionConfig(dest)
                     else:
                         # Same file — write overrides in-place (backup handled by _writeStarDetectionConfig)
-                        pt._writeStarDetectionConfig(dest, config_catalog_lm)
+                        pt._writeStarDetectionConfig(dest)
                     # Sync in-memory config attrs so modified state is cleared
                     pt.config.intensity_threshold = pt.override_intensity_threshold
                     pt.config.neighborhood_size = pt.override_neighborhood_size
@@ -1901,8 +1897,6 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                     pt.config.segment_radius = pt.override_segment_radius
                     pt.config.max_feature_ratio = pt.override_max_feature_ratio
                     pt.config.roundness_threshold = pt.override_roundness_threshold
-                    # Keep the in-memory LM in sync, so the config isn't flagged as modified again
-                    pt.config.catalog_mag_limit = config_catalog_lm
                     pt._updateConfigSaveButtonState()
                     results.append("Config saved to: " + dest)
                 except Exception as e:
@@ -4771,10 +4765,6 @@ class PlateTool(QtWidgets.QMainWindow):
             or self.override_segment_radius != getattr(cfg, 'segment_radius', self.override_segment_radius)
             or abs(self.override_max_feature_ratio - getattr(cfg, 'max_feature_ratio', self.override_max_feature_ratio)) > 1e-6
             or abs(self.override_roundness_threshold - getattr(cfg, 'roundness_threshold', self.override_roundness_threshold)) > 1e-6
-            # The LM is saved to the config too. Compare it at the precision it's written with
-            #   (one decimal), so a save doesn't leave the config looking modified.
-            or abs(getattr(self, 'cat_lim_mag', 0.0)
-                   - getattr(cfg, 'catalog_mag_limit', getattr(self, 'cat_lim_mag', 0.0))) > 0.05
         )
 
     def _updateConfigSaveButtonState(self):
@@ -4795,9 +4785,6 @@ class PlateTool(QtWidgets.QMainWindow):
 
         self.updateLeftLabels()
         self.updateStars()
-
-        # The LM is saved to the config, so refresh the unsaved indicators
-        self._updateConfigSaveButtonState()
 
 
     def toggleStarDetectionOverride(self):
@@ -5357,9 +5344,6 @@ class PlateTool(QtWidgets.QMainWindow):
             # Store tuned LM for restoration after fitting (balancing may change it)
             self.tuned_cat_lim_mag = best_lm
             self.catalog_lm_tuned = True
-
-            # The tuned LM is an unsaved config change on its own, flag it
-            self._updateConfigSaveButtonState()
 
             # Count visible catalog stars at new LM (filter to FOV first to prevent back-projection)
             _, catalog_in_fov = self.filterCatalogStarsInsideFOV(self.catalog_stars)
@@ -6098,7 +6082,7 @@ class PlateTool(QtWidgets.QMainWindow):
         return final_lm
 
 
-    def _writeStarDetectionConfig(self, config_path, catalog_mag_limit):
+    def _writeStarDetectionConfig(self, config_path):
         """Write star detection parameters to the specified config file.
 
         Preserves comments and formatting by doing surgical line updates.
@@ -6116,6 +6100,9 @@ class PlateTool(QtWidgets.QMainWindow):
             print("Config backed up to:", backup_path)
 
         # Values to update: (section, key, value)
+        # The catalog limiting magnitude is deliberately not written. It is a working value in
+        #   SkyFit2, and saving it back would shift the LM that recalibration uses every time
+        #   the config is saved.
         updates = {
             "StarExtraction": {
                 "intensity_threshold": str(self.override_intensity_threshold),
@@ -6124,9 +6111,6 @@ class PlateTool(QtWidgets.QMainWindow):
                 "neighborhood_size": str(self.override_neighborhood_size),
                 "max_feature_ratio": str(self.override_max_feature_ratio),
                 "roundness_threshold": str(self.override_roundness_threshold),
-            },
-            "Calibration": {
-                "catalog_mag_limit": f"{catalog_mag_limit:.1f}",
             },
         }
 
@@ -6205,7 +6189,6 @@ class PlateTool(QtWidgets.QMainWindow):
             print(f"  intensity_threshold: {self.override_intensity_threshold}")
             print(f"  segment_radius: {self.override_segment_radius}")
             print(f"  max_stars: {self.override_max_stars}")
-            print(f"  catalog_mag_limit: {catalog_mag_limit:.1f}")
 
             qmessagebox(message=f"Star detection settings saved to:\n{config_path}",
                        title="Settings Saved", message_type="info")
@@ -10410,9 +10393,6 @@ class PlateTool(QtWidgets.QMainWindow):
             self.updateStars()
             self.tab.settings.updateLimMag()
 
-            # The LM is saved to the config, so refresh the unsaved indicators
-            self._updateConfigSaveButtonState()
-
         elif event.key() == QtCore.Qt.Key.Key_F:
             self.cat_lim_mag -= 0.1
             self.catalog_stars = self.loadCatalogStars(self.cat_lim_mag)
@@ -10420,8 +10400,6 @@ class PlateTool(QtWidgets.QMainWindow):
             self.updateLeftLabels()
             self.updateStars()
             self.tab.settings.updateLimMag()
-
-            self._updateConfigSaveButtonState()
 
 
         # Increase image gamma

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1866,16 +1866,9 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                 try:
                     src = pt.config.config_file_name
                     dest = os.path.join(target_dir, os.path.basename(src))
-                    # Write the tuned catalog LM as-is. This used to subtract 1.0 to
-                    #   compensate for the "+ 1" in ApplyRecalibrate, but that margin only
-                    #   controls how deep readStarCatalog() pulls the catalog file into
-                    #   memory (ApplyRecalibrate.py:813-827); the limit stars are actually
-                    #   matched against is config.catalog_mag_limit itself, taken raw by
-                    #   subsetCatalog (ApplyRecalibrate.py:229), and likewise by CheckFit,
-                    #   AutoPlatepar and SkyFit2 on the next start. So there was nothing to
-                    #   compensate for, and subtracting a magnitude left every one of those
-                    #   consumers a magnitude shallower than what was tuned. Recalibration
-                    #   still reads one magnitude deeper than it matches, as intended.
+                    # Write the tuned catalog LM as is. ApplyRecalibrate reads the catalog one
+                    #   magnitude deeper than this, but it matches stars down to the raw
+                    #   catalog_mag_limit, so nothing has to be subtracted here.
                     config_catalog_lm = max(3.0, pt.cat_lim_mag)
                     if os.path.realpath(src) != os.path.realpath(dest):
                         # Copy the config to the target, then write overrides into the copy
@@ -1891,10 +1884,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                     pt.config.segment_radius = pt.override_segment_radius
                     pt.config.max_feature_ratio = pt.override_max_feature_ratio
                     pt.config.roundness_threshold = pt.override_roundness_threshold
-                    # Sync the LM to the value actually written, not to pt.cat_lim_mag: the
-                    #   file holds it to one decimal, and isConfigModified() compares against
-                    #   this attribute, so storing the unrounded value would report the config
-                    #   as modified again the moment it was saved
+                    # Keep the in-memory LM in sync, so the config isn't flagged as modified again
                     pt.config.catalog_mag_limit = config_catalog_lm
                     pt._updateConfigSaveButtonState()
                     results.append("Config saved to: " + dest)
@@ -4754,11 +4744,8 @@ class PlateTool(QtWidgets.QMainWindow):
             or self.override_segment_radius != getattr(cfg, 'segment_radius', self.override_segment_radius)
             or abs(self.override_max_feature_ratio - getattr(cfg, 'max_feature_ratio', self.override_max_feature_ratio)) > 1e-6
             or abs(self.override_roundness_threshold - getattr(cfg, 'roundness_threshold', self.override_roundness_threshold)) > 1e-6
-            # The catalog LM is written to the config too, so a tuned or hand-set LM has to
-            #   count as an unsaved change - otherwise Save Config stays disabled and there is
-            #   no way to persist it. Compared at the precision it is written with (one
-            #   decimal), so the rounding in _writeStarDetectionConfig cannot leave the config
-            #   looking permanently modified after a save.
+            # The LM is saved to the config too. Compare it at the precision it's written with
+            #   (one decimal), so a save doesn't leave the config looking modified.
             or abs(getattr(self, 'cat_lim_mag', 0.0)
                    - getattr(cfg, 'catalog_mag_limit', getattr(self, 'cat_lim_mag', 0.0))) > 0.05
         )
@@ -4782,8 +4769,7 @@ class PlateTool(QtWidgets.QMainWindow):
         self.updateLeftLabels()
         self.updateStars()
 
-        # The LM is part of what Save Config writes, so refresh the save button and the
-        #   File Manager's unsaved indicator
+        # The LM is saved to the config, so refresh the unsaved indicators
         self._updateConfigSaveButtonState()
 
 
@@ -5345,9 +5331,7 @@ class PlateTool(QtWidgets.QMainWindow):
             self.tuned_cat_lim_mag = best_lm
             self.catalog_lm_tuned = True
 
-            # The tuned LM is an unsaved config change in its own right. It usually rides
-            #   along with the tuned segment_radius, but flag it explicitly so a tune that
-            #   only moves the LM still offers to save.
+            # The tuned LM is an unsaved config change on its own, flag it
             self._updateConfigSaveButtonState()
 
             # Count visible catalog stars at new LM (filter to FOV first to prevent back-projection)
@@ -10327,6 +10311,9 @@ class PlateTool(QtWidgets.QMainWindow):
             self.updateStars()
             self.tab.settings.updateLimMag()
 
+            # The LM is saved to the config, so refresh the unsaved indicators
+            self._updateConfigSaveButtonState()
+
         elif event.key() == QtCore.Qt.Key_F:
             self.cat_lim_mag -= 0.1
             self.catalog_stars = self.loadCatalogStars(self.cat_lim_mag)
@@ -10334,6 +10321,8 @@ class PlateTool(QtWidgets.QMainWindow):
             self.updateLeftLabels()
             self.updateStars()
             self.tab.settings.updateLimMag()
+
+            self._updateConfigSaveButtonState()
 
 
         # Increase image gamma

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1866,7 +1866,17 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                 try:
                     src = pt.config.config_file_name
                     dest = os.path.join(target_dir, os.path.basename(src))
-                    config_catalog_lm = max(3.0, pt.cat_lim_mag - 1.0)
+                    # Write the tuned catalog LM as-is. This used to subtract 1.0 to
+                    #   compensate for the "+ 1" in ApplyRecalibrate, but that margin only
+                    #   controls how deep readStarCatalog() pulls the catalog file into
+                    #   memory (ApplyRecalibrate.py:813-827); the limit stars are actually
+                    #   matched against is config.catalog_mag_limit itself, taken raw by
+                    #   subsetCatalog (ApplyRecalibrate.py:229), and likewise by CheckFit,
+                    #   AutoPlatepar and SkyFit2 on the next start. So there was nothing to
+                    #   compensate for, and subtracting a magnitude left every one of those
+                    #   consumers a magnitude shallower than what was tuned. Recalibration
+                    #   still reads one magnitude deeper than it matches, as intended.
+                    config_catalog_lm = max(3.0, pt.cat_lim_mag)
                     if os.path.realpath(src) != os.path.realpath(dest):
                         # Copy the config to the target, then write overrides into the copy
                         shutil.copy2(src, dest)

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1804,6 +1804,9 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
         dlg.setMinimumWidth(400)
         layout = QtWidgets.QVBoxLayout(dlg)
 
+        # Show what the save will write into the config, so nothing changes behind the user's back
+        lm_checkbox = self._addConfigPreview(layout) if ftype == "Config" else None
+
         checkboxes = []
         for i, (label, path) in enumerate(self._locations):
             cb = QtWidgets.QCheckBox(self._locationMenuLabel(label, path))
@@ -1862,9 +1865,58 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
         if dlg.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             paths = [cb.property("path") for cb in checkboxes if cb.isChecked()]
             if paths:
-                self._saveFile(ftype, paths)
+                save_lm = (lm_checkbox is not None) and lm_checkbox.isChecked()
+                self._saveFile(ftype, paths, save_lm=save_lm)
 
-    def _saveFile(self, ftype, target_dirs):
+
+    def _addConfigPreview(self, layout):
+        """ List the values a config save will write, as old -> new.
+
+        The tuned catalog limiting magnitude gets a checkbox of its own, as it is only written on
+        request. Returns that checkbox, or None if the LM was not tuned in this session.
+        """
+        pt = self.plate_tool
+
+        group = QtWidgets.QGroupBox("Values written to the config")
+        group_layout = QtWidgets.QVBoxLayout(group)
+
+        # Star extraction parameters, always written
+        for key, new_value in [
+                ("intensity_threshold", pt.override_intensity_threshold),
+                ("segment_radius", pt.override_segment_radius),
+                ("max_stars", pt.override_max_stars),
+                ("neighborhood_size", pt.override_neighborhood_size),
+                ("max_feature_ratio", pt.override_max_feature_ratio),
+                ("roundness_threshold", pt.override_roundness_threshold)]:
+
+            # Compare the strings that end up in the file, not the numbers
+            old_str = str(getattr(pt.config, key, "?"))
+            new_str = str(new_value)
+
+            if old_str == new_str:
+                group_layout.addWidget(QtWidgets.QLabel("{}: {} (unchanged)".format(key, new_str)))
+            else:
+                group_layout.addWidget(QtWidgets.QLabel("{}: {} -> {}".format(key, old_str, new_str)))
+
+        # The catalog LM is only offered when the tuner found one. Everything else that moves the LM
+        #   (the spinboxes, the R/F keys, plate fitting) is a working value that must not be saved,
+        #   or the LM that recalibration uses would drift with every save.
+        lm_checkbox = None
+        if getattr(pt, 'catalog_lm_tuned', False) and hasattr(pt, 'tuned_cat_lim_mag'):
+
+            lm_checkbox = QtWidgets.QCheckBox("catalog_mag_limit: {} -> {:.1f} (tuned)".format(
+                getattr(pt.config, 'catalog_mag_limit', "?"), pt.tuned_cat_lim_mag))
+            lm_checkbox.setChecked(True)
+            lm_checkbox.setToolTip("Recalibration matches stars down to this magnitude. "
+                                   "Uncheck to keep the value already in the config.")
+            group_layout.addWidget(lm_checkbox)
+
+        layout.addWidget(group)
+
+        return lm_checkbox
+
+
+    def _saveFile(self, ftype, target_dirs, save_lm=False):
         """Save a single file type to one or more target directories."""
         pt = self.plate_tool
         results = []
@@ -1883,13 +1935,17 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                 try:
                     src = pt.config.config_file_name
                     dest = os.path.join(target_dir, os.path.basename(src))
+
+                    # Only write the catalog LM if it was tuned and the user kept it checked
+                    catalog_lm = pt.tuned_cat_lim_mag if save_lm else None
+
                     if os.path.realpath(src) != os.path.realpath(dest):
                         # Copy the config to the target, then write overrides into the copy
                         shutil.copy2(src, dest)
-                        pt._writeStarDetectionConfig(dest)
+                        pt._writeStarDetectionConfig(dest, catalog_mag_limit=catalog_lm)
                     else:
                         # Same file — write overrides in-place (backup handled by _writeStarDetectionConfig)
-                        pt._writeStarDetectionConfig(dest)
+                        pt._writeStarDetectionConfig(dest, catalog_mag_limit=catalog_lm)
                     # Sync in-memory config attrs so modified state is cleared
                     pt.config.intensity_threshold = pt.override_intensity_threshold
                     pt.config.neighborhood_size = pt.override_neighborhood_size
@@ -1897,6 +1953,9 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                     pt.config.segment_radius = pt.override_segment_radius
                     pt.config.max_feature_ratio = pt.override_max_feature_ratio
                     pt.config.roundness_threshold = pt.override_roundness_threshold
+                    if catalog_lm is not None:
+                        # Match the one decimal the file holds
+                        pt.config.catalog_mag_limit = round(catalog_lm, 1)
                     pt._updateConfigSaveButtonState()
                     results.append("Config saved to: " + dest)
                 except Exception as e:
@@ -4765,7 +4824,22 @@ class PlateTool(QtWidgets.QMainWindow):
             or self.override_segment_radius != getattr(cfg, 'segment_radius', self.override_segment_radius)
             or abs(self.override_max_feature_ratio - getattr(cfg, 'max_feature_ratio', self.override_max_feature_ratio)) > 1e-6
             or abs(self.override_roundness_threshold - getattr(cfg, 'roundness_threshold', self.override_roundness_threshold)) > 1e-6
+            or self.isTunedCatalogLMUnsaved()
         )
+
+    def isTunedCatalogLMUnsaved(self):
+        """Check if the tuner found a catalog LM that is not the one in the config.
+
+        Only the tuned LM counts. The working LM (the spinboxes, the R/F keys, plate fitting) is
+        never saved, so it must not mark the config as modified either.
+        """
+        if not getattr(self, 'catalog_lm_tuned', False) or not hasattr(self, 'tuned_cat_lim_mag'):
+            return False
+
+        # Compare at the one decimal the config is written with
+        cfg_lm = getattr(self.config, 'catalog_mag_limit', self.tuned_cat_lim_mag)
+
+        return abs(round(self.tuned_cat_lim_mag, 1) - cfg_lm) > 0.05
 
     def _updateConfigSaveButtonState(self):
         """Enable/disable the Save Config button based on whether overrides differ from config."""
@@ -5344,6 +5418,9 @@ class PlateTool(QtWidgets.QMainWindow):
             # Store tuned LM for restoration after fitting (balancing may change it)
             self.tuned_cat_lim_mag = best_lm
             self.catalog_lm_tuned = True
+
+            # The tuned LM can now be saved, so offer it even if nothing else was tuned
+            self._updateConfigSaveButtonState()
 
             # Count visible catalog stars at new LM (filter to FOV first to prevent back-projection)
             _, catalog_in_fov = self.filterCatalogStarsInsideFOV(self.catalog_stars)
@@ -6082,11 +6159,18 @@ class PlateTool(QtWidgets.QMainWindow):
         return final_lm
 
 
-    def _writeStarDetectionConfig(self, config_path):
+    def _writeStarDetectionConfig(self, config_path, catalog_mag_limit=None):
         """Write star detection parameters to the specified config file.
 
         Preserves comments and formatting by doing surgical line updates.
         Uses ': ' separator like the RMS config format.
+
+        Arguments:
+            config_path: [str] Path to the config file to update.
+
+        Keyword arguments:
+            catalog_mag_limit: [float] Catalog limiting magnitude to write. None (default) leaves
+                the one in the config alone.
         """
         import re
         from datetime import datetime
@@ -6100,9 +6184,6 @@ class PlateTool(QtWidgets.QMainWindow):
             print("Config backed up to:", backup_path)
 
         # Values to update: (section, key, value)
-        # The catalog limiting magnitude is deliberately not written. It is a working value in
-        #   SkyFit2, and saving it back would shift the LM that recalibration uses every time
-        #   the config is saved.
         updates = {
             "StarExtraction": {
                 "intensity_threshold": str(self.override_intensity_threshold),
@@ -6113,6 +6194,11 @@ class PlateTool(QtWidgets.QMainWindow):
                 "roundness_threshold": str(self.override_roundness_threshold),
             },
         }
+
+        # The LM is only written when the tuner found one and the user asked to keep it. Writing it
+        #   on every save would shift the LM that recalibration matches stars at, save after save.
+        if catalog_mag_limit is not None:
+            updates["Calibration"] = {"catalog_mag_limit": "{:.1f}".format(catalog_mag_limit)}
 
         try:
             # Read existing file
@@ -6189,6 +6275,8 @@ class PlateTool(QtWidgets.QMainWindow):
             print(f"  intensity_threshold: {self.override_intensity_threshold}")
             print(f"  segment_radius: {self.override_segment_radius}")
             print(f"  max_stars: {self.override_max_stars}")
+            if catalog_mag_limit is not None:
+                print(f"  catalog_mag_limit: {catalog_mag_limit:.1f}")
 
             qmessagebox(message=f"Star detection settings saved to:\n{config_path}",
                        title="Settings Saved", message_type="info")

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -232,6 +232,10 @@ except Exception as e:
     print(f'ASTRA import error: {e}')
 
 
+# Smallest max_stars a config save is allowed to write. Tuning for interactive work can settle on
+#   far fewer stars than the nightly processing needs.
+MIN_CONFIG_MAX_STARS = 800
+
 
 ##############################################################################################################
 # ASTRA GUI Code
@@ -1884,7 +1888,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
         for key, new_value in [
                 ("intensity_threshold", pt.override_intensity_threshold),
                 ("segment_radius", pt.override_segment_radius),
-                ("max_stars", pt.override_max_stars),
+                ("max_stars", pt.configMaxStars()),
                 ("neighborhood_size", pt.override_neighborhood_size),
                 ("max_feature_ratio", pt.override_max_feature_ratio),
                 ("roundness_threshold", pt.override_roundness_threshold)]:
@@ -1894,9 +1898,15 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
             new_str = str(new_value)
 
             if old_str == new_str:
-                group_layout.addWidget(QtWidgets.QLabel("{}: {} (unchanged)".format(key, new_str)))
+                text = "{}: {} (unchanged)".format(key, new_str)
             else:
-                group_layout.addWidget(QtWidgets.QLabel("{}: {} -> {}".format(key, old_str, new_str)))
+                text = "{}: {} -> {}".format(key, old_str, new_str)
+
+            # Say so when the floor, rather than the tuning, set the value
+            if key == "max_stars" and pt.override_max_stars < MIN_CONFIG_MAX_STARS:
+                text += " (raised to the minimum for processing)"
+
+            group_layout.addWidget(QtWidgets.QLabel(text))
 
         # The catalog LM is only offered when the tuner found one. Everything else that moves the LM
         #   (the spinboxes, the R/F keys, plate fitting) is a working value that must not be saved,
@@ -1949,7 +1959,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
                     # Sync in-memory config attrs so modified state is cleared
                     pt.config.intensity_threshold = pt.override_intensity_threshold
                     pt.config.neighborhood_size = pt.override_neighborhood_size
-                    pt.config.max_stars = pt.override_max_stars
+                    pt.config.max_stars = pt.configMaxStars()
                     pt.config.segment_radius = pt.override_segment_radius
                     pt.config.max_feature_ratio = pt.override_max_feature_ratio
                     pt.config.roundness_threshold = pt.override_roundness_threshold
@@ -4820,12 +4830,20 @@ class PlateTool(QtWidgets.QMainWindow):
         return (
             self.override_intensity_threshold != getattr(cfg, 'intensity_threshold', self.override_intensity_threshold)
             or self.override_neighborhood_size != getattr(cfg, 'neighborhood_size', self.override_neighborhood_size)
-            or self.override_max_stars != getattr(cfg, 'max_stars', self.override_max_stars)
+            or self.configMaxStars() != getattr(cfg, 'max_stars', self.configMaxStars())
             or self.override_segment_radius != getattr(cfg, 'segment_radius', self.override_segment_radius)
             or abs(self.override_max_feature_ratio - getattr(cfg, 'max_feature_ratio', self.override_max_feature_ratio)) > 1e-6
             or abs(self.override_roundness_threshold - getattr(cfg, 'roundness_threshold', self.override_roundness_threshold)) > 1e-6
             or self.isTunedCatalogLMUnsaved()
         )
+
+    def configMaxStars(self):
+        """Return the max_stars value that a config save writes.
+
+        Tuning for interactive work can settle on far fewer stars than the nightly processing
+        needs, so the saved value is never allowed below MIN_CONFIG_MAX_STARS.
+        """
+        return max(self.override_max_stars, MIN_CONFIG_MAX_STARS)
 
     def isTunedCatalogLMUnsaved(self):
         """Check if the tuner found a catalog LM that is not the one in the config.
@@ -6188,7 +6206,7 @@ class PlateTool(QtWidgets.QMainWindow):
             "StarExtraction": {
                 "intensity_threshold": str(self.override_intensity_threshold),
                 "segment_radius": str(self.override_segment_radius),
-                "max_stars": str(self.override_max_stars),
+                "max_stars": str(self.configMaxStars()),
                 "neighborhood_size": str(self.override_neighborhood_size),
                 "max_feature_ratio": str(self.override_max_feature_ratio),
                 "roundness_threshold": str(self.override_roundness_threshold),
@@ -6274,7 +6292,7 @@ class PlateTool(QtWidgets.QMainWindow):
             print(f"Saved star detection settings to: {config_path}")
             print(f"  intensity_threshold: {self.override_intensity_threshold}")
             print(f"  segment_radius: {self.override_segment_radius}")
-            print(f"  max_stars: {self.override_max_stars}")
+            print(f"  max_stars: {self.configMaxStars()}")
             if catalog_mag_limit is not None:
                 print(f"  catalog_mag_limit: {catalog_mag_limit:.1f}")
 


### PR DESCRIPTION
Saving the config from SkyFit2 wrote `[Calibration] catalog_mag_limit` on every save, taken from the working LM and offset by minus one magnitude:

```python
config_catalog_lm = max(3.0, pt.cat_lim_mag - 1.0)
```

Both halves of that are wrong.

### The offset compensated for nothing

The `- 1.0` was there to cancel the `+ 1` in `ApplyRecalibrate.py:814`:

```python
# Increase catalog limiting magnitude by one to get more stars for matching
catalog_mag_limit = config.catalog_mag_limit + 1
```

but that value feeds exactly one call — `readStarCatalog(..., lim_mag=catalog_mag_limit)` at line 827. It controls how deep the catalog *file* is read into memory, not which stars are matched. Matching uses `config.catalog_mag_limit` raw, via `effective_lim_mag` at `ApplyRecalibrate.py:229` and then `subsetCatalog`. Same for `CheckFit.py:129,583`, `AutoPlatepar.py:658,784`, and SkyFit2 itself on the next start.

So there was no `+1` to compensate for, and since SkyFit2 seeds its working LM from the config on load, the subtraction ratcheted:

| open # | LM spinbox shows | written to config |
| --- | --- | --- |
| 1 | 5.5 | 4.5 |
| 2 | 4.5 | 3.5 |
| 3 | 3.5 | 3.0 (floor) |

Three open-and-save cycles and the station's recalibration is at the floor. Any station where someone used Save Config has a degraded `catalog_mag_limit` right now, once per save. `_writeStarDetectionConfig` backs the config up on every write (`<name>.config.bak.<timestamp>`), so the original values are recoverable on those machines.

### The wrong value was being saved in the first place

`cat_lim_mag` does double duty. It is a viewing knob — nudged by the two LM spinboxes and the R/F keys to show more or fewer stars — and it is also the output of Phase 3 of the star detection tuner, which searches for the LM whose catalog star count best matches the confirmed true-positive detections.

Writing the knob means squinting at fainter stars and hitting save silently changes what the nightly recalibration matches at. Only the tuned value is worth persisting.

## Changes

**The tuned LM is saved, and nothing else is.** `_saveFile` passes `tuned_cat_lim_mag`, never `cat_lim_mag`, so the viewing knob is now structurally unable to reach the file. No offset, so a save is idempotent — save 6.5, reload 6.5, save 6.5, stable.

**It is opt-in and visible.** The save dialog lists every value the save will write as old → new, with the LM as a checkbox, on by default:

```
Values written to the config
    Parameter              Current      New
    intensity_threshold         18  ->  24
    segment_radius               4  ->  8
    max_stars                  200  ->  800   raised to the minimum for processing
    neighborhood_size           10
    max_feature_ratio          0.8
    roundness_threshold        0.5
    [x] catalog_mag_limit      5.2  ->  6.5   tuned
```

New values are bolded in the dialog wherever they differ; values that stay the same are shown once, without an arrow.

The LM row appears only when the tuner actually produced an LM this session. Otherwise there is no checkbox, `_writeStarDetectionConfig` is called with `catalog_mag_limit=None`, and the LM line in the config is never matched, never rewritten, and never created.

**`max_stars` is floored at 800 when saved.** Tuning optimizes for interactive work, where a few hundred stars are plenty, but the nightly processing needs a deeper list — saving the tuned value could leave a station below the shipped default. The working value in the GUI is left alone, so the detection view does not change under the user.

**The tuned LM counts as an unsaved change on its own** (`isTunedCatalogLMUnsaved`), so a tune that moves only the LM still enables the Save Config button. The working LM never does — that separation is what keeps the value from drifting. The floored `max_stars` is compared the same way, so a config already holding 800 is not reported as modified forever by a smaller working value.

**Unrelated, found while tracing:** the R and F keys changed the LM without refreshing the save-button or File Manager unsaved state. Fixed.

## Testing

Verified headlessly against a real copy of `.config`:

| case | result |
| --- | --- |
| no LM passed | `catalog_mag_limit: 5.2` byte-identical before and after; `[StarExtraction]` updated |
| tuned 6.4732 passed | written as `6.5` |
| saved twice, no LM | files identical, no drift |
| config with no `[Calibration]` section | section not created, no LM key added |
| working `max_stars` 400 / 800 / 1500 | writes 800 / 800 / 1500; config not modified after the post-save sync |

`isTunedCatalogLMUnsaved` checked across six cases including the rounding boundary and a working LM nudged to 9.9 (must not flag). The save dialog was rendered offscreen for both the tuned and untuned cases; the block above is its real output.

Not click-tested in a live SkyFit2 session. Worth one run: tune, confirm the dialog reads the right old → new, save, reopen, confirm the LM spinbox reads the tuned value and the config holds it.

Existing station configs are unaffected until someone saves from SkyFit2.
