### PR TITLE
Scale SkyFit2 geo point markers with the view size

### DIFF
--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -3969,6 +3969,7 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
     sigStarNamesToggled = QtCore.pyqtSignal()
     sigApparentMagCorrToggled = QtCore.pyqtSignal()
     sigLabelMagLimitChanged = QtCore.pyqtSignal(float)
+    sigGeoMarkerScaleChanged = QtCore.pyqtSignal(float)
     sigConstellationToggled = QtCore.pyqtSignal()
     sigCalStarsToggled = QtCore.pyqtSignal()
     sigDistortionToggled = QtCore.pyqtSignal()
@@ -4040,6 +4041,28 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
         label_mag_layout.addWidget(self.label_mag_spinbox)
         label_mag_layout.addStretch()
         vbox.addLayout(label_mag_layout)
+
+        # Geo point marker size multiplier (the base size is computed automatically from the size of
+        #   the image frame, this only scales it)
+        geo_marker_layout = QtWidgets.QHBoxLayout()
+        self.geo_marker_label = QtWidgets.QLabel('Geo Point Size:')
+        geo_marker_layout.addWidget(self.geo_marker_label)
+        self.geo_marker_spinbox = QtWidgets.QDoubleSpinBox()
+        self.geo_marker_spinbox.setRange(0.1, 5.0)
+        self.geo_marker_spinbox.setSingleStep(0.1)
+        self.geo_marker_spinbox.setDecimals(1)
+        self.geo_marker_spinbox.setToolTip('Scale the geo point markers relative to their '
+                                           'automatically computed size')
+        self.updateGeoMarkerScale()
+        self.geo_marker_spinbox.valueChanged.connect(self.sigGeoMarkerScaleChanged.emit)
+        geo_marker_layout.addWidget(self.geo_marker_spinbox)
+        geo_marker_layout.addStretch()
+        vbox.addLayout(geo_marker_layout)
+
+        # Only show the control if geo points are loaded
+        if self.gui.geo_points_obj is None:
+            self.geo_marker_label.hide()
+            self.geo_marker_spinbox.hide()
 
         self.show_constellations = QtWidgets.QCheckBox('Show Constellation Lines')
         self.show_constellations.released.connect(self.sigConstellationToggled.emit)
@@ -4212,6 +4235,13 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
 
     def updateShowStarNames(self):
         self.show_star_names.setChecked(self.gui.show_star_names)
+
+    def updateGeoMarkerScale(self):
+
+        # Block the signals so that syncing the widget with the GUI state doesn't trigger a redraw
+        self.geo_marker_spinbox.blockSignals(True)
+        self.geo_marker_spinbox.setValue(self.gui.geo_marker_scale)
+        self.geo_marker_spinbox.blockSignals(False)
 
     def updateShowConstellations(self):
         self.show_constellations.setChecked(self.gui.show_constellations)

--- a/RMS/Routines/SkyFitHelp.py
+++ b/RMS/Routines/SkyFitHelp.py
@@ -673,6 +673,12 @@ def _topic_settings(gui):
         ("Single Click Photometry", "Measure photometry with a single click while picking."),
     ]
 
