### PR TITLE
Add star candidate and PSF-fit visualization

### DIFF
--- a/RMS/ExtractStars.py
+++ b/RMS/ExtractStars.py
@@ -56,7 +56,7 @@ log = getLogger("rmslogger")
 def extractStars(img, img_median=None, mask=None, gamma=1.0, max_star_candidates=1000, border=10,
                  neighborhood_size=10, intensity_threshold=18,
                  segment_radius=4, roundness_threshold=0.5, max_feature_ratio=0.8, bit_depth=8,
-                 extra_info=None):
+                 extra_info=None, show_candidates=False):
     """ Extracts stars on a given image by searching for local maxima and applying PSF fit for star 
         confirmation.
 
@@ -79,6 +79,7 @@ def extractStars(img, img_median=None, mask=None, gamma=1.0, max_star_candidates
             (hot pixels are narrow, while stars are round).
         max_feature_ratio: [float] Maximum ratio between 2 sigma of the star and the image segment area.
         bit_depth: [int] Bit depth of the image. 8 bits by default.
+        show_candidates: [bool] Show the raw star candidates before PSF fitting. False by default.
     
     Return:
         x2, y2, background, intensity, fwhm: [list of ndarrays]
@@ -130,8 +131,8 @@ def extractStars(img, img_median=None, mask=None, gamma=1.0, max_star_candidates
     if extra_info is not None:
         extra_info['num_candidates'] = num_objects
 
-    # Skip the image if there are too many maxima to process
-    if num_objects > max_star_candidates:
+    # Skip the image early if there are too many maxima and no candidate plot was requested
+    if (num_objects > max_star_candidates) and (not show_candidates):
         log.warning('Too many candidate stars to process! {:d}/{:d}'.format(num_objects, max_star_candidates))
         return False
 
@@ -149,8 +150,17 @@ def extractStars(img, img_median=None, mask=None, gamma=1.0, max_star_candidates
     x_init = x_init.flatten() + 0.5
     y_init = y_init.flatten() + 0.5
 
-    # # Plot stars before the PSF fit
-    # plotStars(ff, x, y)
+    # Plot all raw candidates before the PSF fit
+    if show_candidates:
+        plotStars(
+            img, x_init, y_init, bit_depth=bit_depth,
+            title='Star candidates before PSF fitting ({:d})'.format(num_objects)
+        )
+
+    # Skip PSF fitting if the diagnostic plot showed more candidates than the configured limit
+    if num_objects > max_star_candidates:
+        log.warning('Too many candidate stars to process! {:d}/{:d}'.format(num_objects, max_star_candidates))
+        return False
 
     # Fit a PSF to each star on the raw image
     (
@@ -263,7 +273,7 @@ def extractStarsFF(
         max_global_intensity=150,
         neighborhood_size=10, intensity_threshold=18,
         segment_radius=4, roundness_threshold=0.5, max_feature_ratio=0.8,
-        extra_info=None
+        extra_info=None, show_candidates=False
         ):
     """ Extracts stars on a given FF bin by searching for local maxima and applying PSF fit for star 
         confirmation.
