### PR TITLE
Prevent observation summary hanging on network loss and handle symbolic references

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -1088,7 +1088,7 @@ def updateCommitHistoryDirectory(remote_urls, target_directory):
     """ Clone only the commit history of a remote repository.
 
     Arguments:
-        remote_urls: [url] the remote url to be cloned/
+        remote_urls: [url] the remote url to be cloned
         target_directory: [path] the directory into which to clone.
 
     Return:
@@ -1108,14 +1108,24 @@ def updateCommitHistoryDirectory(remote_urls, target_directory):
             first_remote = False
             p = subprocess.Popen(["git", "clone", url, "--filter=blob:none", "--no-checkout"], cwd=target_directory,
                              stdout=subprocess.PIPE)
-            p.wait()
-            # this first remote might have been pulled in with the wrong local_name so rename it
+            try:
+                p.wait(timeout=120)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                raise
+
+            # this first remote might have been pulled in with the wrong local_name so check and rename if required
             commit_repo_directory = os.path.join(target_directory, os.listdir(target_directory)[0])
             downloaded_remote_name = subprocess.check_output(["git", "remote"], cwd = commit_repo_directory).strip().decode('utf-8')
 
             if downloaded_remote_name != local_name:
                 p = subprocess.Popen(["git", "remote", "rename", downloaded_remote_name, local_name], cwd = commit_repo_directory)
-                p.wait()
+
+                try:
+                    p.wait(timeout=120)
+                except subprocess.TimeoutExpired:
+                    p.kill()
+                    raise
 
         else:
             # this is not the first remote so add another remote
@@ -1247,9 +1257,8 @@ def getRemoteBranchNameForCommit(repo, commit):
         if branch_stripped.startswith("remotes/"):
             remote_branch_name = branch_stripped
 
-    # If we are not at the HEAD, then get all the branches which contain the commit.
+    # Get all the branches that contain the commit and pick the most likely
 
-    # 2. Branches that *contain* the commit
     try:
         contains = subprocess.check_output(
             ["git", "branch", "-r", "--contains", commit],
@@ -1258,7 +1267,8 @@ def getRemoteBranchNameForCommit(repo, commit):
     except Exception:
         contains = []
 
-    contains = [c.strip() for c in contains if c.strip()]
+    # Eliminate any symbolic references
+    contains = [c.strip() for c in contains if c.strip() and "->" not in c.strip()]
 
     if contains:
         # If the branch is origin/main or origin/pre-release; then that is almost certainly where we are

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -80,6 +80,10 @@ OBSERVATIONS_TABLE_NAME = "observations"
 OBSERVATION_DB_FILE_NAME = "observation.db"
 NIGHT_DATA_DIR_COL = "night_data_dir"
 
+# Ceiling on any git call made while measuring how far the repository lags the remote. Without it, a dropped
+# network connection leaves git waiting on the socket forever and stalls the whole observation summary.
+GIT_TIMEOUT_SEC = 300
+
 
 def pingOnce(host):
     """Quickly detect if a host is pingable
@@ -1083,6 +1087,36 @@ def nightSummaryData(config, night_data_dir):
             fits_file_shortfall_as_time, fits_file_shortfall_as_time_ephemeris, \
             time_first_fits_file, time_last_fits_file, total_expected_fits, total_expected_fits_ephemeris
 
