### PR TITLE
Finish the Qt6/pyqtgraph-0.13 enum fix started in #953

### DIFF
--- a/RMS/Formats/FrameInterface.py
+++ b/RMS/Formats/FrameInterface.py
@@ -47,19 +47,21 @@ def messagebox(title, message):
     
     # First, try Qt. This is the most specific and desired case.
     try:
-        # We must import QApplication to check for an instance
-        from PyQt5.QtWidgets import QApplication, QMessageBox
-        
+        # Go through the pyqtgraph proxy so the binding matches the one the GUI already loaded.
+        # Importing raw PyQt5 here would either miss the running QApplication or pull a second
+        # Qt binding into the process.
+        from pyqtgraph.Qt import QtWidgets
+
         # Check if a QApplication instance already exists
-        if QApplication.instance():
+        if QtWidgets.QApplication.instance():
             # If it exists, we can safely create and show a message box
-            msg_box = QMessageBox()
+            msg_box = QtWidgets.QMessageBox()
             msg_box.setWindowTitle(title)
             msg_box.setText(message)
-            msg_box.exec_()
+            msg_box.exec()
             return # Success, so we exit the function
     except ImportError:
-        # This means PyQt5 (or your chosen binding) is not installed.
+        # This means no Qt binding (or pyqtgraph) is installed.
         # We'll just pass and try the next option.
         pass
 

--- a/RMS/Formats/FrameInterface.py
+++ b/RMS/Formats/FrameInterface.py
@@ -52,18 +52,21 @@ def messagebox(title, message):
         # Qt binding into the process.
         from pyqtgraph.Qt import QtWidgets
 
-        # Check if a QApplication instance already exists
-        if QtWidgets.QApplication.instance():
-            # If it exists, we can safely create and show a message box
-            msg_box = QtWidgets.QMessageBox()
-            msg_box.setWindowTitle(title)
-            msg_box.setText(message)
-            msg_box.exec()
-            return # Success, so we exit the function
-    except ImportError:
-        # This means no Qt binding (or pyqtgraph) is installed.
-        # We'll just pass and try the next option.
-        pass
+    except Exception:
+        # This means no Qt binding (or pyqtgraph) is installed. pyqtgraph raises a plain
+        # Exception rather than an ImportError when it cannot find a binding, so catch broadly
+        # here. We'll just fall through and try the next option.
+        QtWidgets = None
+
+    # Check if a QApplication instance already exists
+    if (QtWidgets is not None) and QtWidgets.QApplication.instance():
+
+        # If it exists, we can safely create and show a message box
+        msg_box = QtWidgets.QMessageBox()
+        msg_box.setWindowTitle(title)
+        msg_box.setText(message)
+        msg_box.exec()
+        return # Success, so we exit the function
 
     # Second, check for a display and try Tkinter as a fallback
     if os.environ.get('DISPLAY'):

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -37,7 +37,7 @@ class _CornerHelpOverlay(QtCore.QObject):
         self.button.raise_()
 
     def eventFilter(self, obj, event):
-        if obj is self.host and event.type() in (QtCore.QEvent.Resize, QtCore.QEvent.Show):
+        if obj is self.host and event.type() in (QtCore.QEvent.Type.Resize, QtCore.QEvent.Type.Show):
             self.reposition()
         return False
 
@@ -97,8 +97,8 @@ class ScaledSizeHelper:
         btn = QtWidgets.QToolButton()
         btn.setText("i")
         btn.setToolTip(tooltip)
-        btn.setCursor(QtCore.Qt.PointingHandCursor)
-        btn.setFocusPolicy(QtCore.Qt.NoFocus)
+        btn.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
+        btn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
         d = max(self.scaledHeight(1.0), 13)
         btn.setFixedSize(d, d)
         btn.setStyleSheet(
@@ -132,15 +132,15 @@ class ScaledSizeHelper:
 def qmessagebox(message="", title="Error", message_type="warning"):
     msg = QtWidgets.QMessageBox()
     if message_type == "warning":
-        msg.setIcon(QtWidgets.QMessageBox.Warning)
+        msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
     elif message_type == "error":
-        msg.setIcon(QtWidgets.QMessageBox.Critical)
+        msg.setIcon(QtWidgets.QMessageBox.Icon.Critical)
     else:
-        msg.setIcon(QtWidgets.QMessageBox.Information)
+        msg.setIcon(QtWidgets.QMessageBox.Icon.Information)
     msg.setText(message)
     msg.setWindowTitle(title)
-    msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
-    msg.exec_()
+    msg.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
+    msg.exec()
 
 
 class QHSeparationLine(QtWidgets.QFrame):
@@ -149,9 +149,9 @@ class QHSeparationLine(QtWidgets.QFrame):
     super().__init__()
     self.setMinimumWidth(1)
     self.setFixedHeight(20)
-    self.setFrameShape(QtWidgets.QFrame.HLine)
-    self.setFrameShadow(QtWidgets.QFrame.Sunken)
-    self.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Minimum)
+    self.setFrameShape(QtWidgets.QFrame.Shape.HLine)
+    self.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+    self.setSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Minimum)
     return
 
 
@@ -412,10 +412,10 @@ class TextItem(pg.TextItem):
         pg.TextItem.__init__(self, text, color, html, anchor, border, fill, angle, rotateAxis)
         if interaction:
             self.textItem.setOpenExternalLinks(True)
-            self.textItem.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
+            self.textItem.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextBrowserInteraction)
         else:
             self.textItem.setOpenExternalLinks(False)
-            self.textItem.setTextInteractionFlags(QtCore.Qt.NoTextInteraction)
+            self.textItem.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.NoTextInteraction)
 
     def setInteraction(self, enabled):
         """
@@ -426,10 +426,10 @@ class TextItem(pg.TextItem):
         """
         if enabled:
             self.textItem.setOpenExternalLinks(True)
-            self.textItem.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
+            self.textItem.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextBrowserInteraction)
         else:
             self.textItem.setOpenExternalLinks(False)
-            self.textItem.setTextInteractionFlags(QtCore.Qt.NoTextInteraction)
+            self.textItem.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.NoTextInteraction)
 
     def setAlign(self, align):
         """
@@ -972,23 +972,23 @@ class CursorItem(pg.GraphicsObject):
 
         painter = QtGui.QPainter(self.picture)
         if self.mode == 0:
-            pen = QtGui.QPen(QtCore.Qt.yellow, self.thickness, QtCore.Qt.SolidLine)
+            pen = QtGui.QPen(QtCore.Qt.GlobalColor.yellow, self.thickness, QtCore.Qt.PenStyle.SolidLine)
             painter.setPen(pen)
-            painter.setBrush(QtCore.Qt.NoBrush)
+            painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
             painter.drawEllipse(QtCore.QPoint(0, 0), r, r)
 
             # pen.setStyle(Qt.DotLine)
             painter.setPen(pen)
             painter.drawEllipse(QtCore.QPoint(0, 0), 2*r, 2*r)
-            painter.setPen(QtGui.QPen(QtCore.Qt.blue, 2*self.thickness))
+            painter.setPen(QtGui.QPen(QtCore.Qt.GlobalColor.blue, 2*self.thickness))
             painter.drawPoint(QtCore.QPoint(0, 0))
         elif self.mode == 1:
-            pen = QtGui.QPen(QtGui.QColor(128, 0, 128), self.thickness, QtCore.Qt.SolidLine)
+            pen = QtGui.QPen(QtGui.QColor(128, 0, 128), self.thickness, QtCore.Qt.PenStyle.SolidLine)
             painter.setPen(pen)
-            painter.setBrush(QtCore.Qt.NoBrush)
+            painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
             painter.drawEllipse(QtCore.QPoint(0, 0), 2*r, 2*r)
         else:
-            pen = QtGui.QPen(QtGui.QColor(255, 0, 0), self.thickness, QtCore.Qt.SolidLine)
+            pen = QtGui.QPen(QtGui.QColor(255, 0, 0), self.thickness, QtCore.Qt.PenStyle.SolidLine)
             painter.setPen(pen)
             painter.setBrush(QtGui.QColor(255, 0, 0, 100))
             painter.drawEllipse(QtCore.QPoint(0, 0), r, r)
@@ -1036,7 +1036,7 @@ class PointingIndicator(pg.GraphicsObject):
         super().__init__()
 
         # Keep the glyph a constant device-pixel size, anchored at setPos()
-        self.setFlag(QtGui.QGraphicsItem.ItemIgnoresTransformations, True)
+        self.setFlag(QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations, True)
 
         self.arrow_length = float(arrow_length)
 
@@ -1104,7 +1104,7 @@ class PointingIndicator(pg.GraphicsObject):
 
     def paint(self, painter, option, widget=None):
 
-        painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
 
         L = self.arrow_length
 
@@ -1119,7 +1119,7 @@ class PointingIndicator(pg.GraphicsObject):
             ux, uy = np.cos(ea), -np.sin(ea)         # unit toward East along the horizon (device coords)
             px_, py_ = -uy, ux                       # unit perpendicular (for the notch ticks)
 
-            pen = QtGui.QPen(self.step_color, 2.0, QtCore.Qt.SolidLine)
+            pen = QtGui.QPen(self.step_color, 2.0, QtCore.Qt.PenStyle.SolidLine)
             painter.setPen(pen)
             painter.drawLine(QtCore.QPointF(-half*ux, -half*uy), QtCore.QPointF(half*ux, half*uy))
             # End caps
@@ -1138,13 +1138,13 @@ class PointingIndicator(pg.GraphicsObject):
                                      QtCore.QPointF(bx + length*px_, by + length*py_))
 
                 # Little reference notches: West (-90 deg) and East (+90 deg) at +/- half the bar
-                ref_pen = QtGui.QPen(self.step_color, 1.5, QtCore.Qt.SolidLine)
+                ref_pen = QtGui.QPen(self.step_color, 1.5, QtCore.Qt.PenStyle.SolidLine)
                 _notch(-0.5, 3.0, ref_pen)
                 _notch(+0.5, 3.0, ref_pen)
 
                 # Current-azimuth notch (azimuth wrapped to +/-180 deg, mapped over the bar)
                 az_frac = (((self.azimuth + 180.0)%360.0) - 180.0)/180.0
-                _notch(az_frac, 6.0, QtGui.QPen(self.notch_color, 2.2, QtCore.Qt.SolidLine))
+                _notch(az_frac, 6.0, QtGui.QPen(self.notch_color, 2.2, QtCore.Qt.PenStyle.SolidLine))
 
         # Az/Alt readout, in the middle just left of the optical-axis plus (right-aligned, two lines).
         # 'Az' = azimuth (+E of due N), 'Alt' = altitude/elevation. The decimal precision scales with the
@@ -1159,9 +1159,9 @@ class PointingIndicator(pg.GraphicsObject):
         painter.setPen(QtGui.QPen(self.text_color))
         # Two well-separated lines straddling the centre (Alt above, Az below)
         painter.drawText(QtCore.QRectF(tx, -30.0, tw, th),
-                         QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter, alt_str)
+                         QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter, alt_str)
         painter.drawText(QtCore.QRectF(tx, 2.0, tw, th),
-                         QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter, az_str)
+                         QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter, az_str)
 
         # Direction in device coordinates (screen-up = device -Y)
         ang = np.radians(self.angle)
@@ -1169,16 +1169,16 @@ class PointingIndicator(pg.GraphicsObject):
 
         if not self.valid_zenith:
             # Near the zenith the direction is undefined: draw a dashed ring instead of an arrow
-            pen = QtGui.QPen(self.arrow_color, 1.6, QtCore.Qt.DashLine)
+            pen = QtGui.QPen(self.arrow_color, 1.6, QtCore.Qt.PenStyle.DashLine)
             painter.setPen(pen)
-            painter.setBrush(QtCore.Qt.NoBrush)
+            painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
             painter.drawEllipse(QtCore.QPointF(0.0, 0.0), 0.5*L, 0.5*L)
             return
 
         # Shaft (originates from the centre of the optical-axis plus, points toward the zenith)
         x1, y1 = L*dx, L*dy
-        pen = QtGui.QPen(self.arrow_color, 2.2, QtCore.Qt.SolidLine)
-        pen.setCapStyle(QtCore.Qt.RoundCap)
+        pen = QtGui.QPen(self.arrow_color, 2.2, QtCore.Qt.PenStyle.SolidLine)
+        pen.setCapStyle(QtCore.Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
         painter.drawLine(QtCore.QPointF(0.0, 0.0), QtCore.QPointF(x1, y1))
 
@@ -1198,7 +1198,7 @@ class PointingIndicator(pg.GraphicsObject):
         perp = ang + np.pi/2.0
         pwx, pwy = np.cos(perp), -np.sin(perp)
         nw = 6.0
-        painter.setPen(QtGui.QPen(self.notch_color, 2.2, QtCore.Qt.SolidLine))
+        painter.setPen(QtGui.QPen(self.notch_color, 2.2, QtCore.Qt.PenStyle.SolidLine))
         painter.drawLine(QtCore.QPointF(px - nw*pwx, py - nw*pwy),
                          QtCore.QPointF(px + nw*pwx, py + nw*pwy))
 
@@ -1217,11 +1217,11 @@ class HistogramLUTWidget(pg.HistogramLUTWidget):
         super().mousePressEvent(event)
         modifier = QtWidgets.QApplication.keyboardModifiers()
         pos = self.vb.mapSceneToView(event.pos())
-        if self.item.region.movable and modifier == QtCore.Qt.ControlModifier:
+        if self.item.region.movable and modifier == QtCore.Qt.KeyboardModifier.ControlModifier:
             self.item.exitAutoLevels()
-            if event.button() == QtCore.Qt.LeftButton:
+            if event.button() == QtCore.Qt.MouseButton.LeftButton:
                 self.setLevels(pos.y(), self.getLevels()[1])
-            elif event.button() == QtCore.Qt.RightButton:
+            elif event.button() == QtCore.Qt.MouseButton.RightButton:
                 self.setLevels(self.getLevels()[0], pos.y())
 
         # Set focus back on the image window
@@ -1344,7 +1344,7 @@ class RightOptionsTab(QtWidgets.QTabWidget, ScaledSizeHelper):
         self.addTab(self.help, 'ⓘ Help')
 
         self.setCurrentIndex(self.index)  # redundant
-        self.setTabPosition(QtWidgets.QTabWidget.East)
+        self.setTabPosition(QtWidgets.QTabWidget.TabPosition.East)
 
         # Set the initial width once the tabs exist and the bar is on the East side, so the
         # measurement in barWidth() is meaningful
@@ -1357,7 +1357,7 @@ class RightOptionsTab(QtWidgets.QTabWidget, ScaledSizeHelper):
             on the main widget
         """
 
-        if event.key() == QtCore.Qt.Key_Escape:
+        if event.key() == QtCore.Qt.Key.Key_Escape:
             self.gui.view_widget.setFocus()
 
 
