### PR TITLE
Remove dead user_fixed_scale save/restore in SkyFit2 acquisition paths

### DIFF
--- a/Utils/SkyFit2.py
+++ b/Utils/SkyFit2.py
@@ -12708,7 +12708,6 @@ class PlateTool(QtWidgets.QMainWindow):
         user_force_distortion_centre = self.platepar.force_distortion_centre
         user_refraction = self.platepar.refraction
         user_fit_only_pointing = self.fit_only_pointing
-        user_fixed_scale = self.fixed_scale
 
         # Filter catalog stars to those in FOV (prevents back-projection issues)
         _, catalog_stars_fov = self.filterCatalogStarsInsideFOV(self.catalog_stars)
@@ -12897,7 +12896,6 @@ class PlateTool(QtWidgets.QMainWindow):
         self.platepar.remapCoeffsForFlagChange('force_distortion_centre', user_force_distortion_centre)
         self.platepar.refraction = user_refraction
         self.fit_only_pointing = user_fit_only_pointing
-        self.fixed_scale = user_fixed_scale
         # Now set distortion type which will adjust poly_length and pad coefficients
         # Use reset_params=False to preserve the fitted coefficients, just add zeros for new terms
         self.platepar.setDistortionType(user_distortion_type, reset_params=False)
@@ -13619,7 +13617,6 @@ class PlateTool(QtWidgets.QMainWindow):
         user_force_distortion_centre = self.platepar.force_distortion_centre
         user_refraction = self.platepar.refraction
         user_fit_only_pointing = self.fit_only_pointing
-        user_fixed_scale = self.fixed_scale
 
         # Set intermediate fitting parameters (simple, robust settings)
         # Use simple settings for stability with few stars during initial passes
@@ -13867,7 +13864,6 @@ class PlateTool(QtWidgets.QMainWindow):
             self.platepar.setDistortionType(user_distortion_type, reset_params=False)
             self.platepar.refraction = user_refraction
             self.fit_only_pointing = user_fit_only_pointing
-            self.fixed_scale = user_fixed_scale
 
             # Filter photometric outliers before final fit
             if len(self.paired_stars) >= 15:
@@ -13908,7 +13904,6 @@ class PlateTool(QtWidgets.QMainWindow):
             self.platepar.setDistortionType(user_distortion_type, reset_params=True)
             self.platepar.refraction = user_refraction
             self.fit_only_pointing = user_fit_only_pointing
-            self.fixed_scale = user_fixed_scale
 
             print("  Not enough matched stars for fitting (need >= 10)")
             self.updateStars()


### PR DESCRIPTION
Follow-up to @dvida's note on #951 — the NN auto-recalibration callers save/restore `user_fixed_scale` but never forward it, so the "Fixed scale" checkbox has no effect on automatic recalibration.

## What I found (all four flagged sites)
- `SkyFit2.tryQuickAlignment` and `SkyFit2.getInitialParamsAstrometryNet` save `self.fixed_scale → user_fixed_scale` and restore it, but **never modify `self.fixed_scale` in between** (they *do* legitimately force + restore `distortion_type` → `radial5-odd`, `refraction`, `equal_aspect`, etc.), and their `fitAstrometry(use_nn_cost=True)` calls don't pass it.
- `AutoPlatepar.py:600/693` fit with `first_platepar_fit=True` and have no `fixed_scale` handling at all.

**All four are `first_platepar_fit=True` — initial acquisition**, where the scale must be free to be determined. Forwarding `fixed_scale=True` there would pin the scale to a rough seed and degrade acquisition. So *not* honoring the checkbox during acquisition is correct (as you suspected), and the `user_fixed_scale` save/restore is simply dead code that misleadingly reads like unfinished wiring.

## Change
Remove the dead `user_fixed_scale` save (×2) and restore (×3). **No behavior change** — `self.fixed_scale` is never read or written in these blocks. The checkbox continues to be honored where it applies: refinement via `fitPickedStars`, which already forwards `fixed_scale=self.fixed_scale`.

## Note
`user_fit_only_pointing` in the same two methods is saved/restored but likewise never modified — the identical dead pattern. Happy to drop that too, or — if you'd actually prefer the scale *held* during acquisition when the box is checked — to instead **finish the wiring** (forward it into these NN calls). Just say which shape you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