+def runGitCommand(command, cwd):
+    """ Run a git command, failing rather than blocking forever if the network drops.
+
+    Standard output is discarded, so this is only for commands run for their effect and not for their output.
+    A command that times out is logged and re-raised, one that merely fails is logged along with its stderr.
+
+    Arguments:
+        command: [list] the git command and its arguments.
+        cwd: [path] the directory in which to run the command.
+
+    Return:
+        None
+    """
+
+    try:
+        # run() drains the pipes and reaps the child itself, so neither a full pipe nor a stalled socket can
+        # leave this waiting indefinitely
+        result = subprocess.run(command, cwd=cwd, timeout=GIT_TIMEOUT_SEC,
+                                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+
+    except subprocess.TimeoutExpired:
+        # The caller reports the repository lag as undetermined, so say here which command stalled
+        log.warning("git command timed out after {} s: {}".format(GIT_TIMEOUT_SEC, " ".join(command)))
+        raise
+
+    # Nothing here can recover from a failed git call, but the reason should not be swallowed
+    if result.returncode != 0:
+        log.warning("git command failed with code {}: {}".format(result.returncode, " ".join(command)))
+        log.warning(result.stderr.decode("utf-8", errors="replace").strip())
+
 def updateCommitHistoryDirectory(remote_urls, target_directory):
 
     """ Clone only the commit history of a remote repository.
@@ -1106,34 +1140,23 @@ def updateCommitHistoryDirectory(remote_urls, target_directory):
 
         if first_remote:
             first_remote = False
-            p = subprocess.Popen(["git", "clone", url, "--filter=blob:none", "--no-checkout"], cwd=target_directory,
-                             stdout=subprocess.PIPE)
-            try:
-                p.wait(timeout=120)
-            except subprocess.TimeoutExpired:
-                p.kill()
-                raise
+            runGitCommand(["git", "clone", url, "--filter=blob:none", "--no-checkout"], target_directory)
 
             # this first remote might have been pulled in with the wrong local_name so check and rename if required
             commit_repo_directory = os.path.join(target_directory, os.listdir(target_directory)[0])
             downloaded_remote_name = subprocess.check_output(["git", "remote"], cwd = commit_repo_directory).strip().decode('utf-8')
 
             if downloaded_remote_name != local_name:
-                p = subprocess.Popen(["git", "remote", "rename", downloaded_remote_name, local_name], cwd = commit_repo_directory)
-
-                try:
-                    p.wait(timeout=120)
-                except subprocess.TimeoutExpired:
-                    p.kill()
-                    raise
+                runGitCommand(["git", "remote", "rename", downloaded_remote_name, local_name], commit_repo_directory)
 
         else:
             # this is not the first remote so add another remote
 
-            p = subprocess.Popen(["git", "remote", "add", local_name, url], cwd = commit_repo_directory)
-            p.wait()
-            p = subprocess.Popen(["git", "fetch", "--filter=blob:none", local_name], cwd = commit_repo_directory)
-            p.wait()
+            runGitCommand(["git", "remote", "add", local_name, url], commit_repo_directory)
+
+            # Like the clone above, this reaches out over the network and so must not be left to block forever
+            runGitCommand(["git", "fetch", "--filter=blob:none", local_name], commit_repo_directory)
+
     return commit_repo_directory
 
 def getCommit(repo):
@@ -1242,7 +1265,8 @@ def getRemoteBranchNameForCommit(repo, commit):
     """
 
 
-    # This is the simple case, our latest commit is the HEAD
+    # This is the simple case, our latest commit is the HEAD. Only used as the fall back below, as the
+    # branches containing the commit give a better answer when one of them is a tracked branch.
 
     local_branch_list = []
     try:
@@ -1258,7 +1282,6 @@ def getRemoteBranchNameForCommit(repo, commit):
             remote_branch_name = branch_stripped
 
     # Get all the branches that contain the commit and pick the most likely
-
     try:
         contains = subprocess.check_output(
             ["git", "branch", "-r", "--contains", commit],
@@ -1267,8 +1290,9 @@ def getRemoteBranchNameForCommit(repo, commit):
     except Exception:
         contains = []
 
-    # Eliminate any symbolic references
-    contains = [c.strip() for c in contains if c.strip() and "->" not in c.strip()]
+    # Drop symbolic references. Git lists these as "origin/HEAD -> origin/master", which is not a name that
+    # can be handed to any later git call. Match on the spaced arrow, since a branch may legally be named a->b.
+    contains = [c.strip() for c in contains if c.strip() and " -> " not in c]
 
     if contains:
         # If the branch is origin/main or origin/pre-release; then that is almost certainly where we are
@@ -1293,19 +1317,22 @@ def daysBehind():
 
     latest_local_commit = getCommit(os.getcwd())
     latest_local_date = getDateOfCommit(os.getcwd(), latest_local_commit)
-    target_directory_obj = tempfile.TemporaryDirectory()
-    target_directory = target_directory_obj.name
     remote_urls = getRemoteUrls(os.getcwd())
-    commit_repo_directory = updateCommitHistoryDirectory(remote_urls, target_directory)
-    remote_branch_of_commit = getRemoteBranchNameForCommit(commit_repo_directory, latest_local_commit)
-    if not remote_branch_of_commit is None:
-        latest_remote_date = getDateOfCommit(commit_repo_directory, remote_branch_of_commit)
-        days_behind = (latest_remote_date - latest_local_date).total_seconds()/(60 * 60 * 24)
-        target_directory_obj.cleanup()
-        return days_behind, remote_branch_of_commit
-    else:
-        target_directory_obj.cleanup()
-        return "Unable to determine"
+
+    # The clone is only needed to read dates out of, so hold it in a temporary directory. Cleaning up in a
+    # with block means a git timeout below does not leave a partial clone of the history behind.
+    with tempfile.TemporaryDirectory() as target_directory:
+
+        commit_repo_directory = updateCommitHistoryDirectory(remote_urls, target_directory)
+        remote_branch_of_commit = getRemoteBranchNameForCommit(commit_repo_directory, latest_local_commit)
+
+        if not remote_branch_of_commit is None:
+            latest_remote_date = getDateOfCommit(commit_repo_directory, remote_branch_of_commit)
+            days_behind = (latest_remote_date - latest_local_date).total_seconds()/(60 * 60 * 24)
+            return days_behind, remote_branch_of_commit
+
+        else:
+            return "Unable to determine"
 
 def serialize(config, format_nicely=True, as_json=False, night_directory=None, drop_keys_list=None, ordering=None, final=False):
     """ Returns the data from the most recent observation session as either colon


### PR DESCRIPTION
This pull request addresses issue #954 

This patch prevents a network loss causing observation summary generation to hang, by adding a 120 second timeout to the git operation. 

It also prevents a symbolic reference in the list of remotes causing an exception, returning that the remote branch time difference is not determined. 

At present

```
repository_lag_remote_days                : Not determined 
```

With this PR

```
remote_branch                             : systemd 
repository_lag_remote_days                : 0.302 
```

Also minor changes to commenting.