@@ -1379,7 +1379,7 @@ class RightOptionsTab(QtWidgets.QTabWidget, ScaledSizeHelper):
         bar_width = self.tabBar().sizeHint().width()
 
         # Frame drawn on either side of the tab pane
-        frame = 2*self.style().pixelMetric(QtWidgets.QStyle.PM_DefaultFrameWidth, None, self)
+        frame = 2*self.style().pixelMetric(QtWidgets.QStyle.PixelMetric.PM_DefaultFrameWidth, None, self)
 
         return bar_width + frame
 
@@ -1476,7 +1476,7 @@ class HelpWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self._history = []
 
         layout = QtWidgets.QVBoxLayout()
-        layout.setAlignment(QtCore.Qt.AlignTop)
+        layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
         layout.setContentsMargins(*self.scaledMargins(0.5, 0.25))
         layout.setSpacing(self.scaledSpacing(0.25))
         self.setLayout(layout)
@@ -1620,8 +1620,8 @@ class DebruijnSequenceManager(QtWidgets.QWidget, ScaledSizeHelper):
         self.table.setColumnWidth(2, self.scaledWidth(5))   # value
         self.table.setHorizontalHeaderLabels(['break', 'time', 'value'])
         # self.table.verticalHeader().hide()
-        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
-        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.currentCellChanged.connect(self.onCurrentCellChanged)
         self.table.cellChanged.connect(self.onCellChanged)
         self.updateTable()
@@ -1652,12 +1652,12 @@ class DebruijnSequenceManager(QtWidgets.QWidget, ScaledSizeHelper):
         if test is None:
             msg = QtWidgets.QMessageBox()
             msg.setWindowTitle('DFN Manual Reduction Error')
-            msg.setIcon(QtWidgets.QMessageBox.Information)
+            msg.setIcon(QtWidgets.QMessageBox.Icon.Information)
             msg.setText('Sequence is incorrect')
             msg.setInformativeText('Inputted sequence must be a sequence of 11 or 10. '
                                    'The inputted sequence does not.')
-            msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
-            msg.exec_()
+            msg.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
+            msg.exec()
             return
 
         forward, backward = findAllInDeBruijnSequence(test, self.sequence, unknowns=True, reverse=reversed)
@@ -1669,11 +1669,12 @@ class DebruijnSequenceManager(QtWidgets.QWidget, ScaledSizeHelper):
             msg.setWindowTitle('DFN Manual Reduction Solution Selection')
             msg.setText('There are multiple possible matches of the given sequence to the De Bruijn Sequence.\n'
                         'Select one.')
-            msg.setStandardButtons(QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel)
+            msg.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok
+                                   | QtWidgets.QMessageBox.StandardButton.Cancel)
             msg.buttons()[0].setDisabled(True)
             table = QtWidgets.QTableWidget(len(forward) + len(backward), 4)
-            table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
-            table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+            table.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+            table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
             table.setHorizontalHeaderLabels(['break', 'start time', 'direction', 'pattern'])
             table.setColumnWidth(0, self.scaledWidth(8))
             table.setColumnWidth(3, self.scaledWidth(22))
@@ -1686,21 +1687,21 @@ class DebruijnSequenceManager(QtWidgets.QWidget, ScaledSizeHelper):
                 break_ = 2*frame + (not paired_first_bit)
 
                 item1 = QtWidgets.QTableWidgetItem(str(break_))
-                item1.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item1.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 table.setItem(row, 0, item1)
 
                 item2 = QtWidgets.QTableWidgetItem(
                     self.gui.img.img_handle.currentFrameTime(dt_obj=True, frame_no=break_).strftime("%H:%M:%S.%f")[:-3])
-                item2.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item2.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 table.setItem(row, 1, item2)
 
                 item3 = QtWidgets.QTableWidgetItem('forward')
-                item3.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item3.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 table.setItem(row, 2, item3)
 
                 item4 = QtWidgets.QTableWidgetItem(
                     ''.join(str(x) for x in self.sequence[frame - 4:frame + len(test) + 4]))
-                item4.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item4.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 table.setItem(row, 3, item4)
 
             for row, frame in enumerate(backward[::-1]):
@@ -1708,24 +1709,24 @@ class DebruijnSequenceManager(QtWidgets.QWidget, ScaledSizeHelper):
                 break_ = 1024 - 2*frame - (not paired_first_bit) - self.table.rowCount() + 1
 
                 item1 = QtWidgets.QTableWidgetItem(str(break_))
-                item1.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item1.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 table.setItem(row, 0, item1)
 
                 item2 = QtWidgets.QTableWidgetItem(
                     self.gui.img.img_handle.currentFrameTime(dt_obj=True, frame_no=break_).strftime("%H:%M:%S.%f")[:-3])
-                item2.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item2.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 table.setItem(row, 1, item2)
 
                 item3 = QtWidgets.QTableWidgetItem('backward')
-                item3.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item3.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 table.setItem(row, 2, item3)
 
                 item4 = QtWidgets.QTableWidgetItem(
                     ''.join(str(x) for x in self.sequence[::-1][frame - 4:frame + len(test) + 4]))
-                item4.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item4.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 table.setItem(row, 3, item4)
 
-            result = msg.exec_()
+            result = msg.exec()
             if result == msg.standardButton(msg.buttons()[0]):
                 index = table.currentIndex().row()
                 if index < len(forward):
@@ -1747,11 +1748,11 @@ class DebruijnSequenceManager(QtWidgets.QWidget, ScaledSizeHelper):
             print('Neither were found')
             msg = QtWidgets.QMessageBox()
             msg.setWindowTitle('DFN Manual Reduction Error')
-            msg.setIcon(QtWidgets.QMessageBox.Information)
+            msg.setIcon(QtWidgets.QMessageBox.Icon.Information)
             msg.setText('Sequence could not be found')
             msg.setInformativeText('The sequence given is incorrect.')
-            msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
-            msg.exec_()
+            msg.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
+            msg.exec()
             return
 
         self.gui.img.setFrame(f(self.gui.img.getFrame()))
@@ -1849,12 +1850,12 @@ class DebruijnSequenceManager(QtWidgets.QWidget, ScaledSizeHelper):
                 self.table.insertRow(row)
 
                 item1 = QtWidgets.QTableWidgetItem(str(frame))
-                item1.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item1.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 self.table.setItem(row, 0, item1)
 
                 item2 = QtWidgets.QTableWidgetItem(
                     self.gui.img.img_handle.currentFrameTime(dt_obj=True, frame_no=frame).strftime("%H:%M:%S.%f")[:-3])
-                item2.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+                item2.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
                 self.table.setItem(row, 1, item2)
 
                 item3 = QtWidgets.QTableWidgetItem(str(value))
@@ -1865,12 +1866,12 @@ class DebruijnSequenceManager(QtWidgets.QWidget, ScaledSizeHelper):
         self.table.insertRow(row)
 
         item1 = QtWidgets.QTableWidgetItem(str(frame))
-        item1.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+        item1.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
         self.table.setItem(row, 0, item1)
 
         item2 = QtWidgets.QTableWidgetItem(
             self.gui.img.img_handle.currentFrameTime(dt_obj=True, frame_no=frame).strftime("%H:%M:%S.%f")[:-3])
-        item2.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
+        item2.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
         self.table.setItem(row, 1, item2)
 
         item3 = QtWidgets.QTableWidgetItem(str(value))
@@ -1918,7 +1919,7 @@ class GeolocationWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.gui = gui
 
         full_layout = QtWidgets.QVBoxLayout()
-        full_layout.setAlignment(QtCore.Qt.AlignTop)
+        full_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
         self.setLayout(full_layout)
 
         # Tab help button (top-right)
@@ -1926,7 +1927,7 @@ class GeolocationWidget(QtWidgets.QWidget, ScaledSizeHelper):
 
         # Station geo position input boxes
         form = QtWidgets.QFormLayout()
-        form.setLabelAlignment(QtCore.Qt.AlignRight)
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
 
         group = QtWidgets.QGroupBox('Station coordinates')
         group.setLayout(form)
@@ -1942,7 +1943,7 @@ class GeolocationWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.lat.setFixedWidth(self.scaledWidth(self.COORD_INPUT_CHARS))
         self.lat.valueModified.connect(self.onLatChanged)
         hbox.addWidget(self.lat)
-        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         form.addRow(QtWidgets.QLabel('Lat'), hbox)
 
         hbox = QtWidgets.QHBoxLayout()
@@ -1954,7 +1955,7 @@ class GeolocationWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.lon.setFixedWidth(self.scaledWidth(self.COORD_INPUT_CHARS))
         self.lon.valueModified.connect(self.onLonChanged)
         hbox.addWidget(self.lon)
-        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         form.addRow(QtWidgets.QLabel('Lon'), hbox)
 
         hbox = QtWidgets.QHBoxLayout()
@@ -1966,7 +1967,7 @@ class GeolocationWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.elev.setFixedWidth(self.scaledWidth(self.COORD_INPUT_CHARS))
         self.elev.valueModified.connect(self.onElevChanged)
         hbox.addWidget(self.elev)
