### PR TITLE
RMS_Update: restore bounded sudo prompt and raise UDP buffers to 16MB

### DIFF
--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -23,6 +23,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 RMS_BRANCH="${RMS_BRANCH:-""}"  # Use environment variable if set, otherwise empty
 SWITCH_MODE=""  # Set by parse_args: "", "direct", or "interactive"
 FORCE_UPDATE=false  # Set by parse_args when --force is used
+SKIP_BUFFERS=false  # Set by parse_args when --skip-buffers is used
 readonly RMSSOURCEDIR=$HOME/source/RMS
 readonly RMSBACKUPDIR=$HOME/.rms_backup
 readonly CURRENT_CONFIG="$RMSSOURCEDIR/.config"
@@ -136,9 +137,10 @@ validate_rms_directory() {
 }
 
 usage() {
-    print_status "info" "Usage: $0 [--switch <branch>] [--force] [--help]"
+    print_status "info" "Usage: $0 [--switch <branch>] [--force] [--skip-buffers] [--help]"
     print_status "info" "  --switch <branch>  Interactively switch or switch to a specific branch"
     print_status "info" "  --force            Force update even if repository is up-to-date"
+    print_status "info" "  --skip-buffers     Do not check or raise system UDP buffer sizes"
     print_status "info" "  --help             Show usage info"
     print_status "info" ""
     print_status "info" "Environment:"
@@ -163,6 +165,10 @@ parse_args() {
                 ;;
             --force)
                 FORCE_UPDATE=true
+                shift 1
+                ;;
+            --skip-buffers)
+                SKIP_BUFFERS=true
                 shift 1
                 ;;
             --help|-h)
@@ -1137,6 +1143,51 @@ install_missing_dependencies() {
     done
 }
 
