### PR TITLE
ConfigReader: normalize the case of enum-like capture options

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -1107,16 +1107,16 @@ def parseCapture(config, parser):
         pass
 
     if parser.has_option(section, "protocol"):
-        config.protocol = parser.get(section, "protocol")
+        config.protocol = parser.get(section, "protocol").strip().lower()
 
     if parser.has_option(section, "udp_buffer_size"):
         config.udp_buffer_size = parser.getint(section, "udp_buffer_size")
 
     if parser.has_option(section, "media_backend"):
-        config.media_backend = parser.get(section, "media_backend")
+        config.media_backend = parser.get(section, "media_backend").strip().lower()
 
     if parser.has_option(section, "gst_colorspace"):
-        config.gst_colorspace = parser.get(section, "gst_colorspace")
+        config.gst_colorspace = parser.get(section, "gst_colorspace").strip().upper()
 
     if parser.has_option(section, "gst_decoder"):
         config.gst_decoder = parser.get(section, "gst_decoder")
@@ -1225,7 +1225,7 @@ def parseCapture(config, parser):
         config.save_frames = save_requested
 
     if parser.has_option(section, "frame_file_type"):
-        config.frame_file_type = parser.get(section, "frame_file_type")
+        config.frame_file_type = parser.get(section, "frame_file_type").strip().lower()
 
     # Load the JPEG quality
     if parser.has_option(section, "jpgs_quality"):
@@ -1252,7 +1252,7 @@ def parseCapture(config, parser):
 
     # Set whether to delete, archive, or leave saved frames after making timelapse ('delete', 'tar', 'none')
     if parser.has_option(section, "frame_cleanup"):
-        config.frame_cleanup = parser.get(section, "frame_cleanup")
+        config.frame_cleanup = parser.get(section, "frame_cleanup").strip().lower()
 
     # Enable/disable showing a slideshow of last night's meteor detections on the screen during the day
     if parser.has_option(section, "slideshow_enable"):

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -1116,7 +1116,12 @@ def parseCapture(config, parser):
         config.media_backend = parser.get(section, "media_backend").strip().lower()
 
     if parser.has_option(section, "gst_colorspace"):
-        config.gst_colorspace = parser.get(section, "gst_colorspace").strip().upper()
+        gst_colorspace = parser.get(section, "gst_colorspace").strip()
+
+        # Normalize the formats explicitly supported by RMS, while preserving the case of other
+        # GStreamer formats (e.g. RGBx and v210) whose canonical names are case-sensitive.
+        supported_gst_colorspaces = {'bgr': 'BGR', 'gray8': 'GRAY8'}
+        config.gst_colorspace = supported_gst_colorspaces.get(gst_colorspace.lower(), gst_colorspace)
 
     if parser.has_option(section, "gst_decoder"):
         config.gst_decoder = parser.get(section, "gst_decoder")

--- a/Tests/test_ConfigReader.py
+++ b/Tests/test_ConfigReader.py
@@ -1,0 +1,47 @@
+"""Focused tests for capture option parsing."""
+
+import pytest
+
+from RMS import ConfigReader as cr
+
+
+def _parseCaptureOptions(monkeypatch, tmp_path, options):
+    """Parse a minimal Capture section with the supplied options."""
+    parser = cr.RawConfigParser()
+    parser.add_section('Capture')
+    parser.set('Capture', 'save_frames', 'false')
+
+    for option, value in options.items():
+        parser.set('Capture', option, value)
+
+    config = cr.Config()
+    config.config_file_path = str(tmp_path)
+    monkeypatch.setattr(cr, 'isFfmpegWorking', lambda: False)
+    cr.parseCapture(config, parser)
+
+    return config
+
+
+def testCaptureEnumOptionsAreNormalized(monkeypatch, tmp_path):
+    config = _parseCaptureOptions(monkeypatch, tmp_path, {
+        'protocol': ' UDP ',
+        'media_backend': ' GST ',
+        'gst_colorspace': ' gray8 ',
+        'frame_file_type': ' PNG ',
+        'frame_cleanup': ' Delete ',
+    })
+
+    assert config.protocol == 'udp'
+    assert config.media_backend == 'gst'
+    assert config.gst_colorspace == 'GRAY8'
+    assert config.frame_file_type == 'png'
+    assert config.frame_cleanup == 'delete'
+
+
+@pytest.mark.parametrize('gst_colorspace', ['RGBx', 'xRGB', 'v210', 'r210'])
+def testCapturePreservesCanonicalGstColorspaceCase(monkeypatch, tmp_path, gst_colorspace):
+    config = _parseCaptureOptions(monkeypatch, tmp_path, {
+        'gst_colorspace': ' {} '.format(gst_colorspace),
+    })
+
+    assert config.gst_colorspace == gst_colorspace


### PR DESCRIPTION
Config option *names* are case-insensitive (`RawConfigParser` lowercases keys), but *values* are read raw, while several are compared against lowercase or uppercase string literals. A value with the wrong case doesn't raise — it silently falls through to the other branch, so the station runs in a mode its config doesn't describe.

The clearest example is `protocol`:

```python
config.protocol = parser.get(section, "protocol")   # ConfigReader.py

if self.config.protocol == 'udp':                   # BufferedCapture.py
    protocol_str = f"protocols=udp {common_timeouts}"
else:
    protocol_str = f"protocols=tcp {common_timeouts}"
```

`protocol: UDP` captures over TCP, and `ObservationSummary` still reports `protocol_in_use` as `"UDP"` — so the summary disagrees with what GStreamer actually did.

Five options are affected. Each is now normalized where it's parsed:

| Option | Compared against | Normalization |
|---|---|---|
| `protocol` | `'udp'` (`BufferedCapture.py`) | `.strip().lower()` |
| `media_backend` | `'gst'`, `'v4l2'` (`BufferedCapture.py`) | `.strip().lower()` |
| `frame_cleanup` | `'delete'`, `'tar'` (`Reprocess.py`) | `.strip().lower()` |
| `frame_file_type` | `'png'` (`RawFrameSave.py`) | `.strip().lower()` |
| `gst_colorspace` | `'GRAY8'` (`BufferedCapture.py`) | `.strip().upper()` |

`gst_colorspace` goes the other way on purpose: it is interpolated into GStreamer caps as `format=...`, and those format names are uppercase.

Deliberately left alone:

- `ff_format` — used as a literal filename extension, so forcing case would change files on disk.
- All `*_file` / `*_dir` / `*_path` options — filesystem paths, case-sensitive on Linux.
- `shower_color_map`, `sporadic_color` — matplotlib names, case-sensitive there.
- `gst_decoder` — passed straight through as a GStreamer element name, never compared to a literal here.

Note that section headers (`[Capture]`, `[MeteorDetection]`, …) remain case-sensitive; `has_section` matches exactly, so a mis-cased header silently skips the whole section. That's a broader change and isn't touched here.

### Testing

Parsed the shipped `.config` unmodified — values unchanged (`tcp`, `gst`, `BGR`, `jpg`, `delete`). Parsed a copy with `protocol: UDP` (trailing spaces), `media_backend: GST`, `gst_colorspace: gray8`, `frame_file_type: PNG`, `frame_cleanup: Delete` — all five resolve to the canonical form the consumers expect.