-        hbox.addWidget(QtWidgets.QLabel('m', alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel('m', alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         form.addRow(QtWidgets.QLabel('Elev'), hbox)
 
         form.addRow(QtWidgets.QLabel("Press Enter to accept value"))
@@ -2028,7 +2029,7 @@ class GeolocationWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.dist_box.valueModified.connect(self.onDistanceChanged)
         hbox.addWidget(QtWidgets.QLabel('Distance'))
         hbox.addWidget(self.dist_box)
-        hbox.addWidget(QtWidgets.QLabel('m', alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel('m', alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         box.addLayout(hbox)
         box.addWidget(QtWidgets.QLabel("Press Enter to accept value"))
 
@@ -2378,7 +2379,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
 
         # spin boxes
         form = QtWidgets.QFormLayout()
-        form.setLabelAlignment(QtCore.Qt.AlignRight)
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         full_layout.addLayout(form)
 
         hbox = QtWidgets.QHBoxLayout()
@@ -2390,7 +2391,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         self.az_centre.setFixedWidth(self.scaledWidth(self.PARAM_INPUT_CHARS))
         self.az_centre.valueModified.connect(self.onAzChanged)
         hbox.addWidget(self.az_centre)
-        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         form.addRow(QtWidgets.QLabel('Azim'), hbox)
 
         hbox = QtWidgets.QHBoxLayout()
@@ -2402,7 +2403,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         self.alt_centre.setFixedWidth(self.scaledWidth(self.PARAM_INPUT_CHARS))
         self.alt_centre.valueModified.connect(self.onAltChanged)
         hbox.addWidget(self.alt_centre)
-        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         form.addRow(QtWidgets.QLabel('Alt'), hbox)
 
         hbox = QtWidgets.QHBoxLayout()
@@ -2414,7 +2415,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         self.rotation_from_horiz.setFixedWidth(self.scaledWidth(self.PARAM_INPUT_CHARS))
         self.rotation_from_horiz.valueModified.connect(self.onRotChanged)
         hbox.addWidget(self.rotation_from_horiz)
-        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         form.addRow(QtWidgets.QLabel('Horiz rot'), hbox)
 
         hbox = QtWidgets.QHBoxLayout()
@@ -2426,7 +2427,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         self.F_scale.setFixedWidth(self.scaledWidth(self.PARAM_INPUT_CHARS))
         self.F_scale.valueModified.connect(self.onScaleChanged)
         hbox.addWidget(self.F_scale)
-        hbox.addWidget(QtWidgets.QLabel('\'/px', alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel('\'/px', alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         form.addRow(QtWidgets.QLabel('Scale'), hbox)
 
         form.addRow(QtWidgets.QLabel("Press Enter to accept value"))
@@ -2440,7 +2441,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         # self.lat.setFixedWidth(100)
         # self.lat.valueModified.connect(self.onLatChanged)
         # hbox.addWidget(self.lat)
-        # hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignLeft))
+        # hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         # form.addRow(QtWidgets.QLabel('Lat'), hbox)
 
         # hbox = QtWidgets.QHBoxLayout()
@@ -2452,7 +2453,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         # self.lon.setFixedWidth(100)
         # self.lon.valueModified.connect(self.onLonChanged)
         # hbox.addWidget(self.lon)
-        # hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignLeft))
+        # hbox.addWidget(QtWidgets.QLabel(u"\N{DEGREE SIGN}", alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         # form.addRow(QtWidgets.QLabel('Lon'), hbox)
 
         # hbox = QtWidgets.QHBoxLayout()
@@ -2464,7 +2465,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         # self.elev.setFixedWidth(100)
         # self.elev.valueModified.connect(self.onElevChanged)
         # hbox.addWidget(self.elev)
-        # hbox.addWidget(QtWidgets.QLabel('m', alignment=QtCore.Qt.AlignLeft))
+        # hbox.addWidget(QtWidgets.QLabel('m', alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         # form.addRow(QtWidgets.QLabel('Elev'), hbox)
 
         self.distortion_type = QtWidgets.QComboBox(self)
@@ -2511,11 +2512,11 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         self.extinction_scale.setFixedWidth(self.scaledWidth(self.PARAM_INPUT_CHARS - 4))
         self.extinction_scale.valueModified.connect(self.onExtinctionChanged)
         hbox.addWidget(self.extinction_scale)
-        hbox.addWidget(QtWidgets.QLabel('', alignment=QtCore.Qt.AlignLeft))
+        hbox.addWidget(QtWidgets.QLabel('', alignment=QtCore.Qt.AlignmentFlag.AlignLeft))
         form.addRow(QtWidgets.QLabel('Extinction'), hbox)
 
         hbox = QtWidgets.QHBoxLayout()
-        hbox.setAlignment(QtCore.Qt.AlignVCenter)
+        hbox.setAlignment(QtCore.Qt.AlignmentFlag.AlignVCenter)
         self.vignetting_coeff = DoubleSpinBox()
         self.vignetting_coeff.setMinimum(0)
         self.vignetting_coeff.setMaximum(0.1)
@@ -2532,13 +2533,13 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         info_font.setBold(True)
         vignetting_info.setFont(info_font)
         vignetting_info.setStyleSheet("QToolButton { color: #0066cc; border: none; } QToolButton:hover { color: #0044aa; }")
-        vignetting_info.setCursor(QtCore.Qt.PointingHandCursor)
+        vignetting_info.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
         vignetting_info.clicked.connect(self.showVignettingInfo)
         hbox.addWidget(vignetting_info)
         form.addRow(QtWidgets.QLabel("Vignetting"), hbox)
 
         hbox_fixed = QtWidgets.QHBoxLayout()
-        hbox_fixed.setAlignment(QtCore.Qt.AlignVCenter)
+        hbox_fixed.setAlignment(QtCore.Qt.AlignmentFlag.AlignVCenter)
         self.vignetting_fixed = QtWidgets.QCheckBox('Fixed vignetting')
         self.vignetting_fixed.setChecked(True)
         self.vignetting_fixed.released.connect(self.onVignettingFixedToggled)
@@ -2550,7 +2551,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
         info_font.setBold(True)
         vignetting_fixed_info.setFont(info_font)
         vignetting_fixed_info.setStyleSheet("QToolButton { color: #0066cc; border: none; } QToolButton:hover { color: #0044aa; }")
-        vignetting_fixed_info.setCursor(QtCore.Qt.PointingHandCursor)
+        vignetting_fixed_info.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
         vignetting_fixed_info.clicked.connect(self.showVignettingFixedInfo)
         hbox_fixed.addWidget(vignetting_fixed_info)
         hbox_fixed.addStretch()
@@ -2782,7 +2783,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
 
     def showVignettingInfo(self):
         msg = QtWidgets.QMessageBox(self)
-        msg.setIcon(QtWidgets.QMessageBox.Information)
+        msg.setIcon(QtWidgets.QMessageBox.Icon.Information)
         msg.setWindowTitle("Vignetting Coefficient")
         msg.setText("Vignetting coefficient (radians per pixel)")
         msg.setInformativeText(
@@ -2795,11 +2796,11 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
             "(see info next to Fixed Vignetting), or reach out to\n"
             "the GMN community for known good values for your lens."
         )
-        msg.exec_()
+        msg.exec()
 
     def showVignettingFixedInfo(self):
         msg = QtWidgets.QMessageBox(self)
-        msg.setIcon(QtWidgets.QMessageBox.Information)
+        msg.setIcon(QtWidgets.QMessageBox.Icon.Information)
         msg.setWindowTitle("Measuring Vignetting Coefficient")
         msg.setText("Measuring vignetting requires ideal conditions:")
         msg.setInformativeText(
@@ -2812,7 +2813,7 @@ class PlateparParameterManager(QtWidgets.QWidget, ScaledSizeHelper):
             "If these conditions are not met, it is best to leave\n"
             "Fixed Vignetting checked and use the default value."
         )
-        msg.exec_()
+        msg.exec()
 
     def onVignettingFixedToggled(self):
         self.gui.platepar.vignetting_fixed = self.vignetting_fixed.isChecked()
@@ -3398,12 +3399,12 @@ class StarDetectionWidget(QtWidgets.QWidget, ScaledSizeHelper):
             grid.addWidget(QtWidgets.QLabel(name), row, 0)
             val_label = QtWidgets.QLabel(default_str)
             val_label.setFixedSize(self.scaledWidth(6), self.scaledHeight(1))
-            val_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+            val_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
             grid.addWidget(val_label, row, 1)
             row += 1
 
             # Row with slider spanning both columns
-            slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+            slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
             slider.setRange(min_val, max_val)
             slider.setValue(default)
             slider.valueChanged.connect(callback)
@@ -3626,7 +3627,7 @@ class BrushCursorItem(pg.GraphicsObject):
 
     def paint(self, painter, option, widget=None):
         painter.setPen(self._pen)
-        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
         painter.drawEllipse(QtCore.QPointF(0, 0), self._radius, self._radius)
 
     def boundingRect(self):
@@ -3715,7 +3716,7 @@ class MaskWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.brush_size_label = QtWidgets.QLabel('Brush size:')
         brush_size_layout.addWidget(self.brush_size_label)
 
-        self.brush_size_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.brush_size_slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
         self.brush_size_slider.setRange(1, 200)
         self.brush_size_slider.setValue(20)
         self.brush_size_slider.valueChanged.connect(self._onBrushSizeChanged)
@@ -3901,16 +3902,18 @@ class MaskWidget(QtWidgets.QWidget, ScaledSizeHelper):
         """Confirm and clear all polygons."""
         reply = QtWidgets.QMessageBox.question(self, 'Clear All',
             'Delete all mask polygons?',
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
-        if reply == QtWidgets.QMessageBox.Yes:
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+            QtWidgets.QMessageBox.StandardButton.No)
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             self.sigClearPolygons.emit()
 
     def onClearBrush(self):
         """Confirm and clear all brush strokes."""
         reply = QtWidgets.QMessageBox.question(self, 'Clear Brush Strokes',
             'Delete all brush strokes?',
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
-        if reply == QtWidgets.QMessageBox.Yes:
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+            QtWidgets.QMessageBox.StandardButton.No)
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             self.sigClearBrushStrokes.emit()
 
     def updateStatus(self, polygon_count, drawing_points=0, has_brush_strokes=False):
@@ -3993,7 +3996,7 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.gui = gui
 
         vbox = QtWidgets.QVBoxLayout()
-        vbox.setAlignment(QtCore.Qt.AlignTop)
+        vbox.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
         self.setLayout(vbox)
 
         # Tab help button (top-right)
@@ -4432,11 +4435,11 @@ def valid_float_string(string):
 class FloatValidator(QtGui.QValidator):
     def validate(self, string, position):
         if valid_float_string(string):
-            state = QtGui.QValidator.Acceptable
+            state = QtGui.QValidator.State.Acceptable
         elif string == "" or string[position - 1] in 'e.-+':
-            state = QtGui.QValidator.Intermediate
+            state = QtGui.QValidator.State.Intermediate
         else:
-            state = QtGui.QValidator.Invalid
+            state = QtGui.QValidator.State.Invalid
         return state, string, position
 
     def fixup(self, text):
@@ -4462,7 +4465,7 @@ class DoubleSpinBox(QtWidgets.QDoubleSpinBox):
 
     def keyPressEvent(self, e):
         super().keyPressEvent(e)
-        if (e.key() == QtCore.Qt.Key_Return) or (e.key() == QtCore.Qt.Key_Enter):
+        if (e.key() == QtCore.Qt.Key.Key_Return) or (e.key() == QtCore.Qt.Key.Key_Enter):
             self.valueModified.emit()
 
 
@@ -4508,7 +4511,7 @@ class ScientificDoubleSpinBox(QtWidgets.QDoubleSpinBox):
 
     def keyPressEvent(self, e):
         super().keyPressEvent(e)
-        if e.key() == QtCore.Qt.Key_Return:
+        if e.key() == QtCore.Qt.Key.Key_Return:
             self.valueModified.emit()
 
 

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1263,7 +1263,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
         # Pick folder
         dir_path = str(QtWidgets.QFileDialog.getExistingDirectory(
             self, "Select folder with FF/image files",
-            pt.dir_path, QtWidgets.QFileDialog.ShowDirsOnly))
+            pt.dir_path, QtWidgets.QFileDialog.Option.ShowDirsOnly))
         if not dir_path:
             return
 
@@ -1292,11 +1292,11 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
             reply = QtWidgets.QMessageBox.question(
                 self, "Unsaved Changes",
                 "The current platepar has unsaved changes.\nSave before changing station?",
-                QtWidgets.QMessageBox.Save | QtWidgets.QMessageBox.Discard | QtWidgets.QMessageBox.Cancel,
-                QtWidgets.QMessageBox.Save)
-            if reply == QtWidgets.QMessageBox.Cancel:
+                QtWidgets.QMessageBox.StandardButton.Save | QtWidgets.QMessageBox.StandardButton.Discard | QtWidgets.QMessageBox.StandardButton.Cancel,
+                QtWidgets.QMessageBox.StandardButton.Save)
+            if reply == QtWidgets.QMessageBox.StandardButton.Cancel:
                 return
-            if reply == QtWidgets.QMessageBox.Save:
+            if reply == QtWidgets.QMessageBox.StandardButton.Save:
                 pt.savePlatepar()
 
         # Reload via changeStation
@@ -1636,7 +1636,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
             # Use folder picker — _loadFile will find .config in the selected directory
             path = str(QtWidgets.QFileDialog.getExistingDirectory(
                 self, "Select folder containing config", start_dir,
-                QtWidgets.QFileDialog.ShowDirsOnly))
+                QtWidgets.QFileDialog.Option.ShowDirsOnly))
             return path
         elif ftype == "Mask":
             path, _ = QtWidgets.QFileDialog.getOpenFileName(
@@ -1798,10 +1798,10 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
 
         # OK / Cancel
         btn_box = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
+            QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
         btn_box.accepted.connect(dlg.accept)
         btn_box.rejected.connect(dlg.reject)
-        ok_btn = btn_box.button(QtWidgets.QDialogButtonBox.Ok)
+        ok_btn = btn_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
 
         def updateOkButton():
             ok_btn.setEnabled(any(cb.isChecked() for cb in checkboxes))
@@ -1842,7 +1842,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
 
         layout.addWidget(btn_box)
 
-        if dlg.exec_() == QtWidgets.QDialog.Accepted:
+        if dlg.exec_() == QtWidgets.QDialog.DialogCode.Accepted:
             paths = [cb.property("path") for cb in checkboxes if cb.isChecked()]
             if paths:
                 self._saveFile(ftype, paths)
@@ -1946,7 +1946,7 @@ class QFOVinputDialog(QtWidgets.QDialog):
 
         self.setWindowTitle("Pointing information")
 
-        btn = QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        btn = QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel
 
         buttonBox = QtWidgets.QDialogButtonBox(btn)
         buttonBox.accepted.connect(self.accept)
@@ -1958,15 +1958,15 @@ class QFOVinputDialog(QtWidgets.QDialog):
 
 
         azim_validator = QtGui.QDoubleValidator(-180, 360, 9)
-        azim_validator.setNotation(QtGui.QDoubleValidator.StandardNotation)
+        azim_validator.setNotation(QtGui.QDoubleValidator.Notation.StandardNotation)
         self.azim_edit.setValidator(azim_validator)
 
         alt_validator = QtGui.QDoubleValidator(0, 90, 9)
-        alt_validator.setNotation(QtGui.QDoubleValidator.StandardNotation)
+        alt_validator.setNotation(QtGui.QDoubleValidator.Notation.StandardNotation)
         self.alt_edit.setValidator(alt_validator)
 
         rot_validator = QtGui.QDoubleValidator(-180, 360, 9)
-        rot_validator.setNotation(QtGui.QDoubleValidator.StandardNotation)
+        rot_validator.setNotation(QtGui.QDoubleValidator.Notation.StandardNotation)
         self.rot_edit.setValidator(rot_validator)
 
         layout = QtWidgets.QVBoxLayout(self)
@@ -3173,7 +3173,7 @@ class PlateTool(QtWidgets.QMainWindow):
                                            anchor=(0.5, 0.5), 
                                            color=(0, 0, 0), 
                                            fill=(255, 255, 255, 200))
-        self.sat_computing_text.setFont(QtGui.QFont('Arial', 24, QtGui.QFont.Bold))
+        self.sat_computing_text.setFont(QtGui.QFont('Arial', 24, QtGui.QFont.Weight.Bold))
         self.sat_computing_text.hide()
         self.sat_computing_text.setZValue(100)  # Very high z-value to be on top
         self.img_frame.addItem(self.sat_computing_text)
@@ -3269,19 +3269,19 @@ class PlateTool(QtWidgets.QMainWindow):
 
         lut = np.array([[0, 0, 0, 0], [0, 255, 0, 76]], dtype=np.ubyte)
         self.region = pg.ImageItem(lut=lut)
-        self.region.setCompositionMode(QtGui.QPainter.CompositionMode_SourceOver)
+        self.region.setCompositionMode(QtGui.QPainter.CompositionMode.CompositionMode_SourceOver)
         self.region.setZValue(10)
         self.img_frame.addItem(self.region)
 
         self.region_zoom = pg.ImageItem(lut=lut)
-        self.region_zoom.setCompositionMode(QtGui.QPainter.CompositionMode_SourceOver)
+        self.region_zoom.setCompositionMode(QtGui.QPainter.CompositionMode.CompositionMode_SourceOver)
         self.region_zoom.setZValue(10)
         self.zoom_window.addItem(self.region_zoom)
 
         # Mask overlay (red tint over masked areas)
         mask_lut = np.array([[0, 0, 0, 0], [255, 0, 0, 80]], dtype=np.ubyte)
         self.mask_overlay = pg.ImageItem(lut=mask_lut)
-        self.mask_overlay.setCompositionMode(QtGui.QPainter.CompositionMode_SourceOver)
+        self.mask_overlay.setCompositionMode(QtGui.QPainter.CompositionMode.CompositionMode_SourceOver)
         self.mask_overlay.setZValue(8)
         self.img_frame.addItem(self.mask_overlay)
         self.mask_overlay.hide()
@@ -3610,7 +3610,7 @@ class PlateTool(QtWidgets.QMainWindow):
         """
         if dir_path is None:
             dir_path = str(QtWidgets.QFileDialog.getExistingDirectory(self, "Select new station folder",
-                                                                  self.dir_path, QtWidgets.QFileDialog.ShowDirsOnly))
+                                                                  self.dir_path, QtWidgets.QFileDialog.Option.ShowDirsOnly))
 
         if not dir_path:
             return False
@@ -12903,9 +12903,9 @@ class PlateTool(QtWidgets.QMainWindow):
             )
 
             auto_fit_label = "Auto Fit (placeholder)" if not best_ff_available else "Auto Fit"
-            auto_fit_btn = msg_box.addButton(auto_fit_label, QtWidgets.QMessageBox.ActionRole)
-            navigate_btn = msg_box.addButton("Go to Best Image", QtWidgets.QMessageBox.ActionRole)
-            msg_box.addButton(QtWidgets.QMessageBox.Cancel)
+            auto_fit_btn = msg_box.addButton(auto_fit_label, QtWidgets.QMessageBox.ButtonRole.ActionRole)
+            navigate_btn = msg_box.addButton("Go to Best Image", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+            msg_box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
 
             msg_box.setDefaultButton(auto_fit_btn)
             msg_box.exec_()
@@ -13276,10 +13276,10 @@ class PlateTool(QtWidgets.QMainWindow):
                 "Replace Matched Stars?",
                 "You have {} matched star pair(s) that will be replaced by auto-fit.\n\n"
                 "Do you want to continue?".format(len(self.paired_stars)),
-                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-                QtWidgets.QMessageBox.No
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+                QtWidgets.QMessageBox.StandardButton.No
             )
-            if reply != QtWidgets.QMessageBox.Yes:
+            if reply != QtWidgets.QMessageBox.StandardButton.Yes:
                 return
 
         # Show busy state on button
@@ -13454,15 +13454,15 @@ class PlateTool(QtWidgets.QMainWindow):
             msgbox = QtWidgets.QMessageBox(self)
             msgbox.setWindowTitle('Astrometry.net Solution - FOV Mismatch')
             msgbox.setText(msg)
-            msgbox.setIcon(QtWidgets.QMessageBox.Warning)
-            msgbox.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
-            msgbox.setDefaultButton(QtWidgets.QMessageBox.Yes)
+            msgbox.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+            msgbox.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+            msgbox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Yes)
             reply = msgbox.exec_()
         else:
             reply = QtWidgets.QMessageBox.question(self, 'Astrometry.net Solution', msg,
-                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.Yes)
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No, QtWidgets.QMessageBox.StandardButton.Yes)
 
-        if reply == QtWidgets.QMessageBox.No:
+        if reply == QtWidgets.QMessageBox.StandardButton.No:
             self.status_bar.showMessage("Astrometry.net solution applied (no refinement)")
             return self.platepar
 
@@ -14101,9 +14101,9 @@ class PlateTool(QtWidgets.QMainWindow):
         msg = QtWidgets.QMessageBox(self)
         msg.setWindowTitle("No platepar found")
         msg.setText("No platepar files were found in the folder.")
-        browse_btn = msg.addButton("Browse...", QtWidgets.QMessageBox.ActionRole)
-        create_btn = msg.addButton("Create new", QtWidgets.QMessageBox.ActionRole)
-        msg.addButton(QtWidgets.QMessageBox.Cancel)
+        browse_btn = msg.addButton("Browse...", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        create_btn = msg.addButton("Create new", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        msg.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
         msg.exec_()
 
         if msg.clickedButton() == browse_btn:

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -13,6 +13,8 @@ import glob
 import sys
 import time
 import random
+import html
+import re
 from concurrent.futures import ThreadPoolExecutor
 import copy
 import shutil
@@ -216,8 +218,6 @@ from RMS.Astrometry.Conversions import datetime2JD
 
 # Load the ASTRA module
 try:
-    import html, re
-
     from Utils.Astra import ASTRA, PYSWARMS_AVAILABLE
 
     if not PYSWARMS_AVAILABLE:

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -1307,7 +1307,9 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
             reply = QtWidgets.QMessageBox.question(
                 self, "Unsaved Changes",
                 "The current platepar has unsaved changes.\nSave before changing station?",
-                QtWidgets.QMessageBox.StandardButton.Save | QtWidgets.QMessageBox.StandardButton.Discard | QtWidgets.QMessageBox.StandardButton.Cancel,
+                QtWidgets.QMessageBox.StandardButton.Save
+                | QtWidgets.QMessageBox.StandardButton.Discard
+                | QtWidgets.QMessageBox.StandardButton.Cancel,
                 QtWidgets.QMessageBox.StandardButton.Save)
             if reply == QtWidgets.QMessageBox.StandardButton.Cancel:
                 return
@@ -3629,7 +3631,8 @@ class PlateTool(QtWidgets.QMainWindow):
         """
         if dir_path is None:
             dir_path = str(QtWidgets.QFileDialog.getExistingDirectory(self, "Select new station folder",
-                                                                  self.dir_path, QtWidgets.QFileDialog.Option.ShowDirsOnly))
+                                                                      self.dir_path,
+                                                                      QtWidgets.QFileDialog.Option.ShowDirsOnly))
 
         if not dir_path:
             return False
@@ -10022,7 +10025,8 @@ class PlateTool(QtWidgets.QMainWindow):
                     mode = 1
 
                     if modifiers & QtCore.Qt.KeyboardModifier.ControlModifier or \
-                            ((modifiers & QtCore.Qt.KeyboardModifier.AltModifier or QtCore.Qt.Key.Key_0 in self.keys_pressed) and
+                            ((modifiers & QtCore.Qt.KeyboardModifier.AltModifier
+                              or QtCore.Qt.Key.Key_0 in self.keys_pressed) and
                              self.img.img_handle.input_type == 'dfn'):
 
                         self.x_centroid, self.y_centroid = self.mouse_x - 0.5, self.mouse_y - 0.5
@@ -10038,7 +10042,8 @@ class PlateTool(QtWidgets.QMainWindow):
                             print("Skipping detection: non-positive intensity ({:.1f})".format(source_intens))
                             return
 
-                    if (modifiers & QtCore.Qt.KeyboardModifier.AltModifier or QtCore.Qt.Key.Key_0 in self.keys_pressed) and \
+                    if (modifiers & QtCore.Qt.KeyboardModifier.AltModifier
+                            or QtCore.Qt.Key.Key_0 in self.keys_pressed) and \
                             self.img.img_handle.input_type == 'dfn':
                         mode = 0
 
@@ -10288,7 +10293,9 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
         # Fit spectral band ratios (hidden feature)
-        elif event.key() == QtCore.Qt.Key.Key_B and modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier | QtCore.Qt.KeyboardModifier.ShiftModifier):
+        elif event.key() == QtCore.Qt.Key.Key_B \
+                and modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier
+                                  | QtCore.Qt.KeyboardModifier.ShiftModifier):
             self.fitBandRatio()
 
         # Toggle satellite tracks
@@ -10533,7 +10540,8 @@ class PlateTool(QtWidgets.QMainWindow):
 
             # Do a fit on the selected stars while in the star picking mode
             elif (event.key() == QtCore.Qt.Key.Key_Z) and ((modifiers == QtCore.Qt.KeyboardModifier.ControlModifier) \
-                or (modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier | QtCore.Qt.KeyboardModifier.ShiftModifier))):
+                or (modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier
+                                  | QtCore.Qt.KeyboardModifier.ShiftModifier))):
 
                 # If shift was pressed, reset distortion parameters to zero
                 if modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier | QtCore.Qt.KeyboardModifier.ShiftModifier):
