### PR TITLE
Warn when the white-ratio check silently skips meteor detection

### DIFF
--- a/RMS/Detection.py
+++ b/RMS/Detection.py
@@ -364,8 +364,16 @@ def merge3DLines(line_list, vect_angle_thresh, last_count=0):
 
 
 
+# Count of images rejected by the white ratio check, used only to rate limit the warning below
+# instead of firing it on every rejected image. Detection runs one image per worker process, so
+# each worker keeps its own count - fine for throttling, but not a run-wide total, which is why
+# the count is not printed in the message
+white_ratio_reject_count = 0
+
 def checkWhiteRatio(img_thres, ff, max_white_ratio):
     """ Checks if there are too many threshold passers on an image. """
+
+    global white_ratio_reject_count
 
     # Check if the image is too "white" and any further processing makes no sense
     # Compute the radio between the number of threshold passers and all pixels
@@ -375,8 +383,24 @@ def checkWhiteRatio(img_thres, ff, max_white_ratio):
 
     if white_ratio > max_white_ratio:
 
-        log.debug(("Too many threshold passers! White ratio is {:.2f}, which is higher than the "\
-            "max_white_ratio threshold: {:.2f}").format(white_ratio, max_white_ratio))
+        white_ratio_reject_count += 1
+
+        msg = ("Too many threshold passers! White ratio is {:.2f}, which is higher than the "\
+            "max_white_ratio threshold: {:.2f}, so detection is skipped for this image. "\
+            "This is expected on bright or cloudy images, but "\
+            "if it happens on every image of a clear night the detection k1/j1 thresholds are "\
+            "too low for this camera (e.g. video paths that smooth per-pixel temporal noise, "\
+            "such as software re-encoded streams, can push the stdpixel-based threshold below "\
+            "the maxpixel noise floor).").format(white_ratio, max_white_ratio)
+
+        # Make the first rejection (and every 100th) visible at warning level - a station whose
+        # every image is rejected is effectively blind to meteors, and outside of debug logging
+        # this used to be completely silent
+        if (white_ratio_reject_count == 1) or (white_ratio_reject_count%100 == 0):
+            log.warning(msg)
+
+        else:
+            log.debug(msg)
 
         return False
 

--- a/RMS/Detection.py
+++ b/RMS/Detection.py
@@ -364,16 +364,16 @@ def merge3DLines(line_list, vect_angle_thresh, last_count=0):
 
 
 
-# Count of images rejected by the white ratio check, used only to rate limit the warning below
-# instead of firing it on every rejected image. Detection runs one image per worker process, so
-# each worker keeps its own count - fine for throttling, but not a run-wide total, which is why
-# the count is not printed in the message
-white_ratio_reject_count = 0
+# Count images rejected by the white ratio check to rate limit the warning below. QueuedPool
+# workers are long-lived and each process keeps its own count across images; this is not a
+# run-wide total and must not be reported as one.
+_white_ratio_reject_count = 0
+
 
 def checkWhiteRatio(img_thres, ff, max_white_ratio):
     """ Checks if there are too many threshold passers on an image. """
 
-    global white_ratio_reject_count
+    global _white_ratio_reject_count
 
     # Check if the image is too "white" and any further processing makes no sense
     # Compute the radio between the number of threshold passers and all pixels
@@ -383,10 +383,10 @@ def checkWhiteRatio(img_thres, ff, max_white_ratio):
 
     if white_ratio > max_white_ratio:
 
-        white_ratio_reject_count += 1
+        _white_ratio_reject_count += 1
 