@@ -283,6 +293,7 @@ def extractStarsFF(
         flat_struct: [Flat struct] Structure containing the flat field. None by default.
         dark: [ndarray] Dark frame. None by default.
         mask: [ndarray] Mask image. None by default.
+        show_candidates: [bool] Show the raw star candidates before PSF fitting. False by default.
 
     Return:
         x2, y2, background, intensity, fwhm: [list of ndarrays]
@@ -347,7 +358,7 @@ def extractStarsFF(
         neighborhood_size=neighborhood_size, intensity_threshold=intensity_threshold,
         segment_radius=segment_radius, roundness_threshold=roundness_threshold,
         max_feature_ratio=max_feature_ratio, bit_depth=config.bit_depth,
-        extra_info=extra_info
+        extra_info=extra_info, show_candidates=show_candidates
     )
 
     # If the star extraction failed, return an empty list
@@ -797,33 +808,57 @@ def fitPSF(img, img_median, x_init, y_init, gamma=1.0, segment_radius=4, roundne
 
 
 
-def plotStars(ff, x2, y2):
+def plotStars(img, x2, y2, bit_depth=None, title=None):
     """ Plots detected stars on the input image.
+
+    Arguments:
+        img: [ndarray or FF structure] Input image or FF structure containing an average pixel image.
+        x2: [array-like] Star X coordinates.
+        y2: [array-like] Star Y coordinates.
+
+    Keyword arguments:
+        bit_depth: [int] Image bit depth. Inferred from the image data type if not given.
+        title: [str] Optional plot title.
     """
 
+    # Preserve compatibility with callers passing an FF structure
+    if hasattr(img, 'avepixel'):
+        img = img.avepixel
+
+    if bit_depth is None:
+        bit_depth = 8*img.dtype.itemsize
+
     # Plot image with adjusted levels to better see stars
-    plt.imshow(Image.adjustLevels(ff.avepixel, 0, 1.3, 255), cmap='gray')
+    max_level = 2**bit_depth - 1
+    adjusted_img = Image.adjustLevels(img, 0, 1.3, max_level, nbits=bit_depth)
+    fig, ax = plt.subplots()
+    ax.imshow(adjusted_img, cmap='gray')
 
     # Plot stars
     for star in zip(list(y2), list(x2)):
         y, x = star
         c = plt.Circle((x, y), 5, fill=False, color='r')
-        plt.gca().add_patch(c)
+        ax.add_patch(c)
 
-    plt.show()
+    if title is not None:
+        ax.set_title(title)
 
-    plt.clf()
-    plt.close()
+    plt.show(block=True)
+    plt.close(fig)
 
 
 
 
-def extractStarsAndSave(config, ff_dir):
+def extractStarsAndSave(config, ff_dir, show_candidates=False):
     """ Extract stars in the given folder and save the CALSTARS file. 
     
     Arguments:
         config: [config object] configuration object (loaded from the .config file)
         ff_dir: [str] Path to directory where FF files are.
+
+    Keyword arguments:
+        show_candidates: [bool] Show raw star candidates before PSF fitting and process FF files
+            sequentially. False by default.
 
     Return:
         star_list: [list] A list of [ff_name, star_data] entries, where star_data contains a list of 
@@ -852,20 +887,21 @@ def extractStarsAndSave(config, ff_dir):
         extraction_list.append(ff_name)
 
 
-    # If just one file is given, run the extraction on it instead of using the QueuedPool
+    # Interactive plots must run in the main process, so candidate display uses sequential extraction
     workpool = None
-    if len(extraction_list) == 1:
-        ff_name = extraction_list[0]
+    if (len(extraction_list) == 1) or show_candidates:
+        results = []
 
-        log.info('Extracting stars from ' + ff_name)
+        for ff_name in extraction_list:
+            log.info('Extracting stars from ' + ff_name)
 
-        # Run the extraction
-        result = extractStarsFF(
-            ff_dir, ff_name, flat_struct=flat_struct, dark=dark, mask=mask,
-            config=config
-        )
+            # Run the extraction
+            result = extractStarsFF(
+                ff_dir, ff_name, flat_struct=flat_struct, dark=dark, mask=mask,
+                config=config, show_candidates=show_candidates
+            )
 
-        results = [result]
+            results.append(result)
 
 
     else:
@@ -971,6 +1007,9 @@ if __name__ == "__main__":
 
     arg_parser.add_argument('-s', '--showstd', action="store_true", help="""Show a histogram of stddevs of PSFs of all detected stars. """)
 
+    arg_parser.add_argument('--show-candidates', action="store_true", help="""Show raw star candidates
+        before PSF fitting. Files are processed sequentially and each window must be closed to continue. """)
+
     # Parse the command line arguments
     cml_args = arg_parser.parse_args()
 
@@ -991,7 +1030,7 @@ if __name__ == "__main__":
 
 
     # Run extraction and save the resulting CALSTARS file
-    star_list = extractStarsAndSave(config, ff_dir)
+    star_list = extractStarsAndSave(config, ff_dir, show_candidates=cml_args.show_candidates)
 
 
     fwhm_list = []

--- a/RMS/ExtractStars.py
+++ b/RMS/ExtractStars.py
@@ -844,9 +844,19 @@ def plotStars(img, x2, y2, bit_depth=None, title=None, x_fitted=None, y_fitted=N
         else:
             bit_depth = 8
 
-    # Plot image with adjusted levels to better see stars
+    # Automatically stretch the average-pixel background while retaining bright stars
     max_level = 2**bit_depth - 1
-    adjusted_img = Image.adjustLevels(img, 0, 1.3, max_level, nbits=bit_depth)
+    min_level = np.percentile(img, 1.0)
+    max_display_level = np.percentile(img, 99.99)
+
+    # Fall back to the full range for flat images where percentile levels are identical
+    if max_display_level <= min_level:
+        min_level = 0
+        max_display_level = max_level
+
+    adjusted_img = Image.adjustLevels(
+        img, min_level, 1.3, max_display_level, nbits=bit_depth
+    )
     fig, ax = plt.subplots()
     ax.imshow(adjusted_img, cmap='gray')
 

--- a/RMS/ExtractStars.py
+++ b/RMS/ExtractStars.py
@@ -79,7 +79,8 @@ def extractStars(img, img_median=None, mask=None, gamma=1.0, max_star_candidates
             (hot pixels are narrow, while stars are round).
         max_feature_ratio: [float] Maximum ratio between 2 sigma of the star and the image segment area.
         bit_depth: [int] Bit depth of the image. 8 bits by default.
-        show_candidates: [bool] Show the raw star candidates before PSF fitting. False by default.
+        show_candidates: [bool] Show the raw star candidates before PSF fitting and the successfully fitted
+            stars afterwards. False by default.
     
     Return:
         x2, y2, background, intensity, fwhm: [list of ndarrays]
@@ -171,6 +172,14 @@ def extractStars(img, img_median=None, mask=None, gamma=1.0, max_star_candidates
         gamma=gamma,
         segment_radius=segment_radius, roundness_threshold=roundness_threshold, 
         max_feature_ratio=max_feature_ratio, bit_depth=bit_depth
+        )
+
+    # Compare all raw candidates with the stars which passed PSF fitting
+    if show_candidates:
+        plotStars(
+            img, x_init, y_init, bit_depth=bit_depth,
+            title='PSF fitting result ({:d}/{:d} fitted)'.format(len(x_arr), num_objects),
+            x_fitted=x_arr, y_fitted=y_arr
         )
     
     # x_arr, y_arr, amplitude, intensity = list(x), list(y), [], [] # Skip PSF fit
@@ -293,7 +302,8 @@ def extractStarsFF(
         flat_struct: [Flat struct] Structure containing the flat field. None by default.
         dark: [ndarray] Dark frame. None by default.
         mask: [ndarray] Mask image. None by default.
-        show_candidates: [bool] Show the raw star candidates before PSF fitting. False by default.
+        show_candidates: [bool] Show the raw star candidates before PSF fitting and the successfully fitted
+            stars afterwards. False by default.
 
     Return:
         x2, y2, background, intensity, fwhm: [list of ndarrays]
@@ -808,7 +818,7 @@ def fitPSF(img, img_median, x_init, y_init, gamma=1.0, segment_radius=4, roundne
 
 
 
-def plotStars(img, x2, y2, bit_depth=None, title=None):
+def plotStars(img, x2, y2, bit_depth=None, title=None, x_fitted=None, y_fitted=None):
     """ Plots detected stars on the input image.
 
     Arguments:
@@ -820,6 +830,8 @@ def plotStars(img, x2, y2, bit_depth=None, title=None):
         bit_depth: [int] Image bit depth. Inferred for integer images if not given. Floating-point images
             default to 8 bits because their source bit depth cannot be inferred from the data type.
         title: [str] Optional plot title.
+        x_fitted: [array-like] Successfully fitted star X coordinates. None by default.
+        y_fitted: [array-like] Successfully fitted star Y coordinates. None by default.
     """
 
     # Preserve compatibility with callers passing an FF structure
@@ -839,10 +851,21 @@ def plotStars(img, x2, y2, bit_depth=None, title=None):
     ax.imshow(adjusted_img, cmap='gray')
 
     # Plot stars
-    for star in zip(list(y2), list(x2)):
+    for i, star in enumerate(zip(list(y2), list(x2))):
         y, x = star
-        c = plt.Circle((x, y), 5, fill=False, color='r')
+        label = 'Raw candidates' if i == 0 else None
+        c = plt.Circle((x, y), 5, fill=False, color='r', label=label)
         ax.add_patch(c)
+
+    # Mark the successfully fitted stars separately so rejected candidates remain visible in red
+    if (x_fitted is not None) and (y_fitted is not None):
+        ax.plot(
+            list(x_fitted), list(y_fitted), linestyle='None', marker='+', markersize=8,
+            markeredgewidth=1.5, color='lime', label='PSF-fitted stars'
+        )
+
+    if len(x2) or ((x_fitted is not None) and len(x_fitted)):
+        ax.legend(loc='upper right')
 
     if title is not None:
         ax.set_title(title)
@@ -861,8 +884,8 @@ def extractStarsAndSave(config, ff_dir, show_candidates=False):
         ff_dir: [str] Path to directory where FF files are.
 
     Keyword arguments:
-        show_candidates: [bool] Show raw star candidates before PSF fitting and process FF files
-            sequentially. False by default.
+        show_candidates: [bool] Show raw star candidates before PSF fitting, show successfully fitted stars
+            afterwards, and process FF files sequentially. False by default.
 
     Return:
         star_list: [list] A list of [ff_name, star_data] entries, where star_data contains a list of 
@@ -1012,7 +1035,8 @@ if __name__ == "__main__":
     arg_parser.add_argument('-s', '--showstd', action="store_true", help="""Show a histogram of stddevs of PSFs of all detected stars. """)
 
     arg_parser.add_argument('--show-candidates', action="store_true", help="""Show raw star candidates
-        before PSF fitting. Files are processed sequentially and each window must be closed to continue. """)
+        before PSF fitting and successfully fitted stars afterwards. Files are processed sequentially and
+        each window must be closed to continue. """)
 
     # Parse the command line arguments
     cml_args = arg_parser.parse_args()

--- a/RMS/ExtractStars.py
+++ b/RMS/ExtractStars.py
@@ -817,7 +817,8 @@ def plotStars(img, x2, y2, bit_depth=None, title=None):
         y2: [array-like] Star Y coordinates.
 
     Keyword arguments:
-        bit_depth: [int] Image bit depth. Inferred from the image data type if not given.
+        bit_depth: [int] Image bit depth. Inferred for integer images if not given. Floating-point images
+            default to 8 bits because their source bit depth cannot be inferred from the data type.
         title: [str] Optional plot title.
     """
 
@@ -826,7 +827,10 @@ def plotStars(img, x2, y2, bit_depth=None, title=None):
         img = img.avepixel
 
     if bit_depth is None:
-        bit_depth = 8*img.dtype.itemsize
+        if np.issubdtype(img.dtype, np.integer):
+            bit_depth = np.iinfo(img.dtype).bits
+        else:
+            bit_depth = 8
 
     # Plot image with adjusted levels to better see stars
     max_level = 2**bit_depth - 1

--- a/Tests/TestExtractStars.py
+++ b/Tests/TestExtractStars.py
@@ -1,0 +1,135 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+import RMS.ExtractStars as ExtractStars
+
+
+def _singleCandidateImage():
+    """Return a small image with one isolated local maximum."""
+
+    img = np.full((32, 32), 10, dtype=np.float32)
+    img[16, 16] = 255
+
+    return img
+
+
+def _successfulFit(img, img_median, x_init, y_init, **kwargs):
+    """Return valid PSF-fit data for every supplied candidate."""
+
+    count = len(x_init)
+
+    return (
+        list(x_init), list(y_init), [100]*count, [200]*count,
+        [1]*count, [1]*count, [0]*count, [10]*count, [0]*count
+    )
+
+
+def testCandidatesAreShownBeforePsfFit(monkeypatch):
+    events = []
+    extra_info = {}
+
+    def recordCandidates(img, x_data, y_data, **kwargs):
+        events.append(('plot', len(x_data), len(y_data)))
+
+    def recordFit(*args, **kwargs):
+        events.append(('fit', len(args[2]), len(args[3])))
+        return _successfulFit(*args, **kwargs)
+
+    monkeypatch.setattr(ExtractStars, 'plotStars', recordCandidates)
+    monkeypatch.setattr(ExtractStars, 'fitPSF', recordFit)
+
+    status = ExtractStars.extractStars(
+        _singleCandidateImage(), border=1, neighborhood_size=3,
+        extra_info=extra_info, show_candidates=True
+    )
+
+    assert status is not False
+    assert events == [
+        ('plot', extra_info['num_candidates'], extra_info['num_candidates']),
+        ('fit', extra_info['num_candidates'], extra_info['num_candidates'])
+    ]
+
+
+def testOverLimitCandidatesAreShownThenRejected(monkeypatch):
+    candidate_counts = []
+    extra_info = {}
+
+    def recordCandidates(img, x_data, y_data, **kwargs):
+        candidate_counts.append(len(x_data))
+
+    def unexpectedFit(*args, **kwargs):
+        raise AssertionError('PSF fitting must not run for an over-limit candidate set')
+
+    monkeypatch.setattr(ExtractStars, 'plotStars', recordCandidates)
+    monkeypatch.setattr(ExtractStars, 'fitPSF', unexpectedFit)
+
+    status = ExtractStars.extractStars(
+        _singleCandidateImage(), border=1, neighborhood_size=3,
+        max_star_candidates=0, extra_info=extra_info, show_candidates=True
+    )
+
+    assert status is False
+    assert candidate_counts == [extra_info['num_candidates']]
+
+
+def testDefaultOverLimitRejectionDoesNotPlot(monkeypatch):
+    def unexpectedCall(*args, **kwargs):
+        raise AssertionError('Plotting and fitting must not run after the default early rejection')
+
+    monkeypatch.setattr(ExtractStars, 'plotStars', unexpectedCall)
+    monkeypatch.setattr(ExtractStars, 'fitPSF', unexpectedCall)
+
+    status = ExtractStars.extractStars(
+        _singleCandidateImage(), border=1, neighborhood_size=3, max_star_candidates=0
+    )
+
+    assert status is False
+
+
+def testCandidateDisplayProcessesFfFilesSequentially(monkeypatch, tmp_path):
+    extraction_calls = []
+
+    config = SimpleNamespace(stationID='XX0001', height=32, width=32)
+
+    monkeypatch.setattr(ExtractStars, 'loadImageCalibration', lambda *args: (None, None, None))
+    monkeypatch.setattr(ExtractStars.os, 'listdir', lambda path: ['FF_b.bin', 'FF_a.bin'])
+    monkeypatch.setattr(ExtractStars.FFfile, 'validFFName', lambda name: True)
+    monkeypatch.setattr(ExtractStars.CALSTARS, 'writeCALSTARS', lambda *args: None)
+
+    class UnexpectedPool(object):
+        def __init__(self, *args, **kwargs):
+            raise AssertionError('Candidate display must not create a worker pool')
+
+    def extractFf(ff_dir, ff_name, **kwargs):
+        extraction_calls.append((ff_name, kwargs['show_candidates']))
+        return ff_name, [1], [2], [3], [4], [5], [6], [7], [8]
+
+    monkeypatch.setattr(ExtractStars, 'QueuedPool', UnexpectedPool)
+    monkeypatch.setattr(ExtractStars, 'extractStarsFF', extractFf)
+
+    star_list = ExtractStars.extractStarsAndSave(config, str(tmp_path), show_candidates=True)
+
+    assert extraction_calls == [('FF_a.bin', True), ('FF_b.bin', True)]
+    assert [entry[0] for entry in star_list] == ['FF_a.bin', 'FF_b.bin']
+
+
+def testPlotStarsSupportsFfStructuresAndBitDepth(monkeypatch):
+    adjust_call = {}
+    img = np.zeros((8, 8), dtype=np.uint16)
+    ff = SimpleNamespace(avepixel=img)
+
+    def adjustLevels(input_img, minv, gamma, maxv, nbits=None):
+        adjust_call['img'] = input_img
+        adjust_call['maxv'] = maxv
+        adjust_call['nbits'] = nbits
+        return input_img
+
+    monkeypatch.setattr(ExtractStars.Image, 'adjustLevels', adjustLevels)
+    monkeypatch.setattr(ExtractStars.plt, 'show', lambda **kwargs: None)
+
+    ExtractStars.plotStars(ff, [3], [4], title='Candidates')
+
+    assert adjust_call['img'] is img
+    assert adjust_call['maxv'] == 2**16 - 1
+    assert adjust_call['nbits'] == 16

--- a/Tests/TestExtractStars.py
+++ b/Tests/TestExtractStars.py
@@ -30,7 +30,8 @@ def testCandidatesAreShownBeforePsfFit(monkeypatch):
     extra_info = {}
 
     def recordCandidates(img, x_data, y_data, **kwargs):
-        events.append(('plot', len(x_data), len(y_data)))
+        fitted_count = len(kwargs['x_fitted']) if kwargs.get('x_fitted') is not None else 0
+        events.append(('plot', len(x_data), len(y_data), fitted_count))
 
     def recordFit(*args, **kwargs):
         events.append(('fit', len(args[2]), len(args[3])))
@@ -46,8 +47,10 @@ def testCandidatesAreShownBeforePsfFit(monkeypatch):
 
     assert status is not False
     assert events == [
-        ('plot', extra_info['num_candidates'], extra_info['num_candidates']),
-        ('fit', extra_info['num_candidates'], extra_info['num_candidates'])
+        ('plot', extra_info['num_candidates'], extra_info['num_candidates'], 0),
+        ('fit', extra_info['num_candidates'], extra_info['num_candidates']),
+        ('plot', extra_info['num_candidates'], extra_info['num_candidates'],
+         extra_info['num_candidates'])
     ]
 
 
@@ -150,3 +153,27 @@ def testPlotStarsDefaultsFloatingImagesToEightBits(monkeypatch):
     ExtractStars.plotStars(img, [3], [4], title='Candidates')
 
     assert adjust_call == {'maxv': 2**8 - 1, 'nbits': 8}
+
+
+def testPlotStarsMarksFittedPositions(monkeypatch):
+    plot_data = {}
+    original_subplots = ExtractStars.plt.subplots
+
+    def recordSubplots():
+        fig, ax = original_subplots()
+        plot_data['ax'] = ax
+        return fig, ax
+
+    monkeypatch.setattr(ExtractStars.plt, 'subplots', recordSubplots)
+    monkeypatch.setattr(ExtractStars.plt, 'show', lambda **kwargs: None)
+
+    ExtractStars.plotStars(
+        np.zeros((8, 8), dtype=np.uint8), [3, 5], [4, 6],
+        x_fitted=[3.25], y_fitted=[4.25]
+    )
+
+    ax = plot_data['ax']
+    assert len(ax.patches) == 2
+    assert len(ax.lines) == 1
+    assert list(ax.lines[0].get_xdata()) == [3.25]
+    assert list(ax.lines[0].get_ydata()) == [4.25]

--- a/Tests/TestExtractStars.py
+++ b/Tests/TestExtractStars.py
@@ -133,3 +133,20 @@ def testPlotStarsSupportsFfStructuresAndBitDepth(monkeypatch):
     assert adjust_call['img'] is img
     assert adjust_call['maxv'] == 2**16 - 1
     assert adjust_call['nbits'] == 16
+
+
+def testPlotStarsDefaultsFloatingImagesToEightBits(monkeypatch):
+    adjust_call = {}
+    img = np.zeros((8, 8), dtype=np.float32)
+
+    def adjustLevels(input_img, minv, gamma, maxv, nbits=None):
+        adjust_call['maxv'] = maxv
+        adjust_call['nbits'] = nbits
+        return input_img
+
+    monkeypatch.setattr(ExtractStars.Image, 'adjustLevels', adjustLevels)
+    monkeypatch.setattr(ExtractStars.plt, 'show', lambda **kwargs: None)
+
+    ExtractStars.plotStars(img, [3], [4], title='Candidates')
+
+    assert adjust_call == {'maxv': 2**8 - 1, 'nbits': 8}

--- a/Tests/TestExtractStars.py
+++ b/Tests/TestExtractStars.py
@@ -155,6 +155,26 @@ def testPlotStarsDefaultsFloatingImagesToEightBits(monkeypatch):
     assert adjust_call == {'maxv': 2**8 - 1, 'nbits': 8}
 
 
+def testPlotStarsAutomaticallyAdjustsBackgroundLevels(monkeypatch):
+    adjust_call = {}
+    img = np.arange(10000, dtype=np.uint16).reshape((100, 100))
+
+    def adjustLevels(input_img, minv, gamma, maxv, nbits=None):
+        adjust_call['minv'] = minv
+        adjust_call['gamma'] = gamma
+        adjust_call['maxv'] = maxv
+        return input_img
+
+    monkeypatch.setattr(ExtractStars.Image, 'adjustLevels', adjustLevels)
+    monkeypatch.setattr(ExtractStars.plt, 'show', lambda **kwargs: None)
+
+    ExtractStars.plotStars(img, [3], [4])
+
+    assert adjust_call['minv'] == np.percentile(img, 1.0)
+    assert adjust_call['gamma'] == 1.3
+    assert adjust_call['maxv'] == np.percentile(img, 99.99)
+
+
 def testPlotStarsMarksFittedPositions(monkeypatch):
     plot_data = {}
     original_subplots = ExtractStars.plt.subplots


### PR DESCRIPTION
## Summary
- add a --show-candidates option to RMS.ExtractStars
- display raw local-maximum candidates before PSF fitting, including over-limit sets
- after fitting, display raw candidates as red circles and accepted PSF fits as green markers
- auto-level the avepixel background from the 1st to 99.99th percentile with a flat-image fallback
- show candidate/fitted counts and a legend in the comparison plot
- process FF files sequentially while interactive candidate windows are enabled
- keep default parallel extraction unchanged
- infer integer image bit depth safely and default floating display images to 8-bit unless specified

## Tests
- pytest -q Tests/TestExtractStars.py (8 passed)
- real-data run on FF_US002B_20260427_084517_340_0752128.fits (256 candidates, 253 fitted)
- python -m compileall -q RMS/ExtractStars.py Tests/TestExtractStars.py
- python -m RMS.ExtractStars --help
- git diff --check