@@ -10836,7 +10844,8 @@ class PlateTool(QtWidgets.QMainWindow):
 
             # Get initial parameters from astrometry.net (same as Auto Fit button)
             elif (event.key() == QtCore.Qt.Key.Key_X) and ((modifiers == QtCore.Qt.KeyboardModifier.ControlModifier) \
-                or (modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier | QtCore.Qt.KeyboardModifier.ShiftModifier))):
+                or (modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier
+                                  | QtCore.Qt.KeyboardModifier.ShiftModifier))):
 
                 # Use the same auto-fit path as the button (includes catalog balancing, quick alignment)
                 self.autoFitAstrometryNet()
@@ -13555,12 +13564,14 @@ class PlateTool(QtWidgets.QMainWindow):
             msgbox.setWindowTitle('Astrometry.net Solution - FOV Mismatch')
             msgbox.setText(msg)
             msgbox.setIcon(QtWidgets.QMessageBox.Icon.Warning)
-            msgbox.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+            msgbox.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Yes
+                                      | QtWidgets.QMessageBox.StandardButton.No)
             msgbox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Yes)
             reply = msgbox.exec()
         else:
             reply = QtWidgets.QMessageBox.question(self, 'Astrometry.net Solution', msg,
-                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No, QtWidgets.QMessageBox.StandardButton.Yes)
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+                QtWidgets.QMessageBox.StandardButton.Yes)
 
         if reply == QtWidgets.QMessageBox.StandardButton.No:
             self.status_bar.showMessage("Astrometry.net solution applied (no refinement)")

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -132,7 +132,7 @@ try:
     from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
 except Exception as exc:
     message = [
-        "SkyFit requires PyQtGraph/PyQt5 for its GUI components, but the import failed.",
+        "SkyFit requires PyQtGraph/Qt for its GUI components, but the import failed.",
         "The most common causes are missing GUI dependencies or Windows being unable to allocate enough",
         "virtual memory (e.g. the paging file is too small).",
         f"Original import error: {exc}",
@@ -9127,7 +9127,9 @@ class PlateTool(QtWidgets.QMainWindow):
 
         # Remove other PlotCurveItem objects which cannot be pickled
         # Generic scrubber for pyqtgraph/qt items
-        unpicklable_modules = ('pyqtgraph', 'PyQt5', 'RMS.Routines.CustomPyqtgraphClasses', 'matplotlib')
+        # Cover every Qt binding pyqtgraph might have selected, not just PyQt5
+        unpicklable_modules = ('pyqtgraph', 'PyQt5', 'PyQt6', 'PySide2', 'PySide6',
+                               'RMS.Routines.CustomPyqtgraphClasses', 'matplotlib')
         keys_to_remove = []
         for k, v in dic.items():
 
@@ -10221,9 +10223,12 @@ class PlateTool(QtWidgets.QMainWindow):
         modifiers = QtWidgets.QApplication.keyboardModifiers()
         qmodifiers = QtWidgets.QApplication.queryKeyboardModifiers()
 
-        # Strip the GroupSwitchModifier (constantly pressed on some systems for some reason, not used in SkyFit)
-        modifiers &= ~int(QtCore.Qt.KeyboardModifier.GroupSwitchModifier)
-        qmodifiers &= ~int(QtCore.Qt.KeyboardModifier.GroupSwitchModifier)
+        # Strip the GroupSwitchModifier (constantly pressed on some systems for some reason, not used in SkyFit).
+        # Invert the enum member itself instead of an int() of it - on Qt6 bindings the modifier flags are
+        # enum.Flag members, which do not convert to int.
+        group_switch = QtCore.Qt.KeyboardModifier.GroupSwitchModifier
+        modifiers &= ~group_switch
+        qmodifiers &= ~group_switch
 
         self.keys_pressed.append(event.key())
 

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -127,7 +127,7 @@ import scipy.optimize
 from scipy.spatial import cKDTree
 try:
     import pyqtgraph as pg
-    from pyqtgraph.Qt import QtWidgets, QtGui
+    from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
 except Exception as exc:
     message = [
         "SkyFit requires PyQtGraph/PyQt5 for its GUI components, but the import failed.",
@@ -145,6 +145,29 @@ except Exception as exc:
 
     print("\n".join(message))
     sys.exit(1)
+
+
+# Names used unqualified further down. They are taken from the binding that pyqtgraph already
+# selected, so this process never ends up with two Qt bindings loaded at once.
+Qt = QtCore.Qt
+QObject = QtCore.QObject
+QThread = QtCore.QThread
+pyqtSignal = QtCore.Signal
+QFont = QtGui.QFont
+QComboBox = QtWidgets.QComboBox
+QDialog = QtWidgets.QDialog
+QFileDialog = QtWidgets.QFileDialog
+QGridLayout = QtWidgets.QGridLayout
+QGroupBox = QtWidgets.QGroupBox
+QHBoxLayout = QtWidgets.QHBoxLayout
+QLabel = QtWidgets.QLabel
+QLineEdit = QtWidgets.QLineEdit
+QProgressBar = QtWidgets.QProgressBar
+QPushButton = QtWidgets.QPushButton
+QVBoxLayout = QtWidgets.QVBoxLayout
+
+# Qt6 moved QAction from QtWidgets to QtGui, and PyQt5 only has it in QtWidgets.
+QAction = getattr(QtGui, 'QAction', None) or QtWidgets.QAction
 
 
 from RMS.Astrometry.ApplyAstrometry import xyToRaDecPP, raDecToXYPP, \
@@ -195,14 +218,6 @@ from RMS.Astrometry.Conversions import datetime2JD
 try:
     import html, re
 
-    from PyQt5.QtWidgets import (
-        QDialog, QLabel, QVBoxLayout, QHBoxLayout, QPushButton, QLineEdit, QGroupBox, QComboBox, QFileDialog,
-        QProgressBar, QGridLayout
-    )
-    from PyQt5.QtCore import Qt, QThread, pyqtSignal, QObject
-    from PyQt5 import QtCore
-    from PyQt5.QtGui import QFont
-
     from Utils.Astra import ASTRA, PYSWARMS_AVAILABLE
 
     if not PYSWARMS_AVAILABLE:
@@ -249,19 +264,19 @@ if ASTRA_IMPORTED:
             super().__init__(parent)
 
             # Allow ASTRA to be minimized
-            self.setWindowFlag(QtCore.Qt.Window, True)
-            self.setWindowFlag(QtCore.Qt.WindowSystemMenuHint, True)
-            self.setWindowFlag(QtCore.Qt.WindowMinimizeButtonHint, True)
-            self.setWindowFlag(QtCore.Qt.WindowMaximizeButtonHint, True)
-            self.setWindowFlag(QtCore.Qt.WindowCloseButtonHint, True)
+            self.setWindowFlag(QtCore.Qt.WindowType.Window, True)
+            self.setWindowFlag(QtCore.Qt.WindowType.WindowSystemMenuHint, True)
+            self.setWindowFlag(QtCore.Qt.WindowType.WindowMinimizeButtonHint, True)
+            self.setWindowFlag(QtCore.Qt.WindowType.WindowMaximizeButtonHint, True)
+            self.setWindowFlag(QtCore.Qt.WindowType.WindowCloseButtonHint, True)
             self.setWindowFlags(
-                QtCore.Qt.Window
-                | QtCore.Qt.WindowSystemMenuHint
-                | QtCore.Qt.WindowMinimizeButtonHint
-                | QtCore.Qt.WindowMaximizeButtonHint
-                | QtCore.Qt.WindowCloseButtonHint
+                QtCore.Qt.WindowType.Window
+                | QtCore.Qt.WindowType.WindowSystemMenuHint
+                | QtCore.Qt.WindowType.WindowMinimizeButtonHint
+                | QtCore.Qt.WindowType.WindowMaximizeButtonHint
+                | QtCore.Qt.WindowType.WindowCloseButtonHint
             )
-            self.setWindowModality(QtCore.Qt.NonModal)
+            self.setWindowModality(QtCore.Qt.WindowModality.NonModal)
 
             # Make ASTRAGUI close gracefully
             self.on_close_callback = on_close_callback
@@ -287,14 +302,14 @@ if ASTRA_IMPORTED:
                 "<b>ASTRA: Astrometric Streak Tracking and Refinement Algorithm</b> <br> ASTRA is an algoritm for automating manual EMCCD picking/photometry, and can also be used to refine manual picks/photometry."
             )
             intro_label.setWordWrap(True)
-            intro_label.setAlignment(Qt.AlignCenter)
+            intro_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             pick_layout.addWidget(intro_label)
 
             info_label = QLabel(
                 "<b>ASTRA requires (at least) 3 frame-adjacent leading-edge picks at a good-SNR section AND 2 leading edge picks at the frames marking the start/end of the event. These can be loaded through ECSV/txt files, or done manually.</b> <br> Hover over parameters and READY/NOT READY icons for info."
             )
             info_label.setWordWrap(True)
-            info_label.setAlignment(Qt.AlignCenter)
+            info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             pick_layout.addWidget(info_label)
 
             # Create two rows: first for file picker, second for revert button
@@ -762,7 +777,7 @@ if ASTRA_IMPORTED:
                 color = "#4CAF50" if ready else "#F44336"  # Green or Red
                 enable_btn = bool(ready)
             self.astra_status_dot.setText(status_text)
-            self.astra_status_dot.setAlignment(Qt.AlignCenter)
+            self.astra_status_dot.setAlignment(Qt.AlignmentFlag.AlignCenter)
             self.astra_status_dot.setStyleSheet(
                 f"background-color: {color}; color: white; border-radius: 6px; min-width: 80px; min-height: 20px;"
                 "max-height: 40px; font-weight: bold;"
@@ -790,7 +805,7 @@ if ASTRA_IMPORTED:
                 color = "#4CAF50" if ready else "#F44336"  # Green or Red
                 enable_btn = bool(ready)
             self.kalman_status_dot.setText(status_text)
-            self.kalman_status_dot.setAlignment(Qt.AlignCenter)
+            self.kalman_status_dot.setAlignment(Qt.AlignmentFlag.AlignCenter)
             self.kalman_status_dot.setStyleSheet(
                 f"background-color: {color}; color: white; border-radius: 6px; min-width: 80px; min-height: 20px;" 
                 "max-height: 40px; font-weight: bold;"
@@ -882,7 +897,7 @@ if ASTRA_IMPORTED:
 
             self.worker.results_ready.connect(
                 self.skyfit_instance.integrateASTRAResults, 
-                QtCore.Qt.QueuedConnection
+                QtCore.Qt.ConnectionType.QueuedConnection
             )
 
             # Clean up and re-enable UI
@@ -1040,7 +1055,7 @@ if ASTRA_IMPORTED:
             self.kalman_worker.progress.connect(self.updateProgress)
             self.kalman_worker.results_ready.connect(
                 self.skyfit_instance.applyKalmanResults,
-                QtCore.Qt.QueuedConnection
+                QtCore.Qt.ConnectionType.QueuedConnection
             )
 
             # Restore interactivity
@@ -1427,7 +1442,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
         name_label = QtWidgets.QLabel(ftype)
         name_label.setStyleSheet("font-weight: bold;")
         status_label = QtWidgets.QLabel("")
-        status_label.setAlignment(QtCore.Qt.AlignRight)
+        status_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         top.addWidget(name_label)
         top.addStretch()
         top.addWidget(status_label)
@@ -1842,7 +1857,7 @@ class CalibrationFilesDialog(QtWidgets.QDialog):
 
         layout.addWidget(btn_box)
 
-        if dlg.exec_() == QtWidgets.QDialog.DialogCode.Accepted:
+        if dlg.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             paths = [cb.property("path") for cb in checkboxes if cb.isChecked()]
             if paths:
                 self._saveFile(ftype, paths)
@@ -1974,7 +1989,7 @@ class QFOVinputDialog(QtWidgets.QDialog):
         layout.addWidget(QtWidgets.QLabel("Please enter FOV centre (degrees),\nAzimuth +E of due N\nRotation from vertical"))
 
         formlayout = QtWidgets.QFormLayout()
-        formlayout.setLabelAlignment(QtCore.Qt.AlignLeft)
+        formlayout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
 
         formlayout.addRow("Azimuth", self.azim_edit)
         formlayout.addRow("Altitude", self.alt_edit)
@@ -2632,55 +2647,55 @@ class PlateTool(QtWidgets.QMainWindow):
 
         menu = self.menuBar()
 
-        self.new_platepar_action = QtWidgets.QAction("New platepar")
+        self.new_platepar_action = QAction("New platepar")
         self.new_platepar_action.setShortcut("Ctrl+N")  # key bindings here do not get passed to keypress
         self.new_platepar_action.triggered.connect(self.makeNewPlatepar)
 
-        self.save_reduction_action = QtWidgets.QAction('Save state and reduction')
+        self.save_reduction_action = QAction('Save state and reduction')
         self.save_reduction_action.setShortcut('Ctrl+S')
         self.save_reduction_action.triggered.connect(lambda: [self.saveState(),
                                                               self.saveFTPdetectinfo(ECSV_saved=self.saveECSV())])
 
-        self.save_current_frame_action = QtWidgets.QAction('Save current frame')
+        self.save_current_frame_action = QAction('Save current frame')
         self.save_current_frame_action.setShortcut('Ctrl+W')
         self.save_current_frame_action.triggered.connect(self.saveCurrentFrame)
 
-        self.calibration_files_action = QtWidgets.QAction("File Manager...")
+        self.calibration_files_action = QAction("File Manager...")
         self.calibration_files_action.triggered.connect(self.showCalibrationFilesDialog)
 
-        self.quick_save_platepar_action = QtWidgets.QAction("Save platepar to data folder")
+        self.quick_save_platepar_action = QAction("Save platepar to data folder")
         self.quick_save_platepar_action.setShortcut('Ctrl+Shift+S')
         self.quick_save_platepar_action.triggered.connect(self.savePlatepar)
 
-        self.save_state_platepar_action = QtWidgets.QAction("Save state and platepar")
+        self.save_state_platepar_action = QAction("Save state and platepar")
         self.save_state_platepar_action.triggered.connect(lambda: [self.saveState(), self.savePlatepar()])
         self.save_state_platepar_action.setShortcut('Ctrl+S')
 
-        self.load_state_action = QtWidgets.QAction("Load state")
+        self.load_state_action = QAction("Load state")
         self.load_state_action.triggered.connect(self.findLoadState)
 
-        self.save_pairs_action = QtWidgets.QAction("Save matched pairs")
+        self.save_pairs_action = QAction("Save matched pairs")
         self.save_pairs_action.triggered.connect(self.savePairs)
 
-        self.load_pairs_action = QtWidgets.QAction("Load matched pairs")
+        self.load_pairs_action = QAction("Load matched pairs")
         self.load_pairs_action.triggered.connect(self.loadPairs)
 
-        self.toggle_info_action = QtWidgets.QAction("Toggle Info")
+        self.toggle_info_action = QAction("Toggle Info")
         self.toggle_info_action.triggered.connect(self.toggleInfo)
         self.toggle_info_action.setShortcut('F1')
 
-        self.toggle_zoom_window = QtWidgets.QAction("Toggle zoom window")
+        self.toggle_zoom_window = QAction("Toggle zoom window")
         self.toggle_zoom_window.triggered.connect(self.toggleZoomWindow)
         self.toggle_zoom_window.setShortcut('shift+Z')
 
         # Open the in-app Help tab
-        self.open_help_action = QtWidgets.QAction("SkyFit2 Guide")
+        self.open_help_action = QAction("SkyFit2 Guide")
         self.open_help_action.triggered.connect(self.openHelp)
         self.open_help_action.setShortcut('Shift+F1')
 
         # Jump straight to the keyboard reference. F1 is where users look for the shortcut list,
         # but it toggles the info panel, so give the cheat sheet its own key and menu entry.
-        self.keyboard_shortcuts_action = QtWidgets.QAction("Keyboard Shortcuts")
+        self.keyboard_shortcuts_action = QAction("Keyboard Shortcuts")
         self.keyboard_shortcuts_action.triggered.connect(self.openKeyboardReference)
 
         # CTRL + ? as an alias: on layouts where / is a shifted key (German, French, ...) the
@@ -2729,7 +2744,7 @@ class PlateTool(QtWidgets.QMainWindow):
         self.image_navigation_label.setMinimumWidth(80)
         self.status_bar.addPermanentWidget(self.image_navigation_label)
 
-        self.image_navigation_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.image_navigation_slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
         self.image_navigation_slider.setMinimum(1)
         self.image_navigation_slider.setMaximum(1)
         self.image_navigation_slider.setValue(1)
@@ -3109,7 +3124,7 @@ class PlateTool(QtWidgets.QMainWindow):
         self.star_pick_info_text_str += "P - Photometry fit plot"
         self.star_pick_info = TextItem(self.star_pick_info_text_str, anchor=(0.0, 0.75), color=(0, 0, 0), fill=(255, 255, 255, 100))
         self.star_pick_info.setFont(QtGui.QFont('monospace', 8))
-        self.star_pick_info.setAlign(QtCore.Qt.AlignLeft)
+        self.star_pick_info.setAlign(QtCore.Qt.AlignmentFlag.AlignLeft)
         self.star_pick_info.hide()
         self.star_pick_info.setZValue(10)
         self.star_pick_info.setParentItem(self.img_frame)
@@ -3139,26 +3154,26 @@ class PlateTool(QtWidgets.QMainWindow):
 
         # Celestial grid
         self.grid_visible = 1
-        self.celestial_grid = pg.PlotCurveItem(pen=pg.mkPen((255, 255, 255, 150), style=QtCore.Qt.DotLine))
+        self.celestial_grid = pg.PlotCurveItem(pen=pg.mkPen((255, 255, 255, 150), style=QtCore.Qt.PenStyle.DotLine))
         self.celestial_grid.setZValue(1)
         self.img_frame.addItem(self.celestial_grid)
 
 
         # Great circle fit
-        self.great_circle_line = pg.PlotCurveItem(pen=pg.mkPen((138, 43, 226, 255), style=QtCore.Qt.DotLine))
+        self.great_circle_line = pg.PlotCurveItem(pen=pg.mkPen((138, 43, 226, 255), style=QtCore.Qt.PenStyle.DotLine))
         self.great_circle_line.setZValue(1)
         self.img_frame.addItem(self.great_circle_line)
 
 
         # Fit residuals (image, orange)
         self.residual_lines_img = pg.PlotCurveItem(connect='pairs', pen=pg.mkPen((255, 128, 0),
-                                                                             style=QtCore.Qt.DashLine))
+                                                                             style=QtCore.Qt.PenStyle.DashLine))
         self.img_frame.addItem(self.residual_lines_img)
         self.residual_lines_img.setZValue(2)
         
         # Fit residuals (astrometric, yellow)
         self.residual_lines_astro = pg.PlotCurveItem(connect='pairs', pen=pg.mkPen((255, 255, 0),
-                                                                             style=QtCore.Qt.DashLine))
+                                                                             style=QtCore.Qt.PenStyle.DashLine))
         self.img_frame.addItem(self.residual_lines_astro)
         self.residual_lines_astro.setZValue(2)
 
