### PR TITLE
Bound the fireball extractor with a reusable snapshot pool (fixes mid-night OOM)

### DIFF
--- a/RMS/Compression.py
+++ b/RMS/Compression.py
@@ -45,6 +45,15 @@ from RMS.CompressionCy import compressFrames
 log = getLogger("rmslogger")
 
 
+# Maximum number of shared-memory snapshot buffers for the fireball extractor. Each holds a full
+# raw frame block (~236 MB at 720p), so this bounds the extractor's total memory. Two buffers
+# tolerate one over-cadence extraction with no loss - the case of a bright fireball whose own
+# extraction runs long, immediately followed by the block with its continuation. A backlog deeper
+# than that means extraction has fallen behind capture for a sustained stretch (in practice a
+# noise night - clouds, rain, insects), and further blocks are skipped to keep memory bounded.
+MAX_EXTRACTOR_SNAPSHOTS = 2
+
+
 class Compressor(multiprocessing.Process):
     """Compress list of numpy arrays (video frames).
 
@@ -297,7 +306,34 @@ class Compressor(multiprocessing.Process):
 
         n = 0
         exit_wait_start = None
-        
+
+        # Fireball-extractor snapshot pool. Each extractor gets a SNAPSHOT of the frame block,
+        # copied before the capture handshake is released, so it can never race the ping-pong
+        # buffer refill and never pickles the block by value under 'forkserver'/'spawn' (review
+        # finding B2). The snapshots come from a small REUSABLE pool: a buffer is only handed
+        # out again after its extractor has exited, and at most MAX_EXTRACTOR_SNAPSHOTS are ever
+        # allocated - an unbounded buffer-per-block scheme let slow extractions pile up, each
+        # pinning its own ~236 MB snapshot, and the OS OOM-killed capture mid-night.
+        snapshot_pool = []      # free (base, view) pairs, ready for reuse
+        extractors = []         # live (process, (base, view)) pairs
+        skipped_extractions = 0
+
+        def waitForExtractors(timeout=20):
+            """ Give still-running extractors a bounded chance to finish before this process
+                exits. Exiting fires the children's parent-death SIGKILL, and killing one
+                mid-FR-write loses the clip, while killing one mid-write on the shared logging
+                queue can orphan the queue's internal lock (the exact cascade PR #935 fixed).
+                A hung extractor must not block the exit, hence the shared bound.
+            """
+            deadline = time.time() + timeout
+            for ext, _ in extractors:
+                if ext.is_alive():
+                    log.info('Waiting for extractor {:s} to finish...'.format(str(ext.pid)))
+                    ext.join(max(0.1, deadline - time.time()))
+                    if ext.is_alive():
+                        log.warning('Extractor {:s} still running at compressor exit, '
+                            'it will be killed'.format(str(ext.pid)))
+
         # Repeat until the compressor is killed from the outside
         while True:
             # graceful-exit check
@@ -323,6 +359,8 @@ class Compressor(multiprocessing.Process):
                 if self.exit.is_set():
 
                     log.debug('Compression run exit')
+
+                    waitForExtractors()
 
                     self.run_exited.set()
                     os._exit(0)
@@ -383,20 +421,53 @@ class Compressor(multiprocessing.Process):
             # Run the compression
             compressed, field_intensities = self.compress(frames)
 
-            # Snapshot the raw block for the extractor BEFORE releasing the capture
-            # handshake: once start_time returns to 0 the buffer is eligible for refill,
-            # and the extractor reads it seconds later - the old code raced the refill
-            # under 'fork' and pickled the whole ~236 MB block by value under
-            # 'forkserver'/'spawn' (stalling compression and spiking RSS). A shared
-            # mp.Array snapshot costs one memcpy while the handshake is held and crosses
-            # the process boundary without pickling.
-            frames_snapshot_base = None
+            # Snapshot the raw block for the extractor BEFORE releasing the capture handshake:
+            # once start_time returns to 0 the buffer is eligible for refill, and the extractor
+            # reads it seconds later. The snapshot buffer comes from the bounded reusable pool
+            # (see its definition above); if the pool is exhausted, this block's extraction is
+            # skipped - memory must stay bounded, and a pool-deep backlog means the extractions
+            # being skipped are on a night too noisy to produce usable clips anyway.
+            snapshot = None
             if self.config.enable_fireball_detection:
-                frames_snapshot_base = multiprocessing.Array(
-                    ctypes.c_uint8, int(frames.size), lock=False)
-                snapshot_view = np.frombuffer(frames_snapshot_base,
-                    dtype=np.uint8).reshape(frames.shape)
-                np.copyto(snapshot_view, frames)
+
+                # Reap finished extractors and reclaim their snapshot buffers
+                still_running = []
+                for ext, buf in extractors:
+                    if ext.is_alive():
+                        still_running.append((ext, buf))
+                    else:
+                        ext.join()
+                        snapshot_pool.append(buf)
+                extractors = still_running
+
+                if snapshot_pool:
+                    snapshot = snapshot_pool.pop()
+
+                elif len(extractors) < MAX_EXTRACTOR_SNAPSHOTS:
+                    # Grow the pool lazily: on healthy nights only one buffer ever exists
+                    if extractors:
+                        log.info('Extraction running behind capture, allocating snapshot '
+                            'buffer {:d} of {:d}'.format(len(extractors) + 1,
+                            MAX_EXTRACTOR_SNAPSHOTS))
+                    snapshot_base = multiprocessing.Array(
+                        ctypes.c_uint8, int(frames.size), lock=False)
+                    snapshot = (snapshot_base, np.frombuffer(snapshot_base,
+                        dtype=np.uint8).reshape(frames.shape))
+
+                else:
+                    skipped_extractions += 1
+                    log.warning('All {:d} snapshot buffers in use, skipping fireball '
+                        'extraction for this block ({:d} skipped so far)'.format(
+                        MAX_EXTRACTOR_SNAPSHOTS, skipped_extractions))
+
+                if snapshot is not None:
+
+                    if skipped_extractions:
+                        log.info('Extraction caught up after {:d} skipped block(s)'.format(
+                            skipped_extractions))
+                        skipped_extractions = 0
+
+                    np.copyto(snapshot[1], frames)
 
             # Once the compression is done, tell the capture thread to keep filling the buffer
             if buffer_one:
@@ -428,11 +499,12 @@ class Compressor(multiprocessing.Process):
             # Save the extracted intensities per every field
             FieldIntensities.saveFieldIntensitiesBin(field_intensities, self.data_dir, filename_micros)
 
-            # Run the extractor (on the pre-handshake snapshot, never the live buffer)
-            if self.config.enable_fireball_detection:
+            # Run the extractor (on its pre-handshake snapshot, never the live buffer)
+            if snapshot is not None:
+
                 extractor = Extractor(self.config, self.data_dir)
-                extractor.start(frames_snapshot_base, frames.shape, compressed,
-                    filename_millis)
+                extractor.start(snapshot[0], frames.shape, compressed, filename_millis)
+                extractors.append((extractor, snapshot))
 
                 log.debug('Extractor started for: ' + filename_millis)
 
@@ -452,6 +524,8 @@ class Compressor(multiprocessing.Process):
 
 
         log.debug('Compression run exit')
+
+        waitForExtractors()
 
         time.sleep(1.0)
         self.run_exited.set()

--- a/RMS/VideoExtraction.py
+++ b/RMS/VideoExtraction.py
@@ -20,7 +20,7 @@ import math
 import time
 from multiprocessing import Process
 
-from RMS.Misc import AtomicFlag
+from RMS.Misc import AtomicFlag, setParentDeathSignal
 
 import numpy as np
 
@@ -246,25 +246,26 @@ class Extractor(Process):
         """ Start the extractor.
 
         Arguments:
