### PR TITLE
Add trackstack meteor mask

### DIFF
--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -15,7 +15,7 @@ import RMS.ConfigReader as cr
 from RMS.Astrometry.ApplyAstrometry import xyToRaDecPP, raDecToXYPP
 from RMS.Astrometry.Conversions import date2JD, jd2Date
 from RMS.Formats.FFfile import validFFName, getMiddleTimeFF
-from RMS.Formats.FTPdetectinfo import readFTPdetectinfo
+from RMS.Formats.FTPdetectinfo import readFTPdetectinfo, validDefaultFTPdetectinfo
 from RMS.Formats.FFfile import read as readFF
 from RMS.Formats.Platepar import Platepar
 from RMS.Math import angularSeparation
@@ -28,7 +28,7 @@ from RMS.QueuedPool import QueuedPool
 import time
 import datetime
 
-def find_ftp_file(dir_path, config):
+def findFTPFile(dir_path, config):
     if os.path.isfile(os.path.join(dir_path,'.config')):
         tmpcfg = cr.loadConfigFromDirectory('.config', dir_path)
     else:
@@ -42,15 +42,16 @@ def find_ftp_file(dir_path, config):
 
     return ftp_list[0]
 
-def make_mask(ftp_points, initial_mask):
+def makeMeteorMask(ftp_points_list, initial_mask):
     """Make a mask in which only the meteor is visible"""
-    meteor_mask = np.zeros_like(initial_mask.img)
+    meteor_mask = np.zeros_like(initial_mask)
 
-    pts = np.array([[round(p[2]), round(p[3])] for p in ftp_points], dtype=np.int32)
-    meteor_mask = cv2.polylines(meteor_mask, [pts], False, 255, 1)
+    for ftp_points in ftp_points_list:
+        pts = np.array([[round(p[2]), round(p[3])] for p in ftp_points], dtype=np.int32)
+        meteor_mask = cv2.polylines(meteor_mask, [pts], False, 255, 1)
 
     meteor_mask = cv2.dilate(meteor_mask, np.ones((150, 150), np.uint8))