@@ -3288,7 +3303,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
         # Current polygon being drawn (yellow dashed line)
         self.mask_current_line = pg.PlotCurveItem(
-            pen=pg.mkPen((255, 255, 0), width=2, style=QtCore.Qt.DashLine))
+            pen=pg.mkPen((255, 255, 0), width=2, style=QtCore.Qt.PenStyle.DashLine))
         self.mask_current_line.setZValue(15)
         self.img_frame.addItem(self.mask_current_line)
 
@@ -4453,7 +4468,7 @@ class PlateTool(QtWidgets.QMainWindow):
                             # Anchor (1.0, 0.5) places text right edge at anchor point
                             # Small offset clears the marker without drifting too much on zoom
                             text_item = TextItem(html=html_text, anchor=(1.0, 0.5))
-                            text_item.setAlign(QtCore.Qt.AlignRight)
+                            text_item.setAlign(QtCore.Qt.AlignmentFlag.AlignRight)
                             text_item.setPos(self.catalog_x_filtered[i] - 3,
                                              self.catalog_y_filtered[i] + 0.5)
                             # Cache for reuse
@@ -7492,7 +7507,7 @@ class PlateTool(QtWidgets.QMainWindow):
                     text_resid.setPos(star_x, star_y)
                     text_resid.setFont(QtGui.QFont('Arial', photom_resid_size))
                     text_resid.setColor(QtGui.QColor(255, 255, 255))
-                    text_resid.setAlign(QtCore.Qt.AlignCenter)
+                    text_resid.setAlign(QtCore.Qt.AlignmentFlag.AlignCenter)
                     self.residual_text.addTextItem(text_resid)
 
                     # Add the star magnitude above the star
@@ -7500,7 +7515,7 @@ class PlateTool(QtWidgets.QMainWindow):
                     text_mag.setPos(star_x, star_y)
                     text_mag.setFont(QtGui.QFont('Arial', 10))
                     text_mag.setColor(QtGui.QColor(0, 255, 0))
-                    text_mag.setAlign(QtCore.Qt.AlignCenter)
+                    text_mag.setAlign(QtCore.Qt.AlignmentFlag.AlignCenter)
                     self.residual_text.addTextItem(text_mag)
 
                     # Add SNR to the right of the star
@@ -7508,7 +7523,7 @@ class PlateTool(QtWidgets.QMainWindow):
                     text_snr.setPos(star_x, star_y)
                     text_snr.setFont(QtGui.QFont('Arial', 8))
                     text_snr.setColor(snr_color)
-                    text_snr.setAlign(QtCore.Qt.AlignCenter)
+                    text_snr.setAlign(QtCore.Qt.AlignmentFlag.AlignCenter)
                     self.residual_text.addTextItem(text_snr)
 
 
@@ -9658,7 +9673,7 @@ class PlateTool(QtWidgets.QMainWindow):
         """Event filter to catch mouse release and global keyboard shortcuts."""
 
         # Handle mouse release on view_widget viewport (ViewBox doesn't receive it during panning)
-        if event.type() == QtCore.QEvent.MouseButtonRelease:
+        if event.type() == QtCore.QEvent.Type.MouseButtonRelease:
             # Only handle if obj is the view_widget viewport
             if obj == self.view_widget.viewport():
                 # Convert widget coords to scene coords
@@ -9667,35 +9682,35 @@ class PlateTool(QtWidgets.QMainWindow):
             return False  # Don't consume the event
 
         # Handle global keyboard shortcuts
-        if event.type() == QtCore.QEvent.KeyPress:
+        if event.type() == QtCore.QEvent.Type.KeyPress:
             modifiers = event.modifiers()
             key = event.key()
 
             # While typing in a text input (e.g. the Help search box), let the widget keep the
             # keystrokes. Escape still falls through so it can return focus to the image.
-            if key != QtCore.Qt.Key_Escape and self._isTextInputFocused():
+            if key != QtCore.Qt.Key.Key_Escape and self._isTextInputFocused():
                 return False
 
             # Check if this is a shortcut we want to handle globally
             should_intercept = False
 
             # Intercept Ctrl+key combinations (but not when in a text input that needs Ctrl+C/V/X/A)
-            if modifiers & QtCore.Qt.ControlModifier:
+            if modifiers & QtCore.Qt.KeyboardModifier.ControlModifier:
                 # Don't intercept standard text editing shortcuts in text widgets
                 if isinstance(obj, (QtWidgets.QLineEdit, QtWidgets.QTextEdit, QtWidgets.QPlainTextEdit)):
-                    if key in (QtCore.Qt.Key_C, QtCore.Qt.Key_V, QtCore.Qt.Key_X, QtCore.Qt.Key_A):
+                    if key in (QtCore.Qt.Key.Key_C, QtCore.Qt.Key.Key_V, QtCore.Qt.Key.Key_X, QtCore.Qt.Key.Key_A):
                         return False  # Let text widget handle copy/paste/cut/select-all
                 should_intercept = True
 
             # Intercept arrow keys (for image navigation and scale adjustment)
-            elif key in (QtCore.Qt.Key_Left, QtCore.Qt.Key_Right, QtCore.Qt.Key_Up, QtCore.Qt.Key_Down):
+            elif key in (QtCore.Qt.Key.Key_Left, QtCore.Qt.Key.Key_Right, QtCore.Qt.Key.Key_Up, QtCore.Qt.Key.Key_Down):
                 # Don't intercept if focus is on a spinbox (arrows change values)
                 if not isinstance(obj, (QtWidgets.QSpinBox, QtWidgets.QDoubleSpinBox,
                                        QtWidgets.QAbstractSpinBox)):
                     should_intercept = True
 
             # Intercept Escape key to return focus to image