-            frames_base: [multiprocessing.Array] base of the SNAPSHOT frame buffer (a
-                private copy made by the compressor before it releases the capture
-                handshake - the live buffer may be refilled at any time after that).
-                Passing the base instead of a numpy view avoids pickling the whole
-                ~256-frame block by value under the 'forkserver'/'spawn' start methods.
+            frames_base: [multiprocessing.Array] base of the SNAPSHOT frame buffer - a copy
+                of the block made by the compressor before it released the capture handshake,
+                drawn from a small reusable pool. The compressor never refills it while this
+                process is alive, so there is no race with the live buffer; passing the base
+                instead of a numpy view avoids pickling the whole ~256-frame block by value
+                under the 'forkserver'/'spawn' start methods.
             frames_shape: [tuple] Shape (256, H, W) to rebuild the numpy view.
             compressed: [ndarray] array with FTP compressed frames
             filename: [str] name of the FF file which is being processed
 
         """
-        
+
         self.exit = AtomicFlag()
-        
+
         self.frames_base = frames_base
         self.frames_shape = frames_shape
         self.frames = None      # numpy view rebuilt in run() (per-process)
         self.compressed = compressed
         self.filename = filename
-        
+
         super(Extractor, self).start()
     
 
@@ -272,6 +273,14 @@ class Extractor(Process):
     def run(self):
         """ Retrieve frames from list, convert, compress and save them.
         """
+
+        # Die if our parent Compressor dies (e.g. watchdog force-kill), so a hung
+        # extraction cannot be orphaned pinning its ~236 MB snapshot forever. The
+        # compressor's exit paths join live extractors (bounded) first, so a healthy
+        # extractor finishes its FR write before this can fire. Note that under forkserver
+        # this fires on the wrong parent's death (see RawFrameSaver.run), but the
+        # extractor is short-lived so this is only a safety net.
+        setParentDeathSignal()
 
         # Re-establish logging and signal handling in the child (no-op under 'fork')
         initChildProcess(self.logging_queue, self.config)


### PR DESCRIPTION
## Problem

The extractor snapshot introduced in the #935/#938 review round (finding B2) allocates a fresh ~236 MB `multiprocessing.Array` for every FF block and hands it to a fire-and-forget Extractor process. Extractors have no concurrency bound, so whenever extraction runs longer than the ~10 s block cadence (noisy sky, long `find3DLines`), extractors pile up, each pinning its own private snapshot. Memory grows without bound and the OS OOM-kills capture mid-night. Observed in production within days of deploying the squashed PRs; any station on `prerelease` with `enable_fireball_detection` is exposed.

Reverting B2 outright would restore the old unbounded-correctness trade-off instead: extractors reading the live ping-pong buffers race the refill whenever they outlive the ~10 s grace, silently corrupting FR clips - and the OOM frequency suggests that overrun condition is common, so the old race was likely firing regularly and going unnoticed.

## Fix

Replace the per-block allocation with a small reusable snapshot pool that keeps B2's correctness properties and master's boundedness:

- At most `MAX_EXTRACTOR_SNAPSHOTS = 2` buffers are ever allocated, lazily - on a healthy night one buffer exists and is reused for every block. Hard memory ceiling: 2 x ~236 MB per station.
- The block is still copied before the capture handshake is released, and the extractor still receives the base + shape - no refill race, no by-value pickle under `forkserver`/`spawn`.
- A buffer returns to the pool only after its extractor has exited, so reuse can never race a live reader.
- Two buffers absorb one over-cadence extraction with no loss (a bright fireball whose own extraction runs long, followed by its continuation block). Only a 3-deep backlog skips a block, with log visibility: an info line when the second buffer is allocated, a warning per skip with a running count, and an info line on catch-up. Previously both failure modes (the race on master, the pile-up after B2) were silent.
- The compressor's exit paths now join live extractors (bounded, 20 s) so a dawn shutdown does not kill an extractor mid-FR-write, and `Extractor.run()` sets the parent-death signal (same pattern as `RawFrameSaver`) so a hung extraction cannot be orphaned pinning its snapshot forever.

## Testing

- `Tests/test_DeadlockFixes.py` passes (16/16).
- A simulation of the pool state machine (mirroring the loop logic) asserts, across healthy-night / single-slow-fireball / sustained-overrun scenarios: the single buffer is reused, the cap is never exceeded, no buffer is ever owned twice, skips occur only at pool exhaustion, and extraction resumes when a buffer frees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