-    return np.minimum(meteor_mask, initial_mask.img)
+    return np.minimum(meteor_mask, initial_mask)
 
 def trackStack(dir_paths, config, border=5, background_compensation=True, 
         hide_plot=False, showers=None, darkbackground=False, out_dir=None,
@@ -115,7 +116,7 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         for dir_path in dir_paths: 
 
             try:
-                ftp_file = find_ftp_file(dir_path, config)
+                ftp_file = findFTPFile(dir_path, config)
             except FileNotFoundError as e:
                 print(e)
                 return False
@@ -144,13 +145,13 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
     if mask_meteors:
         for dir_path in dir_paths:
             try:
-                ftp_file = find_ftp_file(dir_path, config)
+                ftp_file = findFTPFile(dir_path, config)
             except FileNotFoundError as e:
                 print(e)
                 return False
 
             for ftp_entry in readFTPdetectinfo(os.path.dirname(ftp_file), os.path.basename(ftp_file)):
-                ftp_points[(ftp_entry[0], ftp_entry[2])] = ftp_entry[-1]
+                ftp_points.setdefault(ftp_entry[0], []).append(ftp_entry[-1])
 
     # Take the platepar with the middle time as the reference one
     ff_found_list = []
@@ -450,15 +451,9 @@ def stackFrame(ff_name, recalibrated_platepars, mask, border, pp_ref, img_size, 
     max_deavg = maxpixel - avepixel
 
     if mask_meteors:
-        for i in range(1, 10):
-            # In case there are multiple meteors in a frame, mask around the first one.
-            # When using a shower filter, this may be the wrong one, we'll live with that.
-            try:
-                ff_mask = make_mask(ftp_points[(os.path.basename(ff_name), i * 1.0)], mask)
-                mask_deavg[ff_mask == 0] = 0
-                break
-            except KeyError:
-                pass  # Fall back to using the entire image
+        meteor_tracks = ftp_points.get(ff_basename, [])
+        ff_mask = makeMeteorMask(meteor_tracks, mask.img)
+        max_deavg[ff_mask == 0] = 0
 
     # Normalize the background brightness by applying a large-kernel median filter to avepixel
     if background_compensation:

--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -45,9 +45,11 @@ def find_ftp_file(dir_path, config):
 def make_mask(ftp_points, initial_mask):
     """Make a mask in which only the meteor is visible"""
     meteor_mask = np.zeros_like(initial_mask.img)
-    meteor_mask = cv2.line(meteor_mask, (round(ftp_points[0][2]), round(ftp_points[0][3])),
-                          (round(ftp_points[-1][2]), round(ftp_points[-1][3])), 255, 1)
-    meteor_mask = cv2.dilate(meteor_mask, np.ones((150, 150)))
+
+    pts = np.array([[round(p[2]), round(p[3])] for p in ftp_points], dtype=np.int32)
+    meteor_mask = cv2.polylines(meteor_mask, [pts], False, 255, 1)
+
+    meteor_mask = cv2.dilate(meteor_mask, np.ones((150, 150), np.uint8))
     return np.minimum(meteor_mask, initial_mask.img)
 
 def trackStack(dir_paths, config, border=5, background_compensation=True, 
@@ -74,6 +76,7 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         draw_constellations: [bool] Show constellation lines on stacked image
         one_core_free: [bool] leave one core free whilst processing
         textoption: [int] 0 - no text, 1 - filename, 2 - stationID, date, meteor count overlayed
+        mask_meteors: [bool] use only a portion of the image around a detection
     """
     start_time = time.time()
     # normalise the path in a platform neutral way
@@ -437,25 +440,25 @@ def stackFrame(ff_name, recalibrated_platepars, mask, border, pp_ref, img_size, 
     stack_x = stack_x[filter_arr]
     stack_y = stack_y[filter_arr]
 
-    ff_mask = mask.img
+    # Apply the mask to maxpixel and avepixel
+    maxpixel = copy.deepcopy(ff.maxpixel)
+    maxpixel[mask.img == 0] = 0
+    avepixel = copy.deepcopy(ff.avepixel)
+    avepixel[mask.img == 0] = 0
+
+    # Compute deaveraged maxpixel image
+    max_deavg = maxpixel - avepixel
+
     if mask_meteors:
         for i in range(1, 10):
             # In case there are multiple meteors in a frame, mask around the first one.
             # When using a shower filter, this may be the wrong one, we'll live with that.
             try:
                 ff_mask = make_mask(ftp_points[(os.path.basename(ff_name), i * 1.0)], mask)
+                mask_deavg[ff_mask == 0] = 0
                 break
             except KeyError:
                 pass  # Fall back to using the entire image
-
-    # Apply the mask to maxpixel and avepixel
-    maxpixel = copy.deepcopy(ff.maxpixel)
-    maxpixel[ff_mask == 0] = 0
-    avepixel = copy.deepcopy(ff.avepixel)
-    avepixel[ff_mask == 0] = 0
-
-    # Compute deaveraged maxpixel image
-    max_deavg = maxpixel - avepixel
 
     # Normalize the background brightness by applying a large-kernel median filter to avepixel
     if background_compensation:
@@ -564,7 +567,7 @@ if __name__ == "__main__":
                             help="""Leave at least one core free""")
 
     arg_parser.add_argument('--mask-meteors', action="store_true",
-                            help="""Render only the part of the image around the meteor to suppress planes and satellites (works best for large trackstacks""")
+                            help="""Render only the part of the image around the meteor to suppress planes and satellites (works best for large trackstacks)""")
 
     # Parse the command line arguments
     cml_args = arg_parser.parse_args()

--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import os, sys
@@ -14,6 +15,7 @@ import RMS.ConfigReader as cr
 from RMS.Astrometry.ApplyAstrometry import xyToRaDecPP, raDecToXYPP
 from RMS.Astrometry.Conversions import date2JD, jd2Date
 from RMS.Formats.FFfile import validFFName, getMiddleTimeFF
+from RMS.Formats.FTPdetectinfo import readFTPdetectinfo
 from RMS.Formats.FFfile import read as readFF
 from RMS.Formats.Platepar import Platepar
 from RMS.Math import angularSeparation
@@ -26,11 +28,33 @@ from RMS.QueuedPool import QueuedPool
 import time
 import datetime
 
+def find_ftp_file(dir_path, config):
+    if os.path.isfile(os.path.join(dir_path,'.config')):
+        tmpcfg = cr.loadConfigFromDirectory('.config', dir_path)
+    else:
+        tmpcfg = config
+    ftp_list = glob(os.path.join(dir_path, 'FTPdetectinfo_{}*.txt'.format(tmpcfg.stationID)))
+    ftp_list = [x for x in ftp_list if 'backup' not in x and 'unfiltered' not in x]
+    ftp_list.sort()
+
+    if len(ftp_list) < 1:
+        print('unable to find FTPdetect file in {}'.format(dir_path))
+        return False
+
+    return ftp_list[0]
+
+def make_mask(ftp_points, initial_mask):
+    """Make a mask in which only the meteor is visible"""
+    meteor_mask = np.zeros_like(initial_mask.img)
+    meteor_mask = cv2.line(meteor_mask, (round(ftp_points[0][2]), round(ftp_points[0][3])),
+                          (round(ftp_points[-1][2]), round(ftp_points[-1][3])), 255, 1)
+    meteor_mask = cv2.dilate(meteor_mask, np.ones((150, 150)))
+    return np.minimum(meteor_mask, initial_mask.img)
 
 def trackStack(dir_paths, config, border=5, background_compensation=True, 
         hide_plot=False, showers=None, darkbackground=False, out_dir=None,
         scalefactor=None, draw_constellations=False, one_core_free=False,
-        textoption=0):
+        textoption=0, mask_meteors=False):
     """ Generate a stack with aligned stars, so the sky appears static. The folder should have a
         platepars_all_recalibrated.json file.
 
@@ -88,20 +112,7 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         # Get FTP file so we can filter by shower
         for dir_path in dir_paths: 
 
-            if os.path.isfile(os.path.join(dir_path,'.config')):
-                tmpcfg = cr.loadConfigFromDirectory('.config', dir_path)
-            else:
-                tmpcfg = config
-
-            ftp_list = glob(os.path.join(dir_path, 'FTPdetectinfo_{}*.txt'.format(tmpcfg.stationID)))
-            ftp_list = [x for x in ftp_list if 'backup' not in x and 'unfiltered' not in x]
-            ftp_list.sort() 
-
-            if len(ftp_list) < 1:
-                print('unable to find FTPdetect file in {}'.format(dir_path))
-                return False
-            
-            ftp_file = ftp_list[0] 
+            ftp_file = find_ftp_file(dir_path, config)
 
             print('Performing shower association using {}'.format(ftp_file))
 
@@ -122,6 +133,13 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
                 if validFFName(file_name):
                     ff_list.append(file_name)    
     ff_list = list(set(ff_list))
+
+    ftp_points = {}
+    if mask_meteors:
+        for dir_path in dir_paths:
+            ftp_file = find_ftp_file(dir_path, config)
+            for ftp_entry in readFTPdetectinfo(os.path.dirname(ftp_file), os.path.basename(ftp_file)):
+                ftp_points[(ftp_entry[0], ftp_entry[2])] = ftp_entry[-1]
 
     # Take the platepar with the middle time as the reference one
     ff_found_list = []
@@ -272,7 +290,7 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
     thead_pool = QueuedPool(stackFrame, cores=cores, backup_dir=None, print_state=False, func_extra_args=(recalibrated_platepars, mask, border,
                                                                                    pp_ref, img_size, jd_middle, pp_stack, config,
                                                                                    avg_stack_sum_shared, avg_stack_count_shared, max_deaveraged_shared,
-                                                                                   background_compensation, finished_count, num_ffs))
+                                                                                   background_compensation, finished_count, num_ffs, ftp_points, mask_meteors))
     thead_pool.startPool()
     # add jobs
     for i, ff_name in enumerate(enumlist):
@@ -374,7 +392,7 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
 
 
 def stackFrame(ff_name, recalibrated_platepars, mask, border, pp_ref, img_size, jd_middle, pp_stack, conf, avg_stack_sum_arr,
-               avg_stack_count_arr, max_deaveraged_arr, background_compensation, finished_count, num_ffs):
+               avg_stack_count_arr, max_deaveraged_arr, background_compensation, finished_count, num_ffs, ftp_points, mask_meteors):
     ff_basename = os.path.basename(ff_name)
 
     avg_stack_sum = getArray(img_size, avg_stack_sum_arr)
@@ -411,11 +429,24 @@ def stackFrame(ff_name, recalibrated_platepars, mask, border, pp_ref, img_size, 
     stack_x = stack_x[filter_arr]
     stack_y = stack_y[filter_arr]
 
+    ff_mask = mask.img
+    if mask_meteors:
+        for i in range(1, 10):
+            # Attempt to make something work for multiple meteors in one frame.
+            # Some of them may not be in ftp_points because of a shower filter.
+            # This is not water tight.
+            try:
+                ff_mask = make_mask(ftp_points[(os.path.basename(ff_name), i * 1.0)], mask)
+                break
+            except KeyError:
+                raise RuntimeError(f"Can't find {(os.path.basename(ff_name), i * 1.0)} in {list(ftp_points.keys())}")
+                pass
+
     # Apply the mask to maxpixel and avepixel
     maxpixel = copy.deepcopy(ff.maxpixel)
-    maxpixel[mask.img == 0] = 0
+    maxpixel[ff_mask == 0] = 0
     avepixel = copy.deepcopy(ff.avepixel)
-    avepixel[mask.img == 0] = 0
+    avepixel[ff_mask == 0] = 0
 
     # Compute deaveraged maxpixel image
     max_deavg = maxpixel - avepixel
@@ -526,6 +557,9 @@ if __name__ == "__main__":
     arg_parser.add_argument('--freecore', action="store_true",
                             help="""Leave at least one core free""")
 
+    arg_parser.add_argument('--mask-meteors', action="store_true",
+                            help="""Render only the part of the image around the meteor to suppress planes and satellites (works best for large trackstacks""")
+
     # Parse the command line arguments
     cml_args = arg_parser.parse_args()
 
@@ -548,4 +582,4 @@ if __name__ == "__main__":
         hide_plot=cml_args.hideplot, showers=showers,
         darkbackground=cml_args.darkbackground, out_dir=cml_args.output, scalefactor=cml_args.scalefactor,
         draw_constellations=cml_args.constellations, one_core_free=cml_args.freecore,
-        textoption = text_option)
+        textoption = text_option, mask_meteors=cml_args.mask_meteors)