-            elif key == QtCore.Qt.Key_Escape:
+            elif key == QtCore.Qt.Key.Key_Escape:
                 self.img_frame.setFocus()
                 if self.star_pick_mode:
                     # Let the event propagate to keyPressEvent for star pick handling
@@ -9704,9 +9719,9 @@ class PlateTool(QtWidgets.QMainWindow):
 
             # Intercept single-letter shortcuts that should work globally
             # (but not when typing in text inputs or spinboxes)
-            elif key in (QtCore.Qt.Key_M, QtCore.Qt.Key_R, QtCore.Qt.Key_F, QtCore.Qt.Key_H,
-                         QtCore.Qt.Key_I, QtCore.Qt.Key_P, QtCore.Qt.Key_C, QtCore.Qt.Key_D,
-                         QtCore.Qt.Key_B, QtCore.Qt.Key_V):
+            elif key in (QtCore.Qt.Key.Key_M, QtCore.Qt.Key.Key_R, QtCore.Qt.Key.Key_F, QtCore.Qt.Key.Key_H,
+                         QtCore.Qt.Key.Key_I, QtCore.Qt.Key.Key_P, QtCore.Qt.Key.Key_C, QtCore.Qt.Key.Key_D,
+                         QtCore.Qt.Key.Key_B, QtCore.Qt.Key.Key_V):
                 # Don't intercept if focus is on a text/spin widget
                 # Check the widget and its parent (spinbox line edits have spinbox as parent)
                 widget = obj
@@ -9787,12 +9802,12 @@ class PlateTool(QtWidgets.QMainWindow):
         if self.mode == 'skyfit':
 
             # Add star
-            if button == QtCore.Qt.LeftButton:
+            if button == QtCore.Qt.MouseButton.LeftButton:
 
                 if self.cursor.mode == 0:
 
                     # If CTRL is pressed, place the pick manually - NOTE: the intensity might be off then!!!
-                    if modifiers & QtCore.Qt.ControlModifier:
+                    if modifiers & QtCore.Qt.KeyboardModifier.ControlModifier:
                         self.x_centroid = self.mouse_x - 0.5
                         self.y_centroid = self.mouse_y - 0.5
 
@@ -9910,7 +9925,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Remove star pair on right click
-            elif button == QtCore.Qt.RightButton:
+            elif button == QtCore.Qt.MouseButton.RightButton:
                 if self.cursor.mode == 0:
 
                     # Remove the closest picked star from the list
@@ -9927,13 +9942,13 @@ class PlateTool(QtWidgets.QMainWindow):
 
         # Add centroid in manual reduction
         else:
-            if button == QtCore.Qt.LeftButton:
+            if button == QtCore.Qt.MouseButton.LeftButton:
 
                 if self.cursor.mode == 0:
                     mode = 1
 
-                    if modifiers & QtCore.Qt.ControlModifier or \
-                            ((modifiers & QtCore.Qt.AltModifier or QtCore.Qt.Key_0 in self.keys_pressed) and
+                    if modifiers & QtCore.Qt.KeyboardModifier.ControlModifier or \
+                            ((modifiers & QtCore.Qt.KeyboardModifier.AltModifier or QtCore.Qt.Key.Key_0 in self.keys_pressed) and
                              self.img.img_handle.input_type == 'dfn'):
 
                         self.x_centroid, self.y_centroid = self.mouse_x - 0.5, self.mouse_y - 0.5
@@ -9949,7 +9964,7 @@ class PlateTool(QtWidgets.QMainWindow):
                             print("Skipping detection: non-positive intensity ({:.1f})".format(source_intens))
                             return
 
-                    if (modifiers & QtCore.Qt.AltModifier or QtCore.Qt.Key_0 in self.keys_pressed) and \
+                    if (modifiers & QtCore.Qt.KeyboardModifier.AltModifier or QtCore.Qt.Key.Key_0 in self.keys_pressed) and \
                             self.img.img_handle.input_type == 'dfn':
                         mode = 0
 
@@ -9971,7 +9986,7 @@ class PlateTool(QtWidgets.QMainWindow):
                                           add_photometry=True)
                     self.drawPhotometryColoring()
 
-            elif button == QtCore.Qt.RightButton:
+            elif button == QtCore.Qt.MouseButton.RightButton:
                 if self.cursor.mode == 0:
                     self.removeCentroid(self.img.getFrame())
                     self.updatePicks()
@@ -10064,11 +10079,11 @@ class PlateTool(QtWidgets.QMainWindow):
 
     def onMousePressed(self, event):
 
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             self.clicked = 1
-        elif event.button() == QtCore.Qt.MiddleButton:
+        elif event.button() == QtCore.Qt.MouseButton.MiddleButton:
             self.clicked = 2
-        elif event.button() == QtCore.Qt.RightButton:
+        elif event.button() == QtCore.Qt.MouseButton.RightButton:
             self.clicked = 3
 
         modifiers = QtWidgets.QApplication.keyboardModifiers()
@@ -10087,8 +10102,8 @@ class PlateTool(QtWidgets.QMainWindow):
             mp = self.img_frame.mapSceneToView(pos)
             click_x, click_y = mp.x() - 0.5, mp.y() - 0.5
 
-            if event.button() in (QtCore.Qt.LeftButton, QtCore.Qt.RightButton):
-                self.mask_brush_erasing = (event.button() == QtCore.Qt.RightButton)
+            if event.button() in (QtCore.Qt.MouseButton.LeftButton, QtCore.Qt.MouseButton.RightButton):
+                self.mask_brush_erasing = (event.button() == QtCore.Qt.MouseButton.RightButton)
                 self.mask_brush_painting = True
                 self.mask_brush_last_pos = None
                 self.brushStrokeBegin()
@@ -10104,11 +10119,11 @@ class PlateTool(QtWidgets.QMainWindow):
 
             vertex_hit = self.findNearestMaskVertex(click_x, click_y, threshold=15)
 
-            if event.button() == QtCore.Qt.LeftButton:
+            if event.button() == QtCore.Qt.MouseButton.LeftButton:
                 if vertex_hit is not None:
                     self.mask_dragging_vertex = vertex_hit
                     return
-                elif modifiers & QtCore.Qt.ControlModifier:
+                elif modifiers & QtCore.Qt.KeyboardModifier.ControlModifier:
                     edge_hit = self.findNearestMaskEdge(click_x, click_y, threshold=15)
                     if edge_hit is not None:
                         self.insertMaskVertex(edge_hit, click_x, click_y)
@@ -10116,7 +10131,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 elif self.mask_draw_mode:
                     self.addMaskPoint(click_x, click_y)
                     return
-            elif event.button() == QtCore.Qt.RightButton:
+            elif event.button() == QtCore.Qt.MouseButton.RightButton:
                 if vertex_hit is not None:
                     self.deleteMaskVertex(vertex_hit)
                     return
@@ -10127,7 +10142,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
         # Don't run shortcuts while typing in a text input (e.g. the Help search box). Escape is
         # still allowed through (it returns focus to the image).
-        if event.key() != QtCore.Qt.Key_Escape and self._isTextInputFocused():
+        if event.key() != QtCore.Qt.Key.Key_Escape and self._isTextInputFocused():
             return
 
         # Read modifiers (e.g. CTRL, SHIFT)
@@ -10135,20 +10150,20 @@ class PlateTool(QtWidgets.QMainWindow):
         qmodifiers = QtWidgets.QApplication.queryKeyboardModifiers()
 
         # Strip the GroupSwitchModifier (constantly pressed on some systems for some reason, not used in SkyFit)
-        modifiers &= ~int(QtCore.Qt.GroupSwitchModifier)
-        qmodifiers &= ~int(QtCore.Qt.GroupSwitchModifier)
+        modifiers &= ~int(QtCore.Qt.KeyboardModifier.GroupSwitchModifier)
+        qmodifiers &= ~int(QtCore.Qt.KeyboardModifier.GroupSwitchModifier)
 
         self.keys_pressed.append(event.key())
 
         # Handle mask drawing - Space or Enter to close polygon
         if self.mask_draw_mode and len(self.mask_current_polygon) >= 3:
-            if event.key() in (QtCore.Qt.Key_Space, QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter):
-                if modifiers == QtCore.Qt.NoModifier:
+            if event.key() in (QtCore.Qt.Key.Key_Space, QtCore.Qt.Key.Key_Return, QtCore.Qt.Key.Key_Enter):
+                if modifiers == QtCore.Qt.KeyboardModifier.NoModifier:
                     self.closeMaskPolygon()
                     return
 
         # Handle brush undo - Ctrl+Z when on mask tab
-        if event.key() == QtCore.Qt.Key_Z and (modifiers == QtCore.Qt.ControlModifier):
+        if event.key() == QtCore.Qt.Key.Key_Z and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
             mask_tab_index = self.tab.indexOf(self.tab.mask)
             if self.tab.currentIndex() == mask_tab_index and self.mask_brush_stroke_history:
                 self.undoBrushStroke()
@@ -10159,13 +10174,13 @@ class PlateTool(QtWidgets.QMainWindow):
             return
 
         # Toggle auto levels
-        if event.key() == QtCore.Qt.Key_A and (modifiers == QtCore.Qt.ControlModifier):
+        if event.key() == QtCore.Qt.Key.Key_A and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
             self.tab.hist.toggleAutoLevels()
             # This updates image automatically
 
         # Load the dark
-        elif event.key() == QtCore.Qt.Key_D and (modifiers == QtCore.Qt.ControlModifier):
+        elif event.key() == QtCore.Qt.Key.Key_D and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
             
             dark_file, self.dark = self.loadDark(force_dialog=True)
             if dark_file:
@@ -10189,24 +10204,24 @@ class PlateTool(QtWidgets.QMainWindow):
             self.img.reloadImage()
 
         # Jump to the next star
-        elif event.key() == QtCore.Qt.Key_Space and (modifiers == QtCore.Qt.ShiftModifier):
+        elif event.key() == QtCore.Qt.Key.Key_Space and (modifiers == QtCore.Qt.KeyboardModifier.ShiftModifier):
 
             self.jumpNextStar(miss_this_one=True)
             self.updateBottomLabel()
 
 
         # Fit spectral band ratios (hidden feature)
-        elif event.key() == QtCore.Qt.Key_B and modifiers == (QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier):
+        elif event.key() == QtCore.Qt.Key.Key_B and modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier | QtCore.Qt.KeyboardModifier.ShiftModifier):
             self.fitBandRatio()
 
         # Toggle satellite tracks
-        elif event.key() == QtCore.Qt.Key_T and (modifiers == QtCore.Qt.ControlModifier):
+        elif event.key() == QtCore.Qt.Key.Key_T and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
              self.toggleSatelliteTracks()
 
 
 
         # Load the flat
-        elif event.key() == QtCore.Qt.Key_F and (modifiers == QtCore.Qt.ControlModifier):
+        elif event.key() == QtCore.Qt.Key.Key_F and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
             flat_file, self.flat_struct = self.loadFlat(force_dialog=True)
             if flat_file:
@@ -10222,7 +10237,7 @@ class PlateTool(QtWidgets.QMainWindow):
             self.img.reloadImage()
 
         # Toggle the star picking mode
-        elif event.key() == QtCore.Qt.Key_R and (modifiers == QtCore.Qt.ControlModifier):
+        elif event.key() == QtCore.Qt.Key.Key_R and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
             self.star_pick_mode = not self.star_pick_mode
             self.updateBottomLabel()
@@ -10251,44 +10266,44 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
         # Toggle grid
-        elif (event.key() == QtCore.Qt.Key_G) and (modifiers == QtCore.Qt.ControlModifier):
+        elif (event.key() == QtCore.Qt.Key.Key_G) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
             self.grid_visible = (self.grid_visible + 1)%3
             self.onGridChanged()
             self.tab.settings.updateShowGrid()
 
 
         # Previous image/frame
-        elif event.key() == QtCore.Qt.Key_Left:
+        elif event.key() == QtCore.Qt.Key.Key_Left:
 
             n = -1
 
             # Skip 10 images back if CTRL is pressed
-            if modifiers == QtCore.Qt.ControlModifier:
+            if modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
                 n = -10
 
             self.nextImg(n=n)
 
 
         # Next image/frame
-        elif event.key() == QtCore.Qt.Key_Right:
+        elif event.key() == QtCore.Qt.Key.Key_Right:
 
             n = 1
 
             # Skip 10 images forward if CTRL is pressed
-            if modifiers == QtCore.Qt.ControlModifier:
+            if modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
                 n = 10
 
             self.nextImg(n=n)
 
 
         # Switch between maxpixel and avepixel
-        elif event.key() == QtCore.Qt.Key_M:
+        elif event.key() == QtCore.Qt.Key.Key_M:
             self.toggleImageType()
             self.tab.settings.updateMaxAvePixel()
 
 
         # Change catalog limiting magnitude
-        elif event.key() == QtCore.Qt.Key_R:
+        elif event.key() == QtCore.Qt.Key.Key_R:
             self.cat_lim_mag += 0.1
             self.catalog_stars = self.loadCatalogStars(self.cat_lim_mag)
 
@@ -10296,7 +10311,7 @@ class PlateTool(QtWidgets.QMainWindow):
             self.updateStars()
             self.tab.settings.updateLimMag()
 
-        elif event.key() == QtCore.Qt.Key_F:
+        elif event.key() == QtCore.Qt.Key.Key_F:
             self.cat_lim_mag -= 0.1
             self.catalog_stars = self.loadCatalogStars(self.cat_lim_mag)
 
@@ -10306,7 +10321,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
         # Increase image gamma
-        elif event.key() == QtCore.Qt.Key_U and not modifiers == QtCore.Qt.ControlModifier:
+        elif event.key() == QtCore.Qt.Key.Key_U and not modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
 
             # Increase image gamma by a factor of 1.1x
             self.img.updateGamma(1/0.9)
@@ -10315,7 +10330,7 @@ class PlateTool(QtWidgets.QMainWindow):
             self.updateLeftLabels()
             self.tab.settings.updateImageGamma()
 
-        elif event.key() == QtCore.Qt.Key_J and not modifiers == QtCore.Qt.ControlModifier:
+        elif event.key() == QtCore.Qt.Key.Key_J and not modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
 
             # Decrease image gamma by a factor of 0.9x
             self.img.updateGamma(0.9)
@@ -10326,7 +10341,7 @@ class PlateTool(QtWidgets.QMainWindow):
             self.tab.settings.updateImageGamma()
 
         # Toggle refraction
-        elif event.key() == QtCore.Qt.Key_T:
+        elif event.key() == QtCore.Qt.Key.Key_T:
             if self.platepar is not None:
                 self.platepar.refraction = not self.platepar.refraction
 
