### PR TITLE
Scale the geo point markers by the fitted image, not the frame height

### DIFF
--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -4053,11 +4053,14 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.geo_marker_spinbox.setDecimals(1)
         self.geo_marker_spinbox.setToolTip('Scale the geo point markers relative to their '
                                            'automatically computed size')
-        self.updateGeoMarkerScale()
         self.geo_marker_spinbox.valueChanged.connect(self.sigGeoMarkerScaleChanged.emit)
         geo_marker_layout.addWidget(self.geo_marker_spinbox)
         geo_marker_layout.addStretch()
         vbox.addLayout(geo_marker_layout)
+
+        # Sync only after the layout is in place, as setting the visibility of a widget which has no
+        #   parent yet would briefly show it as a window of its own
+        self.updateGeoMarkerScale()
 
         self.show_constellations = QtWidgets.QCheckBox('Show Constellation Lines')
         self.show_constellations.released.connect(self.sigConstellationToggled.emit)

--- a/RMS/Routines/CustomPyqtgraphClasses.py
+++ b/RMS/Routines/CustomPyqtgraphClasses.py
@@ -4059,11 +4059,6 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
         geo_marker_layout.addStretch()
         vbox.addLayout(geo_marker_layout)
 
-        # Only show the control if geo points are loaded
-        if self.gui.geo_points_obj is None:
-            self.geo_marker_label.hide()
-            self.geo_marker_spinbox.hide()
-
         self.show_constellations = QtWidgets.QCheckBox('Show Constellation Lines')
         self.show_constellations.released.connect(self.sigConstellationToggled.emit)
         self.updateShowConstellations()
@@ -4237,6 +4232,12 @@ class SettingsWidget(QtWidgets.QWidget, ScaledSizeHelper):
         self.show_star_names.setChecked(self.gui.show_star_names)
 
     def updateGeoMarkerScale(self):
+
+        # The control is only relevant when geo points are loaded, which can change when a state is
+        #   loaded into an already constructed GUI
+        show_control = self.gui.geo_points_obj is not None
+        self.geo_marker_label.setVisible(show_control)
+        self.geo_marker_spinbox.setVisible(show_control)
 
         # Block the signals so that syncing the widget with the GUI state doesn't trigger a redraw
         self.geo_marker_spinbox.blockSignals(True)

--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -3846,7 +3846,7 @@ class PlateTool(QtWidgets.QMainWindow):
                                      yMin=0,
                                      yMax=self.config.height)
 
-        # The geo point markers are sized relative to the frame height, so they have to be rescaled
+        # The geo point markers are sized relative to the displayed image, so they have to be rescaled
         self.updateGeoMarkerSize()
 
     def mouseOverStatus(self, x, y):
@@ -7311,23 +7311,30 @@ class PlateTool(QtWidgets.QMainWindow):
             image is fit into the image frame. The number of screen pixels per image pixel thus
             depends on the screen resolution, the display scale factor and the window size, which
             made a fixed marker size look right on some machines and far too large on others.
-            Scaling the size with the frame height keeps the markers at the same visual fraction of
-            the view everywhere. The size can be additionally scaled by the user in the Settings tab.
+            Scaling the size with the size of the displayed image keeps the markers at the same
+            visual fraction of the image everywhere. The size can be additionally scaled by the user
+            in the Settings tab.
 
         Return:
             [float] Marker size in screen pixels.
         """
 
-        # Frame height in screen pixels (0 before the window is shown for the first time)
+        # Frame size in screen pixels (0 before the window is shown for the first time)
+        frame_width = self.img_frame.width()
         frame_height = self.img_frame.height()
 
-        if frame_height <= 0:
+        if (frame_width <= 0) or (frame_height <= 0):
             base_size = 10.0
 
         else:
-            # The reference look is 10 px on a 700 px tall frame, clamped so the markers stay visible
+            # Height of the displayed image in screen pixels. The view is aspect locked, so the image
+            #   is constrained by whichever frame dimension runs out first - only using the frame
+            #   height would rescale the markers when the window is resized in the other direction.
+            image_height = min(frame_height, frame_width*self.config.height/self.config.width)
+
+            # The reference look is 10 px on a 650 px tall image, clamped so the markers stay visible
             #   on tiny windows and don't become unwieldy on very large ones
-            base_size = min(max(frame_height/70.0, 5.0), 30.0)
+            base_size = min(max(image_height/65.0, 5.0), 30.0)
 
         # Keep the markers visible even at the smallest user scale
         return max(base_size*self.geo_marker_scale, 3.0)
@@ -9689,6 +9696,7 @@ class PlateTool(QtWidgets.QMainWindow):
 
             self.tab.param_manager.updatePlatepar()
             self.tab.debruijn.updateTable()
+            self.tab.settings.updateGeoMarkerScale()
             self.changeMode(self.mode)
 
             self.updateLeftLabels()


### PR DESCRIPTION
Follow-up to #957, addressing two points from the automated review of that PR.

## 1. The marker size was keyed off the wrong dimension

`img_frame` is aspect locked, so the displayed image scale is `min(frame_w/X_res, frame_h/Y_res)` — the image is constrained by whichever frame dimension runs out first. Deriving the marker size from the frame height alone was only correct when the image is height constrained.

For a 16:9 camera in a typical window it is not: a 1536x864 window gives a frame of roughly 1160x780, whose `h/w` ≈ 0.67 is greater than `9/16` = 0.5625, which is exactly the `x`-limited branch `onFrameResize` already takes. So in the common case widening the window grew the image but not the markers, and making it taller grew the markers but not the image. 4:3 cameras happened to land on the height-constrained side and were fine.

The base size now comes from the height of the displayed image:

```python
image_height = min(frame_height, frame_width*self.config.height/self.config.width)
base_size = min(max(image_height/65.0, 5.0), 30.0)
```

`config.width/height` is used rather than the platepar resolution to match the aspect comparison `onFrameResize` already makes, and because it is always available. The divisor is 65 instead of 70 so the resulting size is unchanged in practice for a 16:9 camera in a typical window (10.0 px vs 11.1 px before).

## 2. The Settings control went stale after loading a state

`loadState()`'s existing-UI branch refreshes `tab.param_manager` and `tab.debruijn`, and `updateStars()` applies the loaded multiplier to the markers, but `tab.settings` was never refreshed — the spinbox kept showing its pre-load value, so the first edit after a load jumped. It now calls `self.tab.settings.updateGeoMarkerScale()` alongside the other two.

`updateGeoMarkerScale()` also took over the show/hide decision for the control (removing the one-off `hide()` in the widget constructor), since whether geo points exist can change when a state is loaded into an already constructed GUI.

The `hasattr` shim for `geo_marker_scale` was left as is. Loading an old state that lacks the field keeps the running multiplier rather than resetting it to 1.0, which matches every other shim in that block and is the friendlier behaviour.

## Testing

Offscreen (`QT_QPA_PLATFORM=offscreen`) checks:

- 16:9 camera: a 1160x780 frame gives 10.04 px; growing only the height (780 → 1400) no longer changes the size, growing only the width (1160 → 1600) grows it to 12.00 px, and both clamps plus the user-scale floor still hold.
- 4:3 camera: the same 1160x780 frame is height constrained and gives 12.00 px, and a 1160x1400 frame flips to width constrained and gives 13.38 px.
- The zero-size fallback before the window is first shown still returns 10 px.
- `SettingsWidget`: hidden when built without geo points, shown with the loaded value after `updateGeoMarkerScale()` when geo points appear, hidden again when they go away, and the programmatic sync still does not emit the change signal.

Still not exercised as a live GUI — no night data with geo points on hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)