+    if _has_geopoints(gui):
+        display_rows.append(
+            ("Geo Point Size", "Scale the geo point markers. Their base size is computed "
+             "automatically from the size of the image frame, so they look the same at any screen "
+             "resolution and display scaling."))
+
     catalog_rows = [
         ("Gamma", "Display gamma of the image (visual only &ndash; not the camera gamma)."),
         ("Lim Mag", "Catalog limiting magnitude: how faint to load catalog stars."),

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -2431,6 +2431,9 @@ class PlateTool(QtWidgets.QMainWindow):
         self.show_constellations = False
         self.selected_stars_visible = True
 
+        # User multiplier for the automatically computed geo point marker size
+        self.geo_marker_scale = 1.0
+
         # Star detection override parameters
         self.star_detection_override_enabled = False  # Use override parameters instead of CALSTARS
         self.star_detection_override_data = {}  # Store re-detected stars per FF file
@@ -3403,6 +3406,7 @@ class PlateTool(QtWidgets.QMainWindow):
         self.tab.settings.sigStarNamesToggled.connect(self.toggleShowStarNames)
         self.tab.settings.sigApparentMagCorrToggled.connect(self.toggleApparentMagCorr)
         self.tab.settings.sigLabelMagLimitChanged.connect(self.onLabelMagLimitChanged)
+        self.tab.settings.sigGeoMarkerScaleChanged.connect(self.onGeoMarkerScaleChanged)
         self.tab.settings.sigConstellationToggled.connect(self.toggleShowConstellations)
         self.tab.settings.sigCalStarsToggled.connect(self.toggleShowCalStars)
         self.tab.settings.sigSelStarsToggled.connect(self.toggleShowSelectedStars)
@@ -3842,6 +3846,9 @@ class PlateTool(QtWidgets.QMainWindow):
                                      yMin=0,
                                      yMax=self.config.height)
 