@@ -10334,12 +10349,12 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.tab.param_manager.updatePlatepar()
 
         # Toggle showing the catalog stars
-        elif event.key() == QtCore.Qt.Key_H and not (modifiers == QtCore.Qt.ShiftModifier):
+        elif event.key() == QtCore.Qt.Key.Key_H and not (modifiers == QtCore.Qt.KeyboardModifier.ShiftModifier):
             self.toggleShowCatStars()
             self.tab.settings.updateShowCatStars()
 
         # Toggle showing astrometry.net matched stars (Shift+H)
-        elif event.key() == QtCore.Qt.Key_H and (modifiers == QtCore.Qt.ShiftModifier):
+        elif event.key() == QtCore.Qt.Key.Key_H and (modifiers == QtCore.Qt.KeyboardModifier.ShiftModifier):
             self.toggleShowAstrometryNetStars()
             if self.astrometry_solution_info is not None:
                 matched_count = len(self.astrometry_solution_info.get('matched_pairs', []))
@@ -10351,7 +10366,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 print("No astrometry.net solution available. Run 'CTRL+X' or 'CTRL+SHIFT+X' first.")
 
         # Toggle inverting colors
-        elif (event.key() == QtCore.Qt.Key_I) and not (modifiers == QtCore.Qt.ControlModifier):
+        elif (event.key() == QtCore.Qt.Key.Key_I) and not (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
             self.toggleInvertColours()
             self.tab.settings.updateInvertColours()
 
@@ -10360,7 +10375,7 @@ class PlateTool(QtWidgets.QMainWindow):
         elif self.mode == 'skyfit':
 
             # Change distortion type to poly3+radial
-            if (event.key() == QtCore.Qt.Key_1) and (modifiers == QtCore.Qt.ControlModifier):
+            if (event.key() == QtCore.Qt.Key.Key_1) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
                 self.dist_type_index = 0
                 self.changeDistortionType()
@@ -10370,7 +10385,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
 
             # Change distortion type to poly3+radial3
-            if (event.key() == QtCore.Qt.Key_2) and (modifiers == QtCore.Qt.ControlModifier):
+            if (event.key() == QtCore.Qt.Key.Key_2) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
                 self.dist_type_index = 1
                 self.changeDistortionType()
@@ -10380,7 +10395,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
 
             # Change distortion type to poly3+radial5
-            if (event.key() == QtCore.Qt.Key_3) and (modifiers == QtCore.Qt.ControlModifier):
+            if (event.key() == QtCore.Qt.Key.Key_3) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
                 self.dist_type_index = 6
                 self.changeDistortionType()
@@ -10390,7 +10405,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
 
             # Change distortion type to radial3
-            elif (event.key() == QtCore.Qt.Key_4) and (modifiers == QtCore.Qt.ControlModifier):
+            elif (event.key() == QtCore.Qt.Key.Key_4) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
                 self.dist_type_index = 7
                 self.changeDistortionType()
@@ -10400,7 +10415,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
 
             # Change distortion type to radial5
-            elif (event.key() == QtCore.Qt.Key_5) and (modifiers == QtCore.Qt.ControlModifier):
+            elif (event.key() == QtCore.Qt.Key.Key_5) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
                 self.dist_type_index = 8
                 self.changeDistortionType()
@@ -10410,7 +10425,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
 
             # Change distortion type to radial7
-            elif (event.key() == QtCore.Qt.Key_6) and (modifiers == QtCore.Qt.ControlModifier):
+            elif (event.key() == QtCore.Qt.Key.Key_6) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
                 self.dist_type_index = 9
                 self.changeDistortionType()
@@ -10420,7 +10435,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
 
             # Change distortion type to radial9
-            elif (event.key() == QtCore.Qt.Key_7) and (modifiers == QtCore.Qt.ControlModifier):
+            elif (event.key() == QtCore.Qt.Key.Key_7) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
 
                 self.dist_type_index = 10
                 self.changeDistortionType()
@@ -10430,21 +10445,21 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
 
             # Make new platepar
-            elif (event.key() == QtCore.Qt.Key_N) and (modifiers == QtCore.Qt.ControlModifier):
+            elif (event.key() == QtCore.Qt.Key.Key_N) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
                 self.makeNewPlatepar()
 
             # Show distortion
-            elif (event.key() == QtCore.Qt.Key_I) and (modifiers == QtCore.Qt.ControlModifier):
+            elif (event.key() == QtCore.Qt.Key.Key_I) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
                 self.toggleDistortion()
                 self.tab.settings.updateShowDistortion()
 
 
             # Do a fit on the selected stars while in the star picking mode
-            elif (event.key() == QtCore.Qt.Key_Z) and ((modifiers == QtCore.Qt.ControlModifier) \
-                or (modifiers == (QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier))):
+            elif (event.key() == QtCore.Qt.Key.Key_Z) and ((modifiers == QtCore.Qt.KeyboardModifier.ControlModifier) \
+                or (modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier | QtCore.Qt.KeyboardModifier.ShiftModifier))):
 
                 # If shift was pressed, reset distortion parameters to zero
-                if modifiers == (QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier):
+                if modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier | QtCore.Qt.KeyboardModifier.ShiftModifier):
                     print("Resetting the distortion coeffs and refitting...")
                     self.platepar.resetDistortionParameters()
                     self.first_platepar_fit = True
@@ -10454,28 +10469,28 @@ class PlateTool(QtWidgets.QMainWindow):
                 print('Plate fitted!')
 
             # Pan the view left on screen (roll-aware)
-            elif event.key() == QtCore.Qt.Key_A:
+            elif event.key() == QtCore.Qt.Key.Key_A:
                 self.nudgeReferenceScreen(-1, 0)
 
             # Pan the view right on screen (roll-aware)
-            elif event.key() == QtCore.Qt.Key_D:
+            elif event.key() == QtCore.Qt.Key.Key_D:
                 self.nudgeReferenceScreen(+1, 0)
 
             # Pan the view up on screen (roll-aware)
-            elif event.key() == QtCore.Qt.Key_W:
+            elif event.key() == QtCore.Qt.Key.Key_W:
                 self.nudgeReferenceScreen(0, +1)
 
             # Pan the view down on screen (roll-aware)
-            elif event.key() == QtCore.Qt.Key_S:
+            elif event.key() == QtCore.Qt.Key.Key_S:
                 self.nudgeReferenceScreen(0, -1)
 
             # Pan to unmatched star most distant from all other matched stars
 
-            elif event.key() == QtCore.Qt.Key_U and modifiers == QtCore.Qt.ControlModifier:
+            elif event.key() == QtCore.Qt.Key.Key_U and modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
 
                 self.jumpNextStar(miss_this_one=False)
 
-            elif event.key() == QtCore.Qt.Key_O and modifiers == QtCore.Qt.ControlModifier:
+            elif event.key() == QtCore.Qt.Key.Key_O and modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
 
                 self.toggleAutoPan()
                 self.tab.settings.updateAutoPan()
@@ -10484,7 +10499,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Move rotation parameter (plain Q only, not Shift+Q)
-            elif event.key() == QtCore.Qt.Key_Q and not (modifiers == QtCore.Qt.ShiftModifier):
+            elif event.key() == QtCore.Qt.Key.Key_Q and not (modifiers == QtCore.Qt.KeyboardModifier.ShiftModifier):
                 self.platepar.pos_angle_ref -= self.key_increment
                 self.platepar.rotation_from_horiz = rotationWrtHorizon(self.platepar)
 
@@ -10492,7 +10507,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
                 self.tab.param_manager.updatePlatepar()
 
-            elif event.key() == QtCore.Qt.Key_E:
+            elif event.key() == QtCore.Qt.Key.Key_E:
                 self.platepar.pos_angle_ref += self.key_increment
                 self.platepar.rotation_from_horiz = rotationWrtHorizon(self.platepar)
 
@@ -10502,14 +10517,14 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Change image scale
-            elif event.key() == QtCore.Qt.Key_Up:
+            elif event.key() == QtCore.Qt.Key.Key_Up:
                 self.platepar.F_scale *= 1.0 + self.key_increment/100.0
 
                 self.updateLeftLabels()
                 self.updateStars()
                 self.tab.param_manager.updatePlatepar()
 
-            elif event.key() == QtCore.Qt.Key_Down:
+            elif event.key() == QtCore.Qt.Key.Key_Down:
                 self.platepar.F_scale *= 1.0 - self.key_increment/100.0
 
                 self.updateLeftLabels()
@@ -10517,7 +10532,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.tab.param_manager.updatePlatepar()
 
 
-            elif event.key() == QtCore.Qt.Key_1:
+            elif event.key() == QtCore.Qt.Key.Key_1:
 
                 # Increment X offset
                 self.platepar.x_poly_rev[0] += 0.5
@@ -10529,7 +10544,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
                 self.updateDistortion()
 
-            elif event.key() == QtCore.Qt.Key_2:
+            elif event.key() == QtCore.Qt.Key.Key_2:
 
                 # Decrement X offset
                 self.platepar.x_poly_rev[0] -= 0.5
@@ -10541,7 +10556,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
                 self.updateDistortion()
 
-            elif event.key() == QtCore.Qt.Key_3:
+            elif event.key() == QtCore.Qt.Key.Key_3:
 
                 # Increment Y offset
                 self.platepar.y_poly_rev[0] += 0.5
@@ -10553,7 +10568,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
                 self.updateDistortion()
 
-            elif event.key() == QtCore.Qt.Key_4:
+            elif event.key() == QtCore.Qt.Key.Key_4:
 
                 # Decrement Y offset
                 self.platepar.y_poly_rev[0] -= 0.5
@@ -10565,7 +10580,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
                 self.updateDistortion()
 
-            elif event.key() == QtCore.Qt.Key_5:
+            elif event.key() == QtCore.Qt.Key.Key_5:
 
                 # Decrement X 1st order distortion
                 self.platepar.x_poly_rev[1] -= 0.01
@@ -10577,7 +10592,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
                 self.updateDistortion()
 
-            elif event.key() == QtCore.Qt.Key_6:
+            elif event.key() == QtCore.Qt.Key.Key_6:
 
                 # Increment X 1st order distortion
                 self.platepar.x_poly_rev[1] += 0.01
@@ -10589,7 +10604,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
                 self.updateDistortion()
 
-            elif event.key() == QtCore.Qt.Key_7:
+            elif event.key() == QtCore.Qt.Key.Key_7:
 
                 # Decrement Y 1st order distortion
                 self.platepar.y_poly_rev[2] -= 0.01
@@ -10601,7 +10616,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 self.updateStars()
                 self.updateDistortion()
 
-            elif event.key() == QtCore.Qt.Key_8:
+            elif event.key() == QtCore.Qt.Key.Key_8:
 
                 # Increment Y 1st order distortion
                 self.platepar.y_poly_rev[2] += 0.01
@@ -10615,14 +10630,14 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Change extinction scale
-            elif event.key() == QtCore.Qt.Key_9:
+            elif event.key() == QtCore.Qt.Key.Key_9:
                 
                 self.platepar.extinction_scale += 0.1
 
                 self.tab.param_manager.updatePlatepar()
                 self.onExtinctionChanged()
 
-            elif event.key() == QtCore.Qt.Key_0:
+            elif event.key() == QtCore.Qt.Key.Key_0:
 
                 self.platepar.extinction_scale -= 0.1
 
@@ -10634,7 +10649,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Key increment
-            elif event.key() == QtCore.Qt.Key_Plus:
+            elif event.key() == QtCore.Qt.Key.Key_Plus:
 
                 if self.key_increment <= 0.091:
                     self.key_increment += 0.01
@@ -10649,7 +10664,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
                 self.updateLeftLabels()
 
-            elif event.key() == QtCore.Qt.Key_Minus:
+            elif event.key() == QtCore.Qt.Key.Key_Minus:
 
                 if self.key_increment <= 0.11:
                     self.key_increment -= 0.01
@@ -10666,7 +10681,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Enter FOV centre
-            elif event.key() == QtCore.Qt.Key_V:
+            elif event.key() == QtCore.Qt.Key.Key_V:
 
                 # Load the new FOV centre
                 data = self.getFOVcentre()
@@ -10699,7 +10714,7 @@ class PlateTool(QtWidgets.QMainWindow):
             
 
             # Force distortion centre to image centre
-            elif event.key() == QtCore.Qt.Key_B:
+            elif event.key() == QtCore.Qt.Key.Key_B:
                 if self.platepar is not None:
                     # Use remapCoeffsForFlagChange to preserve distortion coefficients
                     new_value = not self.platepar.force_distortion_centre
@@ -10713,7 +10728,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Toggle equal aspect ratio for radial distortions
-            elif event.key() == QtCore.Qt.Key_G:
+            elif event.key() == QtCore.Qt.Key.Key_G:
 
                 if self.platepar is not None:
                     # Use remapCoeffsForFlagChange to preserve distortion coefficients
@@ -10728,7 +10743,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Toggle asymmetry correction for radial distortions
-            elif event.key() == QtCore.Qt.Key_Y:
+            elif event.key() == QtCore.Qt.Key.Key_Y:
 
                 if self.platepar is not None:
                     # Use remapCoeffsForFlagChange to preserve distortion coefficients
@@ -10743,19 +10758,19 @@ class PlateTool(QtWidgets.QMainWindow):
 
 
             # Get initial parameters from astrometry.net (same as Auto Fit button)
-            elif (event.key() == QtCore.Qt.Key_X) and ((modifiers == QtCore.Qt.ControlModifier) \
-                or (modifiers == (QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier))):
+            elif (event.key() == QtCore.Qt.Key.Key_X) and ((modifiers == QtCore.Qt.KeyboardModifier.ControlModifier) \
+                or (modifiers == (QtCore.Qt.KeyboardModifier.ControlModifier | QtCore.Qt.KeyboardModifier.ShiftModifier))):
 
                 # Use the same auto-fit path as the button (includes catalog balancing, quick alignment)
                 self.autoFitAstrometryNet()
 
             # Test quick align with config mag limit (Shift+Q) - simulates CheckFit/ApplyRecalibrate
-            elif (event.key() == QtCore.Qt.Key_Q) and (modifiers == QtCore.Qt.ShiftModifier):
+            elif (event.key() == QtCore.Qt.Key.Key_Q) and (modifiers == QtCore.Qt.KeyboardModifier.ShiftModifier):
                 self.testQuickAlignWithConfigMagLimit()
 
 
             # Toggle showing detected stars
-            elif event.key() == QtCore.Qt.Key_C:
+            elif event.key() == QtCore.Qt.Key.Key_C:
                 self.toggleShowCalStars()
                 self.tab.settings.updateShowCalStars()
                 # updates image automatically
@@ -10764,14 +10779,14 @@ class PlateTool(QtWidgets.QMainWindow):
             # Save the point to the matched stars list by pressing Enter or Space or to the
             # unsuitable stars
 
