### PR TITLE
Ignore Cython-generated C sources by pattern and QueuedPool backup pickles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,15 +96,20 @@ target/
 
 camerasettings/*.json
 
-# these files are created by cython and should not be tracked
-RMS/Astrometry/CyFunctions.c
-RMS/CompressionCy.c
-RMS/Routines/BinImageCy.c
-RMS/Routines/DynamicFTPCompressionCy.c
-RMS/Routines/Grouping3Dcy.c
-RMS/Routines/MorphCy.c
-RMS/Routines/Kht.cpp
-Utils/SaturationTools.c
+# Cython writes a .c (or .cpp) next to every .pyx when the extensions are built.
+# Matched by pattern rather than listed one by one, so adding a .pyx cannot leak its
+# generated source into the repo - the old per-file list had to be edited by hand for
+# every new module, and a missed entry is easy to commit by accident.
+# Native/Hough holds the only hand-written C/C++ in the tree, so it is kept.
+*.c
+*.cpp
+!Native/Hough/*.c
+!Native/Hough/*.cpp
+
+# Detection backups written by QueuedPool. These belong next to the captured night,
+# but land in the working directory when the tests or a manual run are started from
+# the repo root.
+rms_queue_bkup_*.pickle
 
 # Large GMN catalog that's too big for GitHub
 Catalogs/GMN_StarCatalog_LM12.0.bin


### PR DESCRIPTION
`.gitignore` listed the Cython-generated `.c`/`.cpp` files one by one:

```
RMS/Astrometry/CyFunctions.c
RMS/CompressionCy.c
...
Utils/SaturationTools.c
```

All eight `.pyx` modules on `prerelease` happen to be covered, so nothing leaks today. The problem is that the list has to be edited by hand for every new `.pyx`, and a missing entry is invisible until someone runs `build_ext` and then stages broadly.

That is not hypothetical: `ExtractStarsCy.pyx` exists on the star-extraction branches but has no entry here, so its generated `RMS/ExtractStarsCy.c` (~13.7k lines) is untracked-but-not-ignored on any branch built from this base. The same blob was accidentally committed once already and needed #941 to be squash-merged to keep it out of `prerelease` history.

### Change

Match by pattern instead, keeping the only hand-written C/C++ in the tree:

```
*.c
*.cpp
!Native/Hough/*.c
!Native/Hough/*.cpp
```

Also ignore `rms_queue_bkup_*.pickle`. Those are `QueuedPool` detection backups that belong next to the captured night, but land in the working directory when the tests or a manual reprocess are started from the repo root.

### Verification

- Every previously listed file is still ignored, plus `RMS/ExtractStarsCy.c` and a hypothetical future `SomeFuture/NewModuleCy.c`, checked with `git check-ignore --no-index`.
- All 15 tracked `Native/Hough` sources and headers remain visible.
- `git ls-files | git check-ignore --stdin --no-index` returns nothing, i.e. no currently tracked file becomes ignored.
- `python setup.py build_ext --inplace` succeeds and leaves the working tree clean apart from this `.gitignore` edit, so every generated artifact is now covered.