+# Raise the system UDP buffer limits if they are below what GStreamer needs.
+#
+# BufferedCapture.py asks rtspsrc for a 16MB udp-buffer-size, but the kernel
+# silently clamps that request to net.core.rmem_max. If the limit is lower the
+# request is a no-op and frames are dropped under load.
+#
+# This never fails the update - buffer sizing affects capture at runtime, it is
+# not a prerequisite for building RMS.
+update_udp_buffers() {
+    local buffers_script="$RMSSOURCEDIR/Scripts/UpdateBuffers.sh"
+
+    if [ "$SKIP_BUFFERS" = true ]; then
+        print_status "info" "Skipping UDP buffer check (--skip-buffers)."
+        return 0
+    fi
+
+    if [ ! -f "$buffers_script" ]; then
+        print_status "warning" "UpdateBuffers.sh not found, skipping UDP buffer check."
+        return 0
+    fi
+
+    # The check itself is unprivileged, so only reach for sudo if there is work
+    if bash "$buffers_script" --check >/dev/null 2>&1; then
+        print_status "success" "UDP buffers are already sized correctly."
+        return 0
+    fi
+
+    print_status "info" "UDP buffers are below the 16MB GStreamer requests, so the kernel is clamping it."
+
+    if ! ensure_sudo "UDP buffer configuration"; then
+        print_status "warning" "UDP buffers left unchanged. To apply them later, run:"
+        print_status "info" "  sudo $buffers_script --yes"
+        return 0
+    fi
+
+    if sudo bash "$buffers_script" --yes; then
+        print_status "success" "UDP buffers raised to the recommended size."
+    else
+        print_status "warning" "Could not raise UDP buffers. To retry, run:"
+        print_status "info" "  sudo $buffers_script --yes"
+    fi
+
+    return 0
+}
+
 get_commit_info() {
     local branch=${1:-""}
     local commit
@@ -1580,6 +1631,9 @@ PY
     # Install missing dependencies
     print_header "Installing Missing Dependencies"
     install_missing_dependencies
+
+    print_header "Checking UDP Buffer Sizes"
+    update_udp_buffers
 
     print_header "Installing Python Requirements"
     print_status "info" "This may take a few minutes..."

--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -44,6 +44,19 @@ readonly GIT_RETRY_DELAY=15  # Seconds between git operation retries
 BRANCH_REMOTE=""
 UPSTREAM_BRANCH=""
 
+# PID of the background sudo keep-alive process started by ensure_sudo()
+SUDO_KEEP_ALIVE_PID=""
+
+# Stop the background sudo keep-alive process, if one is running.
+# Safe to call repeatedly and when no keep-alive was ever started.
+stop_sudo_keep_alive() {
+    if [ -n "${SUDO_KEEP_ALIVE_PID:-}" ]; then
+        kill "$SUDO_KEEP_ALIVE_PID" 2>/dev/null || true
+        wait "$SUDO_KEEP_ALIVE_PID" 2>/dev/null || true
+        SUDO_KEEP_ALIVE_PID=""
+    fi
+}
+
 # Trap handler for emergency cleanup
 emergency_cleanup() {
     local exit_code=$?
@@ -58,6 +71,9 @@ emergency_cleanup() {
     
     # Release lock safely before any potentially failing operations
     exec 200>&- 2>/dev/null || true
+
+    # Stop the background sudo refresher so it cannot outlive the script
+    stop_sudo_keep_alive
     
     print_status "error" "Script failed at line $line_number with exit code $exit_code"
     print_status "warning" "Attempting emergency recovery..."
@@ -93,6 +109,9 @@ emergency_cleanup() {
 
 # Set up trap for errors and signals
 trap 'emergency_cleanup $LINENO' ERR INT TERM
+
+# Always reap the sudo keep-alive, including on a clean exit
+trap stop_sudo_keep_alive EXIT
 
 # Safety check to prevent catastrophic deletions if RMSSOURCEDIR is misconfigured
 validate_rms_directory() {
@@ -986,6 +1005,85 @@ switch_to_branch() {
 }
 
 
+# Establish sudo credentials for the operation described by $1.
+# Returns 0 if sudo can be used afterwards, 1 if not. Never exits the script.
+#
+# The password prompt is deliberately bounded by a read timeout rather than
+# left to sudo. Sudo's own passwd_timeout defaults to 0 (no timeout), so an
+# unattended run can block forever - which matters because GRMSUpdater.sh
+# stops all stations before calling this script.
+ensure_sudo() {
+    local reason="$1"
+    local timeout_duration=30
+    local attempts=3
+    local refresh_interval=$((timeout_duration / 2))
+    local password=""
+    local i
+
+    # Already root, or sudo needs no password - nothing to establish
+    if [ "$(id -u)" -eq 0 ] || sudo -n true 2>/dev/null; then
+        return 0
+    fi
+
+    # A password is required, which only works with someone at the terminal
+    if [ "$INTERACTIVE" != true ]; then
+        print_status "warning" "Sudo password required for $reason, but no terminal is attached."
+        return 1
+    fi
+
+    if [ "$USE_COLOR" = true ]; then
+        tput bold; tput setaf 3  # Bold yellow
+    fi
+    echo "
+==============================================
+  Sudo access needed for $reason
+==============================================
+"
+    if [ "$USE_COLOR" = true ]; then
+        tput sgr0  # Reset formatting
+    fi
+    interactive_sleep 1
+
+    echo "You have $attempts attempts, with a ${timeout_duration}-second timeout."
+
+    for ((i = 1; i <= attempts; i++)); do
+        # read returns non-zero on timeout or EOF, leaving $password empty
+        if ! read -r -s -t "$timeout_duration" \
+            -p "[sudo] password for ${USER:-$(id -un)} (timeout in ${timeout_duration}s): " password; then
+            echo
+            print_status "warning" "Password entry timed out. Skipping $reason."
+            return 1
+        fi
+        echo  # Move to a new line after the hidden input
+
+        # printf, not echo: echo can mangle backslashes in a password
+        if [ -n "$password" ] && printf '%s\n' "$password" | sudo -S -v 2>/dev/null; then
+            password=""
+
+            # Refresh the timestamp in the background so it survives a long
+            # apt-get. -n keeps it from ever competing for the terminal, and
+            # the kill -0 check stops it once this script is gone.
+            (
+                while kill -0 "$$" 2>/dev/null; do
+                    sudo -n -v 2>/dev/null || exit 0
+                    sleep "$refresh_interval"
+                done
+            ) &
+            SUDO_KEEP_ALIVE_PID=$!
+            return 0
+        fi
+
+        if [ "$i" -lt "$attempts" ]; then
+            echo "Sorry, try again. You have $((attempts - i)) attempts remaining."
+        fi
+    done
+
+    password=""
+    print_status "warning" "$attempts incorrect password attempts. Skipping $reason."
+    return 1
+}
+
+
 # Install missing dependencies
 install_missing_dependencies() {
 
@@ -1025,40 +1123,18 @@ install_missing_dependencies() {
     print_status "info" "The following packages will be installed: ${missing_packages[*]}"
     interactive_sleep 1
 
-    if sudo -n true 2>/dev/null; then
-        print_status "info" "Passwordless sudo available. Installing missing packages..."
-        sudo apt-get update
-        for package in "${missing_packages[@]}"; do
-            if ! sudo apt-get install -y "$package"; then
-                print_status "error" "Failed to install $package. Please install it manually."
-            fi
-        done
-    else
-        # Show prominent message for sudo
-        if [ "$USE_COLOR" = true ]; then
-            tput bold; tput setaf 3  # Bold yellow
-            echo "
-==============================================
-  Sudo access needed for package installation
-==============================================
-"
-            tput sgr0  # Reset formatting
-        else
-            echo "
-==============================================
-  Sudo access needed for package installation
-==============================================
-"
-        fi
-        interactive_sleep 2
-        
-        sudo apt-get update
-        for package in "${missing_packages[@]}"; do
-            if ! sudo apt-get install -y "$package"; then
-                print_status "error" "Failed to install $package. Please install it manually."
-            fi
-        done
+    if ! ensure_sudo "package installation"; then
+        print_status "warning" "Skipping package installation. Install manually with:"
+        print_status "info" "  sudo apt-get install ${missing_packages[*]}"
+        return
     fi
+
+    sudo apt-get update
+    for package in "${missing_packages[@]}"; do
+        if ! sudo apt-get install -y "$package"; then
+            print_status "error" "Failed to install $package. Please install it manually."
+        fi
+    done
 }
 
 get_commit_info() {

--- a/Scripts/UpdateBuffers.sh
+++ b/Scripts/UpdateBuffers.sh
@@ -3,7 +3,12 @@
 # UDP Buffer Size Configuration Script
 # -----------------------------------
 # Purpose: Configures system UDP buffer sizes for GStreamer UDP streaming
-# Usage: sudo ./Scripts/UpdateBuffers.sh
+# Usage: sudo ./Scripts/UpdateBuffers.sh [--check] [--yes]
+#
+#   --check  Report whether the buffers need raising and exit. Requires no
+#            root privileges: reading sysctl values is unprivileged.
+#            Exit 0 = buffers are adequate, 10 = they need raising.
+#   --yes    Apply the recommended values without prompting.
 #
 # This script checks and optionally updates UDP buffer sizes to handle
 # GStreamer's UDP source requirements (rtspsrc udp-buffer-size, default 16MB).
@@ -16,16 +21,35 @@
 # - Update settings if confirmed
 # - Show before/after comparison
 
-
-# Check if running as root
-if [ "$EUID" -ne 0 ]; then 
-    echo "Please run as root (sudo)"
-    exit 1
-fi
-
 # Configuration
 RECOMMENDED_SIZE=16777216  # 16MB in bytes - must be >= rtspsrc udp-buffer-size in BufferedCapture.py
 MIN_RECOMMENDED=1048576    # 1MB in bytes (old default; below this UDP RtspSrc bursts overflow)
+
+CHECK_ONLY=false
+ASSUME_YES=false
+
+# Parse arguments before the root check, so --check works unprivileged
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check)
+            CHECK_ONLY=true
+            shift
+            ;;
+        --yes|-y)
+            ASSUME_YES=true
+            shift
+            ;;
+        --help|-h)
+            sed -n '3,10p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            echo "Usage: sudo $0 [--check] [--yes]" >&2
+            exit 1
+            ;;
+    esac
+done
 
 # Function to convert bytes to human readable format
 human_readable() {
@@ -35,6 +59,19 @@ human_readable() {
     else
         echo "$(( bytes / 1024 )) KB"
     fi
+}
+
+# Return 0 if both buffers are at or above the recommended size, 1 otherwise.
+# Reads /proc/sys via sysctl, which needs no privileges.
+buffers_adequate() {
+    local rmem wmem
+    rmem=$(sysctl -n net.core.rmem_max 2>/dev/null) || return 1
+    wmem=$(sysctl -n net.core.wmem_max 2>/dev/null) || return 1
+
+    if [ "$rmem" -lt "$RECOMMENDED_SIZE" ] || [ "$wmem" -lt "$RECOMMENDED_SIZE" ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Function to display buffer settings
@@ -48,36 +85,57 @@ show_settings() {
     echo "Send buffer max (wmem_max): $current_wmem_max bytes ($(human_readable $current_wmem_max))"
     echo "----------------------"
 
-    # Check if buffers are below recommended size
-    local update_needed=false
+    # Report how far below the thresholds we are, if at all
     if [ $current_rmem_max -lt $MIN_RECOMMENDED ] || [ $current_wmem_max -lt $MIN_RECOMMENDED ]; then
-        echo -e "WARNING: Current buffer sizes are below the minimum recommended size ($(human_readable $MIN_RECOMMENDED))"
+        echo "WARNING: Current buffer sizes are below the minimum recommended size ($(human_readable $MIN_RECOMMENDED))"
         echo "This may cause issues with GStreamer UDP buffer allocation."
-        update_needed=true
     elif [ $current_rmem_max -lt $RECOMMENDED_SIZE ] || [ $current_wmem_max -lt $RECOMMENDED_SIZE ]; then
-        echo -e "NOTE: Current buffer sizes are below the recommended size ($(human_readable $RECOMMENDED_SIZE))"
-        echo "Increasing them would provide more headroom for UDP operations."
-        update_needed=true
-    fi
-
-    if [ "$update_needed" = true ]; then
-        echo -e "\nWould you like to update the buffer sizes to the recommended values? (y/n)"
-        read -r response
-        if [[ "$response" =~ ^[Yy]$ ]]; then
-            return 0  # proceed with update
-        else
-            echo "No changes made. Exiting..."
-            exit 0
-        fi
-    else
-        echo -e "Current buffer sizes are at or above recommended values."
-        exit 0
+        echo "NOTE: Current buffer sizes are below the recommended size ($(human_readable $RECOMMENDED_SIZE))"
+        echo "GStreamer requests $(human_readable $RECOMMENDED_SIZE); the kernel clamps the request to these values."
     fi
 }
 
-# Show initial settings and check if update is needed
+# --check: report status and exit without touching anything
+if [ "$CHECK_ONLY" = true ]; then
+    if buffers_adequate; then
+        echo "UDP buffers are at or above the recommended size ($(human_readable $RECOMMENDED_SIZE))."
+        exit 0
+    fi
+    show_settings
+    exit 10
+fi
+
+# Check if running as root (only the applying path needs privileges)
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run as root (sudo)"
+    exit 1
+fi
+
+# Show initial settings and check if an update is needed
 echo "CHECKING CURRENT SETTINGS:"
 show_settings
+
+if buffers_adequate; then
+    echo -e "\nCurrent buffer sizes are at or above recommended values."
+    exit 0
+fi
+
+# Confirm, unless --yes was given
+if [ "$ASSUME_YES" != true ]; then
+    if [ ! -t 0 ]; then
+        # No terminal to ask on. Fail loudly rather than silently doing nothing,
+        # so a calling script cannot mistake a no-op for success.
+        echo "ERROR: Buffers need raising but stdin is not a terminal. Re-run with --yes." >&2
+        exit 1
+    fi
+
+    echo -e "\nWould you like to update the buffer sizes to the recommended values? (y/n)"
+    read -r response
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        echo "No changes made. Exiting..."
+        exit 0
+    fi
+fi
 echo
 
 # Use drop-in file in /etc/sysctl.d/ for systemd compatibility
@@ -123,5 +181,12 @@ sysctl -p "$SYSCTL_DROP_IN" >/dev/null 2>&1
 
 echo -e "\nAFTER CHANGES:"
 show_settings
+
+# Verify the values actually took, rather than assuming
+if ! buffers_adequate; then
+    echo -e "\nERROR: Buffers are still below the recommended size after applying changes." >&2
+    echo "Check for a conflicting setting in /etc/sysctl.d/ or a read-only /proc." >&2
+    exit 1
+fi
 
 echo -e "\nDone! Settings will persist across reboots via $SYSCTL_DROP_IN"


### PR DESCRIPTION
Two related changes to `RMS_Update.sh`, kept as separate commits.

### 1. Restore the bounded sudo password prompt

`sudoWithTimeout()` was added in `52b085ec` and removed in `c5fd3ab5` ("Prevent corruption of config and mask file", a 384-line restructure). Nothing in that commit was about sudo and no reference to it survives, so this looks like collateral of the rewrite rather than a decision.

Without it, the fallback branch runs a bare `sudo apt-get` and waits on sudo's own prompt. Sudo's `passwd_timeout` defaults to `0` (no timeout), so an unattended run can block indefinitely — which matters because `GRMSUpdater.sh` stops all stations before calling this script.

Reinstated as `ensure_sudo "<reason>"`: 30s `read -t` timeout, 3 attempts, background keep-alive to survive a long `apt-get`. `install_missing_dependencies` now goes through it, collapsing the `apt-get` loop that was previously written out twice.

Four deliberate differences from the original:

- the keep-alive is trapped (`stop_sudo_keep_alive` from `emergency_cleanup` and a new `EXIT` trap) — the original leaked it
- background refresh uses `sudo -n -v` so it can never compete for the terminal, plus a `kill -0 "$$"` guard
- `printf` instead of `echo` for the password, which `echo` can mangle on backslashes
- returns 1 without prompting when no terminal is attached, so non-interactive callers skip instead of hanging

### 2. Raise UDP buffers to 16MB during update

`BufferedCapture.py` asks rtspsrc for a 16MB `udp-buffer-size`, but the kernel clamps that to `net.core.rmem_max`. Where the limit is lower the request is a no-op and frames drop under load. `UpdateBuffers.sh` already sets this, but nothing ever called it, so stations only got it if run by hand.

- `UpdateBuffers.sh` gains `--check` (unprivileged, exit 0 adequate / 10 needs raising) and `--yes`; argument parsing moved above the root gate so `--check` works without sudo
- fixes a silent no-op: with no tty and no `--yes`, the confirm prompt used to read empty, print "No changes made" and exit 0 — indistinguishable from success to a caller. It now fails loudly
- applying verifies the values actually took instead of assuming
- `RMS_Update.sh` gains `update_udp_buffers()` after the dependency step, plus `--skip-buffers`

The check is unprivileged, so sudo is only requested when there is real work: one prompt per station, silent no-op on every update after. It always returns 0 — buffer sizing affects capture at runtime and should never fail a build.

### Testing

Against a mock Linux `sysctl` (macOS has no `net.core.*`):

- `--check` at 208KB / 1MB / 16MB returns 10 / 10 / 0
- no tty without `--yes` exits 1; with `--yes` proceeds; already-adequate exits 0 without applying
- timeout path measured at exactly one 30s interval, not 3x
- all three `update_udp_buffers` paths return 0
- both scripts pass `bash -n`

Nothing was executed against `/etc` — the apply stage was stubbed in the test copy.

### Note

`GRMSUpdater.sh:595` now takes the skip path and prints the manual command rather than stalling with stations stopped. That also means multi-camera hosts won't get the buffer bump automatically and will need one manual `sudo ./Scripts/UpdateBuffers.sh --yes`. If that should be automatic, the cleaner fix is for GRMSUpdater to establish sudo up front, before `stop_stations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