-            elif (event.key() == QtCore.Qt.Key_Return) or (event.key() == QtCore.Qt.Key_Enter) \
-                or (event.key() == QtCore.Qt.Key_Space):
+            elif (event.key() == QtCore.Qt.Key.Key_Return) or (event.key() == QtCore.Qt.Key.Key_Enter) \
+                or (event.key() == QtCore.Qt.Key.Key_Space):
 
                 if self.star_pick_mode:
                     
                     # Check if the star has been skipped
                     unsuitable = False
-                    if modifiers == QtCore.Qt.ControlModifier:
+                    if modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
                         
                         # If a star has been skipped, mark it as unsuitable
                         if (self.old_autopan_x is not None) and (self.old_autopan_y is not None):
@@ -10855,12 +10870,12 @@ class PlateTool(QtWidgets.QMainWindow):
                     else:
 
                         # Jump to next star if CTRL + SPACE is pressed
-                        if modifiers == QtCore.Qt.ControlModifier:
+                        if modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
                             print("Jumping to the next star")
                             self.jumpNextStar(miss_this_one=False)
 
 
-            elif event.key() == QtCore.Qt.Key_Escape:
+            elif event.key() == QtCore.Qt.Key.Key_Escape:
                 if self.star_pick_mode:
                     
                     # If the ESC is pressed when the star has been centroided, reset the centroid
@@ -10868,11 +10883,11 @@ class PlateTool(QtWidgets.QMainWindow):
                     self.updatePairedStars()
 
             # Show the photometry plot
-            elif event.key() == QtCore.Qt.Key_P and not modifiers == QtCore.Qt.ControlModifier:
+            elif event.key() == QtCore.Qt.Key.Key_P and not modifiers == QtCore.Qt.KeyboardModifier.ControlModifier:
                 self.photometry(show_plot=True)
 
             # Show astrometry residuals plot
-            elif event.key() == QtCore.Qt.Key_L:
+            elif event.key() == QtCore.Qt.Key.Key_L:
                 if self.star_pick_mode:
                     self.showAstrometryFitPlots()
 
@@ -10881,36 +10896,36 @@ class PlateTool(QtWidgets.QMainWindow):
         elif self.mode == 'manualreduction':
 
             # Set photometry mode
-            if (qmodifiers & QtCore.Qt.ShiftModifier):
+            if (qmodifiers & QtCore.Qt.KeyboardModifier.ShiftModifier):
                 self.cursor.setMode(2)
 
-            if event.key() == QtCore.Qt.Key_P:
+            if event.key() == QtCore.Qt.Key.Key_P:
                 self.showLightcurve()
 
-            elif event.key() == QtCore.Qt.Key_D or event.key() == QtCore.Qt.Key_Space:
+            elif event.key() == QtCore.Qt.Key.Key_D or event.key() == QtCore.Qt.Key.Key_Space:
                 self.nextImg(n=1)
 
-            elif event.key() == QtCore.Qt.Key_A:
+            elif event.key() == QtCore.Qt.Key.Key_A:
                 self.nextImg(n=-1)
 
-            elif event.key() == QtCore.Qt.Key_Up:
+            elif event.key() == QtCore.Qt.Key.Key_Up:
                 self.nextImg(n=25)
 
-            elif event.key() == QtCore.Qt.Key_Down:
+            elif event.key() == QtCore.Qt.Key.Key_Down:
                 self.nextImg(n=-25)
 
-            elif event.key() == QtCore.Qt.Key_Comma:
+            elif event.key() == QtCore.Qt.Key.Key_Comma:
                 if hasattr(self.img.img_handle, 'current_line'):
                     print('Current line: {}'.format(self.img.img_handle.current_line))
                     self.img.prevLine()
 
-            elif event.key() == QtCore.Qt.Key_Period:
+            elif event.key() == QtCore.Qt.Key.Key_Period:
                 if hasattr(self.img.img_handle, 'current_line'):
                     print('Current line: {}'.format(self.img.img_handle.current_line))
                     self.img.nextLine()
 
             # Launch ASTRA GUI
-            elif (event.key() == QtCore.Qt.Key_K) and (modifiers == QtCore.Qt.ControlModifier):
+            elif (event.key() == QtCore.Qt.Key.Key_K) and (modifiers == QtCore.Qt.KeyboardModifier.ControlModifier):
                 
                 if ASTRA_IMPORTED:
                     
@@ -11616,7 +11631,7 @@ class PlateTool(QtWidgets.QMainWindow):
         if self.mode == 'skyfit':
             pass
         else:
-            if qmodifiers != QtCore.Qt.ShiftModifier:
+            if qmodifiers != QtCore.Qt.KeyboardModifier.ShiftModifier:
                 self.cursor.setMode(0)
 
 
@@ -11635,7 +11650,7 @@ class PlateTool(QtWidgets.QMainWindow):
         if self.img_frame.sceneBoundingRect().contains(event.pos()):
 
             # Brush mode + Shift: scroll changes brush size; bare scroll falls through to zoom
-            if self.mask_brush_mode and (modifier & QtCore.Qt.ShiftModifier):
+            if self.mask_brush_mode and (modifier & QtCore.Qt.KeyboardModifier.ShiftModifier):
                 step = max(1, self.mask_brush_radius // 10)
                 if delta > 0:
                     self.mask_brush_radius = min(200, self.mask_brush_radius + step)
@@ -11649,7 +11664,7 @@ class PlateTool(QtWidgets.QMainWindow):
                 return
 
             # If control is pressed in star picking mode, change the size of the aperture
-            elif (modifier & QtCore.Qt.ControlModifier) and self.star_pick_mode:
+            elif (modifier & QtCore.Qt.KeyboardModifier.ControlModifier) and self.star_pick_mode:
 
                 # Increase aperture size
                 if delta < 0:
@@ -12908,7 +12923,7 @@ class PlateTool(QtWidgets.QMainWindow):
             msg_box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
 
             msg_box.setDefaultButton(auto_fit_btn)
-            msg_box.exec_()
+            msg_box.exec()
 
             clicked = msg_box.clickedButton()
 
@@ -13457,7 +13472,7 @@ class PlateTool(QtWidgets.QMainWindow):
             msgbox.setIcon(QtWidgets.QMessageBox.Icon.Warning)
             msgbox.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
             msgbox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Yes)
-            reply = msgbox.exec_()
+            reply = msgbox.exec()
         else:
             reply = QtWidgets.QMessageBox.question(self, 'Astrometry.net Solution', msg,
                 QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No, QtWidgets.QMessageBox.StandardButton.Yes)
@@ -13675,7 +13690,7 @@ class PlateTool(QtWidgets.QMainWindow):
         d.loadLensTemplates(self.config, self.dir_path, self.config.width, self.config.height)
 
         # Get inputs regardless of OK or Cancel - both use same defaults if empty
-        d.exec_()
+        d.exec()
         data = d.getInputs()
 
         self.azim_centre, self.alt_centre, rot_horizontal, lenses_template_file = data
@@ -14104,7 +14119,7 @@ class PlateTool(QtWidgets.QMainWindow):
         browse_btn = msg.addButton("Browse...", QtWidgets.QMessageBox.ButtonRole.ActionRole)
         create_btn = msg.addButton("Create new", QtWidgets.QMessageBox.ButtonRole.ActionRole)
         msg.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
-        msg.exec_()
+        msg.exec()
 
         if msg.clickedButton() == browse_btn:
             platepar_file = QtWidgets.QFileDialog.getOpenFileName(
@@ -14235,7 +14250,7 @@ class PlateTool(QtWidgets.QMainWindow):
             dlg._showSaveDialog(save_ftype)
             dlg.close()
         else:
-            dlg.exec_()
+            dlg.exec()
 
     def saveCurrentFrame(self):
         """ Saves the current frame to disk. """
@@ -17649,4 +17664,4 @@ if __name__ == '__main__':
 
 
     # Run the GUI app
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,11 @@ imreg_dft @ git+https://github.com/matejak/imreg_dft@master
 configparser==4.0.2
 imageio>=2.31
 python-dvr>=0.0.1 ; python_version >='3.6'
-pyqtgraph>=0.12,<0.13 ; python_version >='3.6'
+# The <0.13 cap was needed because 0.13 dropped the shim that re-exposed the old unscoped Qt
+# enum aliases, and its binding preference changed to Qt6-first. The GUI now uses scoped enum
+# names throughout, so newer releases work. pyqtgraph's own requires_python keeps old stations
+# on a compatible version (0.12.4 on 3.7, 0.13.3 on 3.8, 0.13.7 on 3.9, 0.14 on 3.10+).
+pyqtgraph>=0.12 ; python_version >='3.6'
 pyyaml; python_version>='3.6'
 tflite-runtime; python_version >= '3.6' and python_version < '3.12' and sys_platform != 'darwin'
 ai-edge-litert>=1.3 ; python_version >= '3.12' and platform_machine != "armv6l" and platform_machine != "armv7l"

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,11 +23,7 @@ imreg_dft @ git+https://github.com/matejak/imreg_dft@master
 configparser==4.0.2
 imageio>=2.31
 python-dvr>=0.0.1 ; python_version >='3.6'
-# The <0.13 cap was needed because 0.13 dropped the shim that re-exposed the old unscoped Qt
-# enum aliases, and its binding preference changed to Qt6-first. The GUI now uses scoped enum
-# names throughout, so newer releases work. pyqtgraph's own requires_python keeps old stations
-# on a compatible version (0.12.4 on 3.7, 0.13.3 on 3.8, 0.13.7 on 3.9, 0.14 on 3.10+).
-pyqtgraph>=0.12 ; python_version >='3.6'
+pyqtgraph>=0.12,<0.13 ; python_version >='3.6'
 pyyaml; python_version>='3.6'
 tflite-runtime; python_version >= '3.6' and python_version < '3.12' and sys_platform != 'darwin'
 ai-edge-litert>=1.3 ; python_version >= '3.12' and platform_machine != "armv6l" and platform_machine != "armv7l"


### PR DESCRIPTION
Builds on #953 (merged into this branch, so @GlassOnTin's commit and authorship are preserved) and finishes the job.

## Root cause

Not Qt 5.15, as #953's description assumed. The trigger is **pyqtgraph 0.13+**:

- `libOrder` changed to `[PyQt6, PySide6, PyQt5, PySide2]`, so PyQt6 wins even when PyQt5 is installed.
- 0.13 dropped the shim that used to re-expose the old unscoped enum aliases on Qt6 bindings.
- 0.12's shim also copied `QtWidgets` into its `QtGui` namespace; 0.13 does not.

`requirements.txt` pinned `pyqtgraph<0.13` and the installer pulls `python3-pyqt5`, so this never happens on the supported stack. Debian Trixie ships pyqtgraph 0.13.x with PyQt6 available, which is how @GlassOnTin hit it.

## Why #953 alone was not enough

`Utils/SkyFit2.py` was only part of the surface. On PyQt6 the pre-fix code dies at `CustomPyqtgraphClasses.py:152` — `type object 'QFrame' has no attribute 'HLine'` — before any dialog opens.

1. **`RMS/Routines/CustomPyqtgraphClasses.py`** takes `QtCore`/`QtGui`/`QtWidgets` from the same proxy and had 119 flat enum accesses. Several are on the startup path: `RightOptionsTab.__init__` hits `QTabWidget.East` while SkyFit2 is still building its window. The shared `qmessagebox()` helper is here too, and SkyFit2 calls it 48 times.
2. **`QtGui.QGraphicsItem`** (`:1039`) only ever resolved via the 0.12 QtGui/QtWidgets merge, so it broke on 0.13 independently of the enum question.
3. **`QtCore` in SkyFit2 came from raw PyQt5**, imported inside the `try:` that loads ASTRA. On a PyQt6-only stack that import raises, ASTRA is disabled with a "you can ignore this" notice, and the 135 later `QtCore` uses outside the guard then fail with `NameError` on the first keypress. Where both bindings are installed it is worse: pyqtgraph widgets are PyQt6 objects while `QDialog`/`QFont` are PyQt5, putting two Qt bindings in one process.
4. **`QtWidgets.QAction`** (14 sites) does not exist on Qt6, which moved `QAction` to `QtGui`, while PyQt5 only has it in `QtWidgets`.
5. **`.exec_()`** (13 sites) was removed in Qt6. `.exec()` has existed on PyQt5 all along.
6. **`RMS/Formats/FrameInterface.messagebox`** imported raw PyQt5, so it would miss a running `QApplication` and silently fall back to Tkinter or the console.

## What changed

- All 314 flat enum accesses across the three files scoped to their enum class. Each scoped name was derived from the actual type of the flat value in the binding, then checked to resolve to the identical integer value — behaviour on PyQt5 is unchanged.
- Every Qt name now comes from whichever binding pyqtgraph selected, bound at module scope outside the ASTRA guard. Only the `Utils.Astra` import and the `pyswarms` check stay inside it.
- `QAction` resolved once at import: `getattr(QtGui, 'QAction', None) or QtWidgets.QAction`.
- `.exec_()` → `.exec()`; `QtGui.QGraphicsItem` → `QtWidgets.QGraphicsItem`; `html`/`re` hoisted to module scope (`re` was used outside the ASTRA guard).
- Last commit relaxes the `pyqtgraph<0.13` cap — see the caveat below.

## Verification

Automated, on two stacks — PyQt5 5.15.2 / pyqtgraph 0.12.3 and PyQt6 6.11.0 / pyqtgraph 0.14.0:

- All **192 distinct Qt attribute chains** in the touched files resolve under both bindings. Repo-wide re-scan finds zero flat enum accesses left.
- Offscreen `QApplication` construction test: widgets build, `paint()` paths run, `QFOVinputDialog` (the dialog that crashed) builds, `QAction` resolves to `PyQt6.QtGui.QAction` on Qt6 and `PyQt5.QtWidgets.QAction` on Qt5.
- Flag semantics confirmed identical on both bindings for the 4 `modifiers == (Ctrl | Shift)` sites, `modifiers & Alt` truthiness, and OR'd `ItemFlag`/`AlignmentFlag`/`WindowType` round-trips.
- ASTRA-disabled path tested by blocking `Utils.Astra`: every Qt name stays bound, on both bindings.
- **Control:** the same tests against `prerelease` + #953 alone fail at `QFrame.HLine` on PyQt6, confirming #953 was not sufficient.

Manual, on PyQt5 by @dvida: mask-tab confirmations (both rewrapped calls, default button intact), De Bruijn dialog, zenith indicator scaling, error dialogs, ASTRA window flags, and the full menu bar.

## Caveat on the last commit

Relaxing the `pyqtgraph` cap changes what every station installs on its next update, and the full GUI has not been soak-tested on 0.13/0.14 — only the construction paths above. pyqtgraph's own `requires_python` keeps old stations on a compatible version (0.12.4 on Python 3.7, 0.13.3 on 3.8, 0.13.7 on 3.9, 0.14 on 3.10+). It is a separate commit so it can be reverted on its own if that turns out to be premature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