+        # The geo point markers are sized relative to the frame height, so they have to be rescaled
+        self.updateGeoMarkerSize()
+
     def mouseOverStatus(self, x, y):
         """ Format the status message which will be printed in the status bar below the plot.
 
@@ -4103,11 +4110,13 @@ class PlateTool(QtWidgets.QMainWindow):
 
             # Plot geo points
             if self.catalog_stars_visible:
-                geo_size = 20
+
+                # The marker size is scaled with the frame size so that the markers look the same
+                #   regardless of the screen resolution and the display scaling
                 self.geo_markers.setData(x=self.geo_x_filtered + 0.5, y=self.geo_y_filtered + 0.5, \
-                    size=geo_size)
+                    size=self.geoMarkerSize())
                 self.geo_markers2.setData(x=self.geo_x_filtered + 0.5, y=self.geo_y_filtered + 0.5, \
-                    size=geo_size)
+                    size=self.geoMarkerSizeZoom())
 
 
         ### Draw catalog stars on the image using the current platepar ###
@@ -7295,6 +7304,57 @@ class PlateTool(QtWidgets.QMainWindow):
         return base_dpi*scale
 
 
+    def geoMarkerSize(self):
+        """ Compute the size of the geo point markers in the main window in screen pixels.
+
+            The markers are drawn in screen pixels (pyqtgraph's pxMode is on by default), while the
+            image is fit into the image frame. The number of screen pixels per image pixel thus
+            depends on the screen resolution, the display scale factor and the window size, which
+            made a fixed marker size look right on some machines and far too large on others.
+            Scaling the size with the frame height keeps the markers at the same visual fraction of
+            the view everywhere. The size can be additionally scaled by the user in the Settings tab.
+
+        Return:
+            [float] Marker size in screen pixels.
+        """
+
+        # Frame height in screen pixels (0 before the window is shown for the first time)
+        frame_height = self.img_frame.height()
+
+        if frame_height <= 0:
+            base_size = 10.0
+
+        else:
+            # The reference look is 10 px on a 700 px tall frame, clamped so the markers stay visible
+            #   on tiny windows and don't become unwieldy on very large ones
+            base_size = min(max(frame_height/70.0, 5.0), 30.0)
+
+        # Keep the markers visible even at the smallest user scale
+        return max(base_size*self.geo_marker_scale, 3.0)
+
+
+    def geoMarkerSizeZoom(self):
+        """ Compute the size of the geo point markers in the zoom window in screen pixels.
+
+            The zoom window has a fixed size and a fixed view range, so its scale in screen pixels
+            per image pixel is always the same and needs no automatic scaling. Only the user
+            multiplier from the Settings tab is applied.
+
+        Return:
+            [float] Marker size in screen pixels.
+        """
+
+        # Keep the markers visible even at the smallest user scale
+        return max(20.0*self.geo_marker_scale, 3.0)
+
+
+    def updateGeoMarkerSize(self):
+        """ Apply the current geo point marker size without redrawing all the overlays. """
+
+        self.geo_markers.setSize(self.geoMarkerSize())
+        self.geo_markers2.setSize(self.geoMarkerSizeZoom())
+
+
     def photometry(self, show_plot=False, force_update=False):
         """
         Perform the photometry on selected stars. Updates residual text above and below picked stars
@@ -9425,6 +9485,10 @@ class PlateTool(QtWidgets.QMainWindow):
         # Update the possibly missing params
         if not hasattr(self, "geo_points_obj"):
             self.geo_points_obj = None
+
+        # Update the possibly missing params
+        if not hasattr(self, "geo_marker_scale"):
+            self.geo_marker_scale = 1.0
 
 
         # Update the possibly missing begin time
@@ -12057,6 +12121,14 @@ class PlateTool(QtWidgets.QMainWindow):
         # Redraw if labels are visible
         if self.show_star_names or self.show_spectral_type:
             self.updateStars()
+
+    def onGeoMarkerScaleChanged(self, value):
+        """ Handle change in the geo point marker size multiplier. """
+
+        self.geo_marker_scale = value
+
+        # Only the marker size changes, so there is no need for a full redraw
+        self.updateGeoMarkerSize()
 
     def toggleShowConstellations(self):
         """ Toggle showing/hiding constellation lines. """


### PR DESCRIPTION
## Problem

A user reported that the green `+` geo point markers in SkyFit2 are far too large on their PC, while they look fine on others. The size was a hardcoded constant:

```python
geo_size = 20
```

`pg.ScatterPlotItem` has `pxMode=True` by default (never overridden in RMS), so that is **20 screen pixels**, independent of the image. The image itself is fit into `img_frame`, so the number of screen pixels per image pixel depends on the frame size in logical pixels — which varies with the screen resolution, the OS/Qt display scale factor and the window size. On a machine with a smaller logical frame those 20 px span many more image pixels, so the crosses look huge and overlap each other.

## Changes

- `PlateTool.geoMarkerSize()` derives the main-window size from the height of the image frame (`frame_height/70`, clamped to 5–30 px), so the markers keep the same visual proportion on any display. This also makes them **half** their previous size (10 px instead of 20 px on a 700 px tall frame).
- `PlateTool.geoMarkerSizeZoom()` keeps the zoom-window marker at 20 px. That view has a fixed 200 px size and a fixed ±20 image px range, so its scale is always the same and needs no automatic scaling.
- New **Geo Point Size** multiplier (0.1–5.0, default 1.0) in the Settings tab, for anyone who wants them bigger or smaller. It is hidden unless geo points are loaded, like the other geo-point-only controls. The final size is floored at 3 px so a small multiplier can't make the markers disappear.
- `updateGeoMarkerSize()` re-applies the size on window resize and on a settings change without a full overlay redraw.
- `geo_marker_scale` gets a `hasattr` shim in `loadState()`, so old `.state` files still load (and a saved value is preserved rather than reset).
- Help entry for the new control in the Settings topic.

No other overlay marker is touched — every other one has the same kind of hardcoded screen-pixel size, but only the reported geo point problem is fixed here.

## Testing

- All three files compile.
- Offscreen (`QT_QPA_PLATFORM=offscreen`) checks: the size math over frame heights 200/700/1400/4000 and multipliers 0.1–2.0 hits the expected values including both clamps, the floor, and the zero-height fallback before the window is first shown; `SettingsWidget` builds with and without geo points and hides the control in the latter case; a user edit emits the signal once while a programmatic sync does not re-emit; the help page gains the row only when geo points are present.
- Not yet exercised as a live GUI against real geo points — worth a look with `-p <geopoints.csv>`, resizing the window and running with `QT_SCALE_FACTOR=1.5` to mimic the reporting machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)