--- a/Utils/TrackStack.py
+++ b/Utils/TrackStack.py
@@ -38,8 +38,7 @@ def find_ftp_file(dir_path, config):
     ftp_list.sort()
 
     if len(ftp_list) < 1:
-        print('unable to find FTPdetect file in {}'.format(dir_path))
-        return False
+        raise FileNotFoundError('unable to find FTPdetect file in {}'.format(dir_path))
 
     return ftp_list[0]
 
@@ -112,7 +111,11 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
         # Get FTP file so we can filter by shower
         for dir_path in dir_paths: 
 
-            ftp_file = find_ftp_file(dir_path, config)
+            try:
+                ftp_file = find_ftp_file(dir_path, config)
+            except FileNotFoundError as e:
+                print(e)
+                return False
 
             print('Performing shower association using {}'.format(ftp_file))
 
@@ -137,7 +140,12 @@ def trackStack(dir_paths, config, border=5, background_compensation=True,
     ftp_points = {}
     if mask_meteors:
         for dir_path in dir_paths:
-            ftp_file = find_ftp_file(dir_path, config)
+            try:
+                ftp_file = find_ftp_file(dir_path, config)
+            except FileNotFoundError as e:
+                print(e)
+                return False
+
             for ftp_entry in readFTPdetectinfo(os.path.dirname(ftp_file), os.path.basename(ftp_file)):
                 ftp_points[(ftp_entry[0], ftp_entry[2])] = ftp_entry[-1]
 
@@ -432,15 +440,13 @@ def stackFrame(ff_name, recalibrated_platepars, mask, border, pp_ref, img_size, 
     ff_mask = mask.img
     if mask_meteors:
         for i in range(1, 10):
-            # Attempt to make something work for multiple meteors in one frame.
-            # Some of them may not be in ftp_points because of a shower filter.
-            # This is not water tight.
+            # In case there are multiple meteors in a frame, mask around the first one.
+            # When using a shower filter, this may be the wrong one, we'll live with that.
             try:
                 ff_mask = make_mask(ftp_points[(os.path.basename(ff_name), i * 1.0)], mask)
                 break
             except KeyError:
-                raise RuntimeError(f"Can't find {(os.path.basename(ff_name), i * 1.0)} in {list(ftp_points.keys())}")
-                pass
+                pass  # Fall back to using the entire image
 
     # Apply the mask to maxpixel and avepixel
     maxpixel = copy.deepcopy(ff.maxpixel)


### PR DESCRIPTION
This adds an option to stack only the part of the images which have the meteor detection. With this option, in the resulting trackstack there are less planes and satellites.

Example before:
<img width="1165" height="1174" alt="trackstack_without" src="https://github.com/user-attachments/assets/18af419c-1a56-4a21-befd-8063e46d03c2" />

After:
<img width="1065" height="1116" alt="trackstack_with_filter" src="https://github.com/user-attachments/assets/7c545440-45d6-4149-8cbe-dd5062f63777" />