-        msg = ("Too many threshold passers! White ratio is {:.2f}, which is higher than the "\
-            "max_white_ratio threshold: {:.2f}, so detection is skipped for this image. "\
+        msg = ("Too many threshold passers! White ratio is {:.4f}, which is higher than the "\
+            "max_white_ratio threshold: {:.4f}, so detection is skipped for this image. "\
             "This is expected on bright or cloudy images, but "\
             "if it happens on every image of a clear night the detection k1/j1 thresholds are "\
             "too low for this camera (e.g. video paths that smooth per-pixel temporal noise, "\
@@ -396,7 +396,7 @@ def checkWhiteRatio(img_thres, ff, max_white_ratio):
         # Make the first rejection (and every 100th) visible at warning level - a station whose
         # every image is rejected is effectively blind to meteors, and outside of debug logging
         # this used to be completely silent
-        if (white_ratio_reject_count == 1) or (white_ratio_reject_count%100 == 0):
+        if (_white_ratio_reject_count == 1) or (_white_ratio_reject_count%100 == 0):
             log.warning(msg)
 
         else:

--- a/Tests/TestDetection.py
+++ b/Tests/TestDetection.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+import RMS.Detection as Detection
+
+
+@pytest.fixture(autouse=True)
+def reset_white_ratio_reject_count():
+    """ Reset the process-local warning counter so tests remain independent. """
+
+    original_count = Detection._white_ratio_reject_count
+    Detection._white_ratio_reject_count = 0
+
+    yield
+
+    Detection._white_ratio_reject_count = original_count
+
+
+def test_check_white_ratio_warning_cadence(monkeypatch):
+    """ Rejections warn on the first and every 100th image, and otherwise log at debug level. """
+
+    warning_counts = []
+    debug_messages = []
+    monkeypatch.setattr(Detection.log, 'warning',
+        lambda message: warning_counts.append(Detection._white_ratio_reject_count))
+    monkeypatch.setattr(Detection.log, 'debug', debug_messages.append)
+
+    ff = SimpleNamespace(nrows=10, ncols=10)
+    rejected_image = np.ones((ff.nrows, ff.ncols), dtype=np.uint8)
+
+    results = [Detection.checkWhiteRatio(rejected_image, ff, 0.05) for _ in range(200)]
+
+    assert not any(results)
+    assert warning_counts == [1, 100, 200]
+    assert len(debug_messages) == 197
+
+
+def test_check_white_ratio_accepted_image_does_not_increment_counter(monkeypatch):
+    """ Accepted images pass without affecting the rejection warning cadence. """
+
+    warning_messages = []
+    debug_messages = []
+    monkeypatch.setattr(Detection.log, 'warning', warning_messages.append)
+    monkeypatch.setattr(Detection.log, 'debug', debug_messages.append)
+
+    ff = SimpleNamespace(nrows=10, ncols=10)
+    accepted_image = np.zeros((ff.nrows, ff.ncols), dtype=np.uint8)
+
+    assert Detection.checkWhiteRatio(accepted_image, ff, 0.05)
+    assert Detection._white_ratio_reject_count == 0
+    assert not warning_messages
+    assert not debug_messages
+
+
+def test_check_white_ratio_warning_preserves_threshold_precision(monkeypatch):
+    """ The warning must distinguish a measured ratio just above the configured threshold. """
+
+    warning_messages = []
+    monkeypatch.setattr(Detection.log, 'warning', warning_messages.append)
+
+    ff = SimpleNamespace(nrows=10, ncols=100)
+    rejected_image = np.zeros((ff.nrows, ff.ncols), dtype=np.uint8)
+    rejected_image.flat[:51] = 1
+
+    assert not Detection.checkWhiteRatio(rejected_image, ff, 0.05)
+    assert len(warning_messages) == 1
+    assert "White ratio is 0.0510" in warning_messages[0]
+    assert "max_white_ratio threshold: 0.0500" in warning_messages[0]


### PR DESCRIPTION
### Problem

`checkWhiteRatio()` aborts all line-finding for an image when too many pixels pass the detection threshold, but logs this only at `debug` level. The line does reach the nightly log file (the file handler defaults to DEBUG), but never the console: there the operator sees nothing but `detected meteors: 0`, indistinguishable from a quiet sky, and nothing prompts them to dig through the debug log.

### When it bites

On stations whose video path smooths per-pixel *temporal* noise — notably software re-encoded RTSP streams (Pi + CSI-camera bridges, some IP-camera encoders) — `stdpixel` collapses while the `maxpixel` noise floor remains. The `k1·stdpixel + j1` threshold then lands *below* the noise floor, a large fraction of every frame passes, and the white-ratio guard rejects **every image of a clear night**. The station is silently blind to meteors. (Cloud/twilight raises the background statistics and masks the problem, so it looks intermittent.)

Full analysis and evidence in #969.

### This PR

Promotes the first rejection (and every 100th thereafter, to avoid log spam) to a `warning` that reports the measured white ratio and hints that `k1`/`j1` may be too low for the camera. **No behavioural change to detection** — it purely makes an existing silent failure visible. The deeper fix (adaptive thresholding) is proposed in #969.

### Testing

Verified in an isolated harness that the warning fires on the 1st and 100th rejection only, rejections still return `False`, and sub-threshold images still pass. Found in production on a Pi 5 / IMX296 station feeding via a re-encoded RTSP stream.

