### PR TITLE
Hot pixels: persistent self-maintaining blacklist

### DIFF
--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -559,6 +559,25 @@ class Config:
                                     # measured by SkyFit2's star detection tuner
         self.max_feature_ratio = 0.8 # maximum ratio between 2 sigma of the star and the image segment area
 
+        # Hot pixel blacklist - for cameras with in-camera hot pixel filtering disabled. Detections
+        # which recur at the same pixel across the night are blacklisted in hot_pixels_file
+        # (config dir), removed from CALSTARS, and excluded from the ff_min_stars meteor gate
+        # during capture. The file is re-read on every FF, so external updates (SkyFit priming,
+        # python -m RMS.HotPixels) take effect immediately, even mid-capture.
+        self.hot_pixels_filter = True
+        self.hot_pixels_file = 'hotpixels.json'
+        self.hot_pixels_radius = 2.0 # match/cluster radius in pixels
+        self.hot_pixels_min_count = 15 # a pixel must recur on at least this many FFs...
+        self.hot_pixels_min_frac = 0.01 # ...and on this fraction of the night's star-bearing FFs.
+                                        # Kept low on purpose: the PSF roundness filter hides hot
+                                        # pixels on most FFs and their surfacing rate swings
+                                        # night-to-night (1-10% measured on US005A), so the real
+                                        # discriminators are the coverage/drift/span gates - chance
+                                        # coincidences at one pixel reaching even the min_count
+                                        # floor are Poisson-negligible
+        self.hot_pixels_min_span_minutes = 45.0 # recurrence must span this much of the night
+        self.hot_pixels_max_age_days = 14 # entries unseen for this many days are dropped
+
 
         ##### Calibration
         self.use_flat = False
@@ -1689,6 +1708,27 @@ def parseStarExtraction(config, parser):
 
     if parser.has_option(section, "max_feature_ratio"):
         config.max_feature_ratio = parser.getfloat(section, "max_feature_ratio")
+
+    if parser.has_option(section, "hot_pixels_filter"):
+        config.hot_pixels_filter = parser.getboolean(section, "hot_pixels_filter")
+
+    if parser.has_option(section, "hot_pixels_file"):
+        config.hot_pixels_file = os.path.basename(parser.get(section, "hot_pixels_file"))
+
+    if parser.has_option(section, "hot_pixels_radius"):
+        config.hot_pixels_radius = parser.getfloat(section, "hot_pixels_radius")
+
+    if parser.has_option(section, "hot_pixels_min_count"):
+        config.hot_pixels_min_count = parser.getint(section, "hot_pixels_min_count")
+
+    if parser.has_option(section, "hot_pixels_min_frac"):
+        config.hot_pixels_min_frac = parser.getfloat(section, "hot_pixels_min_frac")
+
+    if parser.has_option(section, "hot_pixels_min_span_minutes"):
+        config.hot_pixels_min_span_minutes = parser.getfloat(section, "hot_pixels_min_span_minutes")
+
+    if parser.has_option(section, "hot_pixels_max_age_days"):
+        config.hot_pixels_max_age_days = parser.getint(section, "hot_pixels_max_age_days")
 
 
 

--- a/RMS/DetectStarsAndMeteors.py
+++ b/RMS/DetectStarsAndMeteors.py
@@ -34,6 +34,7 @@ from RMS.ExtractStars import extractStarsFF
 from RMS.ExtractStarsFrameInterface import extractStarsFrameInterface
 from RMS.Detection import detectMeteors
 from RMS.DetectionTools import loadImageCalibration
+from RMS import HotPixels
 from RMS.QueuedPool import QueuedPool
 from RMS.Logger import LoggingManager, getLogger
 from RMS.Misc import RmsDateTime, setMultiprocessingStartMethod
@@ -224,15 +225,34 @@ def detectStarsAndMeteors(ff_directory, ff_name, config, flat_struct=None, dark=
 
 
     # Run star extraction on FF files
-    star_list = extractStarsFF(ff_directory, ff_name, config=config, 
+    star_list = extractStarsFF(ff_directory, ff_name, config=config,
                                flat_struct=flat_struct, dark=dark, mask=mask)
 
 
-    log.info('Detected stars: ' + str(len(star_list[1])))
+    # Count the stars for the meteor-detection gate, excluding known hot pixels so a field of
+    # blacklisted pixels cannot trigger meteor detection on an otherwise starless image. The full
+    # star list is kept - the end-of-night analysis in saveDetections needs to see the hot pixels
+    # to keep the blacklist fresh, and filters them from CALSTARS there.
+    star_count = len(star_list[1])
+
+    if config.hot_pixels_filter and star_count > 0:
+
+        hp_xy = HotPixels.loadHotPixelCoords(ff_directory, config)
+
+        if len(hp_xy):
+            matched = HotPixels.matchHotPixels(star_list[1], star_list[2], hp_xy,
+                config.hot_pixels_radius)
+            star_count -= int(np.count_nonzero(matched))
+
+    if star_count != len(star_list[1]):
+        log.info('Detected stars: {:d} ({:d} after hot pixel exclusion)'.format(
+            len(star_list[1]), star_count))
+    else:
+        log.info('Detected stars: ' + str(star_count))
 
 
     # Run meteor detection if there are enough stars on the image
-    if len(star_list[1]) >= config.ff_min_stars:
+    if star_count >= config.ff_min_stars:
 
         log.info('At least ' + str(config.ff_min_stars) + ' stars, detecting meteors...')
 
@@ -322,7 +342,8 @@ def saveDetections(detection_results, ff_dir, config, output_suffix=''):
         # Construct the table of the star parameters
         # CALSTARS format: Y(0) X(1) IntensSum(2) Ampltd(3) FWHM(4) BgLvl(5) SNR(6) NSatPx(7)
         # Note: intensity=IntensSum (integrated), amplitude=Ampltd (peak)
-        star_data = zip(y2, x2, intensity, amplitude, fwhm, background, snr, saturated_count)
+        # Materialized to a list - the hot pixel filter below iterates it before writeCALSTARS does
+        star_data = list(zip(y2, x2, intensity, amplitude, fwhm, background, snr, saturated_count))
 
         # Add star info to the star list
         star_list.append([ff_name, star_data])
@@ -361,8 +382,13 @@ def saveDetections(detection_results, ff_dir, config, output_suffix=''):
     if not os.path.exists(ff_dir):
         os.makedirs(ff_dir)
 
+    # Update the hot pixel blacklist from tonight's stationary detections and remove all
+    # blacklisted pixels from the star list before it is written to CALSTARS
+    if config.hot_pixels_filter:
+        star_list = HotPixels.applyHotPixels(star_list, ff_dir, config)
+
     # Write detected stars to the CALSTARS file
-    CALSTARS.writeCALSTARS(star_list, ff_dir, calstars_name, config.stationID, config.height, 
+    CALSTARS.writeCALSTARS(star_list, ff_dir, calstars_name, config.stationID, config.height,
         config.width)
 
     # Generate FTPdetectinfo file name

--- a/RMS/ExtractStars.py
+++ b/RMS/ExtractStars.py
@@ -1080,6 +1080,12 @@ def extractStarsAndSave(config, ff_dir):
     # Generate the name for the CALSTARS file
     calstars_name = 'CALSTARS_' + prefix + '.txt'
 
+    # Update the hot pixel blacklist from this night's stationary detections and remove all
+    # blacklisted pixels before writing CALSTARS - same curation the nightly pipeline applies
+    # in saveDetections, so re-extraction paths (AutoPlatepar, Flux, SkyFit2) stay clean
+    if getattr(config, 'hot_pixels_filter', True):
+        from RMS import HotPixels
+        star_list = HotPixels.applyHotPixels(star_list, ff_dir, config)
 
     # Write detected stars to the CALSTARS file
     CALSTARS.writeCALSTARS(star_list, ff_dir, calstars_name, config.stationID, config.height, config.width)

--- a/RMS/ExtractStarsFrameInterface.py
+++ b/RMS/ExtractStarsFrameInterface.py
@@ -29,9 +29,25 @@ def extractStarsFrameInterface(img_handle, config,
     """
 
     # Extract the stars on the image handle
-    star_list = extractStarsImgHandle(img_handle, config=config, 
+    star_list = extractStarsImgHandle(img_handle, config=config,
                                       flat_struct=flat_struct, dark=dark, mask=mask)
-    
+
+    # Remove detections at blacklisted hot pixel positions. Only the persistent blacklist is
+    # applied - short video runs cannot support the full-night recurrence analysis the FF
+    # pipeline uses to update it
+    if getattr(config, 'hot_pixels_filter', True):
+
+        from RMS import HotPixels
+
+        hp_xy = HotPixels.loadHotPixelCoords(img_handle.dir_path, config)
+
+        if len(hp_xy):
+            star_list, n_removed = HotPixels.filterStarList(star_list, hp_xy,
+                getattr(config, 'hot_pixels_radius', 2.0))
+
+            if n_removed:
+                print("Removed {:d} detections at blacklisted hot pixel positions".format(n_removed))
+
     if save_calstars:
 
         # Construct the name of the CALSTARS file by using the camera code and the time of the first frame

--- a/RMS/HotPixels.py
+++ b/RMS/HotPixels.py
@@ -1,0 +1,616 @@
+# RPi Meteor Station
+# Copyright (C) 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Persistent hot pixel blacklist.
+
+Cameras with in-camera hot pixel filtering disabled produce constant bright pixels which the star
+extractor cannot distinguish from stars on a single FF file. Across a night they are trivially
+separable: real stars drift at the sidereal rate (tens of pixels per hour), while hot pixels recur
+at the same sub-pixel position for hours.
+
+The blacklist lives in a small JSON file (config.hot_pixels_file, resolved night-dir-first with the
+config directory as the fallback, like the mask). It is consulted live during capture so a field of
+hot pixels cannot trip the ff_min_stars meteor-detection gate on an otherwise starless image, and it
+is rebuilt every night from the full star list before the CALSTARS file is written: newly found
+stationary detections are added, entries seen again are refreshed, and entries with no detections
+for hot_pixels_max_age_days are dropped. No manual curation is needed.
+
+A star very close to the celestial pole is the one celestial source that could look stationary, but
+with the default gates (recurrence at one spot in >=20% of the night's FFs over >=45 min within a
+~2 px radius) even Polaris drifts out of the matching circle, so only true sensor defects qualify.
+"""
+
+from __future__ import print_function, division, absolute_import
+
+import os
+import sys
+import json
+import datetime
+
+import numpy as np
+
+from RMS.Formats.FFfile import filenameToDatetime
+from RMS.Logger import getLogger
+from RMS.Misc import RmsDateTime
+
+log = getLogger("rmslogger")
+
+
+DATE_FMT = "%Y-%m-%d"
+
+
+def hotPixelFilePath(dir_path, config):
+    """ Resolve the hot pixel file path, night directory first, config directory as fallback.
+
+    Return:
+        path: [str] Path to an existing hot pixel file, or None if none exists.
+    """
+
+    # getattr guards keep this working with stale unpickled config objects predating the feature
+    file_name = getattr(config, 'hot_pixels_file', 'hotpixels.json')
+
+    for candidate_dir in [dir_path, getattr(config, 'config_file_path', None)]:
+
+        if candidate_dir is None:
+            continue
+
+        path = os.path.join(candidate_dir, file_name)
+
+        if os.path.isfile(path):
+            return path
+
+    return None
+
+
+def loadHotPixels(dir_path, config):
+    """ Load the hot pixel data structure.
+
+    Return:
+        hp_data: [dict] {"version": 1, "updated": ..., "pixels": [...]}. An empty structure is
+            returned if no file exists or it cannot be parsed.
+    """
+
+    empty = {"version": 1, "updated": None, "pixels": []}
+
+    path = hotPixelFilePath(dir_path, config)
+
+    if path is None:
+        return empty
+
+    try:
+        with open(path) as f:
+            hp_data = json.load(f)
+
+    except (ValueError, OSError) as e:
+        log.warning("Could not read hot pixel file {:s}: {:s}".format(path, repr(e)))
+        return empty
+
+    if not isinstance(hp_data.get("pixels"), list):
+        return empty
+
+    return hp_data
+
+
+def saveHotPixels(hp_data, dir_path, config):
+    """ Atomically write the hot pixel data structure to dir_path. """
+
+    hp_data["updated"] = RmsDateTime.utcnow().isoformat()
+
+    path = os.path.join(dir_path, getattr(config, 'hot_pixels_file', 'hotpixels.json'))
+    tmp_path = path + ".tmp"
+
+    try:
+        with open(tmp_path, "w") as f:
+            json.dump(hp_data, f, indent=2)
+
+        os.replace(tmp_path, path)
+
+    except OSError as e:
+        log.warning("Could not write hot pixel file {:s}: {:s}".format(path, repr(e)))
+
+
+def hotPixelCoords(hp_data):
+    """ Extract an Nx2 array of (x, y) coordinates from the hot pixel data structure. """
+
+    pixels = hp_data.get("pixels", [])
+
+    if not pixels:
+        return np.empty((0, 2))
+
+    return np.array([[p["x"], p["y"]] for p in pixels], dtype=np.float64)
+
+
+def loadHotPixelCoords(dir_path, config):
+    """ Load just the blacklisted (x, y) coordinates - the live capture-time entry point. """
+
+    return hotPixelCoords(loadHotPixels(dir_path, config))
+
+
+def matchHotPixels(x_arr, y_arr, hp_xy, radius):
+    """ Match detections against the blacklist.
+
+    Arguments:
+        x_arr, y_arr: [list/ndarray] Detection coordinates.
+        hp_xy: [ndarray] Nx2 array of blacklisted (x, y) positions.
+        radius: [float] Match radius in pixels.
+
+    Return:
+        matched: [ndarray of bool] True for every detection within radius of any blacklisted pixel.
+    """
+
+    x_arr = np.asarray(x_arr, dtype=np.float64)
+    y_arr = np.asarray(y_arr, dtype=np.float64)
+
+    if len(hp_xy) == 0 or len(x_arr) == 0:
+        return np.zeros(len(x_arr), dtype=bool)
+
+    dx = x_arr[:, None] - hp_xy[None, :, 0]
+    dy = y_arr[:, None] - hp_xy[None, :, 1]
+
+    return np.any(dx**2 + dy**2 <= radius**2, axis=1)
+
+
+def _ffTime(ff_name):
+    """ FF file name -> datetime, or None if the name cannot be parsed. """
+
+    try:
+        return filenameToDatetime(ff_name)
+
+    except (ValueError, IndexError, TypeError):
+        return None
+
+
+# A cluster must have detections in at least this many quarters of the observed night. A star
+# drifting slowly through the match circle (e.g. near the celestial pole) produces one contiguous
+# block of hits confined to a single quarter; a hot pixel fires throughout the night, clouds
+# included, because it is a sensor defect
+MIN_NIGHT_QUARTERS = 3
+
+def findStationaryDetections(star_list, config):
+    """ Find detections which recur at the same pixel position across the night.
+
+    Verified against a real US005A night (2026-08-18, in-camera filtering disabled): the two
+    genuine hot pixels recur on ~9% of FFs but across the whole night, while a slow near-pole star
+    produced MORE within-radius hits (~380) confined to one ~65 min window. Raw counts therefore
+    cannot separate the two - the temporal structure (quarter coverage + net drift) can.
+
+    Arguments:
+        star_list: [list] CALSTARS-style list of [ff_name, rows] pairs, where each row starts with
+            (y, x, ...).
+        config: [Config]
+
+    Return:
+        clusters: [list of dict] One entry per hot pixel candidate:
+            {"x", "y", "n_det", "n_ff", "span_minutes"}
+    """
+
+    radius = config.hot_pixels_radius
+
+    # Flatten all detections; remember which FF each came from
+    det_x, det_y, det_ff = [], [], []
+    ff_times = {}
+
+    for ff_name, rows in star_list:
+
+        rows = list(rows)
+
+        if not rows:
+            continue
+
+        ff_times[ff_name] = _ffTime(ff_name)
+
+        for row in rows:
+            det_y.append(float(row[0]))
+            det_x.append(float(row[1]))
+            det_ff.append(ff_name)
+
+    n_ff_total = len(ff_times)
+
+    valid_times = [t for t in ff_times.values() if t is not None]
+
+    if n_ff_total == 0 or len(valid_times) < 2:
+        return []
+
+    night_t0 = min(valid_times)
+    night_t1 = max(valid_times)
+
+    det_x = np.array(det_x)
+    det_y = np.array(det_y)
+
+    # A pixel must recur in a meaningful fraction of the night's star-bearing FFs to qualify.
+    # The absolute floor protects short or mostly cloudy nights from promoting noise.
+    min_hits = max(config.hot_pixels_min_count, int(np.ceil(config.hot_pixels_min_frac*n_ff_total)))
+
+    # Bin detections on an integer pixel grid; sub-pixel jitter of a hot pixel can split it across
+    # adjacent bins, so each candidate absorbs its 8 neighbours before the radius test
+    bins = {}
+    for i in range(len(det_x)):
+        key = (int(round(det_x[i])), int(round(det_y[i])))
+        bins.setdefault(key, []).append(i)
+
+    reach = max(1, int(np.ceil(radius)))
+    consumed = np.zeros(len(det_x), dtype=bool)
+    clusters = []
+
+    # Visit the densest bins first so each hot pixel is claimed by its own centre bin
+    for key in sorted(bins, key=lambda k: len(bins[k]), reverse=True):
+
+        candidates = []
+        for dx_bin in range(-reach, reach + 1):
+            for dy_bin in range(-reach, reach + 1):
+                candidates.extend(bins.get((key[0] + dx_bin, key[1] + dy_bin), []))
+
+        candidates = [i for i in candidates if not consumed[i]]
+
+        if len(candidates) < min_hits:
+            continue
+
+        idx = np.array(candidates)
+        cx = np.median(det_x[idx])
+        cy = np.median(det_y[idx])
+
+        # Keep only detections truly within the match radius of the cluster centre
+        in_radius = (det_x[idx] - cx)**2 + (det_y[idx] - cy)**2 <= radius**2
+        idx = idx[in_radius]
+
+        # Count distinct FFs - multiple detections on one FF must not inflate the recurrence
+        cluster_ffs = set(det_ff[i] for i in idx)
+
+        if len(cluster_ffs) < min_hits:
+            continue
+
+        # A real star drifts through the match circle in minutes; require the recurrence to span
+        # a large part of the night
+        times = [ff_times[ff] for ff in cluster_ffs if ff_times[ff] is not None]
+
+        if len(times) < 2:
+            continue
+
+        span_minutes = (max(times) - min(times)).total_seconds()/60
+
+        if span_minutes < config.hot_pixels_min_span_minutes:
+            continue
+
+        # Require detections spread across the night - a slow-moving star (e.g. near the pole)
+        # can rack up an hour of hits inside the match circle, but only as one contiguous block
+        night_span_s = (night_t1 - night_t0).total_seconds()
+        quarters = set()
+        for t in times:
+            q = int(4*(t - night_t0).total_seconds()/(night_span_s + 1e-9))
+            quarters.add(min(q, 3))
+
+        if len(quarters) < MIN_NIGHT_QUARTERS:
+            continue
+
+        # Net drift test: order the cluster's detections by time and compare the median position
+        # of the first and last thirds. A hot pixel stays put (sub-pixel jitter only); a star
+        # crosses the match circle, displacing by ~the circle diameter
+        idx_times = np.array([
+            (ff_times[det_ff[i]] - night_t0).total_seconds() if ff_times[det_ff[i]] is not None
+            else -1.0 for i in idx])
+        timed = idx[idx_times >= 0]
+        timed = timed[np.argsort(idx_times[idx_times >= 0])]
+
+        third = max(1, len(timed)//3)
+        dx_net = np.median(det_x[timed[-third:]]) - np.median(det_x[timed[:third]])
+        dy_net = np.median(det_y[timed[-third:]]) - np.median(det_y[timed[:third]])
+
+        if dx_net**2 + dy_net**2 > (radius/2)**2:
+            continue
+
+        consumed[idx] = True
+
+        clusters.append({
+            "x": round(float(np.median(det_x[idx])), 2),
+            "y": round(float(np.median(det_y[idx])), 2),
+            "n_det": int(len(idx)),
+            "n_ff": int(len(cluster_ffs)),
+            "span_minutes": round(span_minutes, 1),
+        })
+
+    return clusters
+
+
+def updateHotPixelList(hp_data, clusters, night_date, config):
+    """ Merge tonight's stationary clusters into the persistent list and age out stale entries.
+
+    Reprocessing an old night is safe: last_seen only ever moves forward (max-merge), and ageing is
+    measured relative to the night being processed, so an old night can never age out entries that
+    a newer night has refreshed.
+
+    Arguments:
+        hp_data: [dict] Existing hot pixel structure.
+        clusters: [list of dict] Output of findStationaryDetections.
+        night_date: [datetime.date] Date of the night being processed.
+        config: [Config]
+
+    Return:
+        hp_data: [dict] Updated structure.
+    """
+
+    radius = config.hot_pixels_radius
+    night_str = night_date.strftime(DATE_FMT)
+
+    pixels = list(hp_data.get("pixels", []))
+
+    unmatched_clusters = list(clusters)
+
+    for p in pixels:
+
+        # Find the closest cluster matching this existing entry
+        best = None
+        for c in unmatched_clusters:
+            if (c["x"] - p["x"])**2 + (c["y"] - p["y"])**2 <= radius**2:
+                best = c
+                break
+
+        if best is not None:
+
+            unmatched_clusters.remove(best)
+
+            # Refresh the position and the last-seen date (never move last_seen backwards)
+            p["x"], p["y"] = best["x"], best["y"]
+            p["nights_seen"] = int(p.get("nights_seen", 0)) + 1
+            p["hits_last_night"] = best["n_ff"]
+
+            try:
+                prev_seen = datetime.datetime.strptime(p["last_seen"], DATE_FMT).date()
+            except (KeyError, ValueError):
+                prev_seen = night_date
+
+            p["last_seen"] = max(prev_seen, night_date).strftime(DATE_FMT)
+
+    # Add newly discovered hot pixels
+    for c in unmatched_clusters:
+        pixels.append({
+            "x": c["x"],
+            "y": c["y"],
+            "first_seen": night_str,
+            "last_seen": night_str,
+            "nights_seen": 1,
+            "hits_last_night": c["n_ff"],
+        })
+
+    # Age out entries not seen for too long (relative to the night being processed, so
+    # reprocessing old data never ages anything)
+    kept = []
+    for p in pixels:
+
+        try:
+            last_seen = datetime.datetime.strptime(p["last_seen"], DATE_FMT).date()
+        except (KeyError, ValueError):
+            last_seen = night_date
+
+        if (night_date - last_seen).days > config.hot_pixels_max_age_days:
+            log.info("Hot pixel ({:.1f}, {:.1f}) not seen since {:s}, removing from the blacklist".format(
+                p["x"], p["y"], p["last_seen"]))
+        else:
+            kept.append(p)
+
+    hp_data["pixels"] = kept
+
+    return hp_data
+
+
+def filterStarList(star_list, hp_xy, radius):
+    """ Remove all star rows within radius of any blacklisted pixel.
+
+    Arguments:
+        star_list: [list] CALSTARS-style list of [ff_name, rows] pairs, rows starting with (y, x).
+
+    Return:
+        filtered: [list] Same structure with matching rows removed (FF entries left with no stars
+            are dropped, matching writeCALSTARS's expectations).
+        n_removed: [int] Number of rows removed.
+    """
+
+    if len(hp_xy) == 0:
+        return star_list, 0
+
+    filtered = []
+    n_removed = 0
+
+    for ff_name, rows in star_list:
+
+        rows = list(rows)
+
+        if not rows:
+            continue
+
+        ys = [row[0] for row in rows]
+        xs = [row[1] for row in rows]
+
+        matched = matchHotPixels(xs, ys, hp_xy, radius)
+        n_removed += int(np.count_nonzero(matched))
+
+        kept_rows = [row for row, m in zip(rows, matched) if not m]
+
+        if kept_rows:
+            filtered.append([ff_name, kept_rows])
+
+    return filtered, n_removed
+
+
+def applyHotPixels(star_list, night_dir, config):
+    """ Nightly entry point: analyze the night, update the persistent blacklist, filter the stars.
+
+    The master list in the config directory is updated and an audit copy is written into the night
+    directory, so archived nights record exactly which pixels were blacklisted when they were
+    processed.
+
+    Arguments:
+        star_list: [list] CALSTARS-style list of [ff_name, rows] pairs (rows must be materialized
+            lists, not generators).
+        night_dir: [str] Path to the night directory.
+        config: [Config]
+
+    Return:
+        star_list: [list] Filtered star list, safe to pass to writeCALSTARS.
+    """
+
+    # Derive the night date from the earliest FF file
+    times = [t for t in (_ffTime(ff_name) for ff_name, _ in star_list) if t is not None]
+
+    if not times:
+        return star_list
+
+    night_date = min(times).date()
+
+    # Load the master list (config dir; the night dir has no copy yet at this point)
+    hp_data = loadHotPixels(night_dir, config)
+
+    # Find tonight's stationary detections and merge them in
+    clusters = findStationaryDetections(star_list, config)
+
+    if clusters:
+        log.info("Found {:d} stationary (hot pixel) positions: {:s}".format(
+            len(clusters), ", ".join("({:.1f}, {:.1f}) on {:d} FFs".format(
+                c["x"], c["y"], c["n_ff"]) for c in clusters)))
+
+    hp_data = updateHotPixelList(hp_data, clusters, night_date, config)
+
+    # Persist the master list and an audit copy in the night dir
+    if config.config_file_path:
+        saveHotPixels(hp_data, config.config_file_path, config)
+
+    saveHotPixels(hp_data, night_dir, config)
+
+    # Filter the night's stars with the updated list
+    hp_xy = hotPixelCoords(hp_data)
+    star_list, n_removed = filterStarList(star_list, hp_xy, config.hot_pixels_radius)
+
+    if n_removed:
+        log.info("Removed {:d} hot pixel detections from CALSTARS ({:d} blacklisted pixels)".format(
+            n_removed, len(hp_xy)))
+
+    return star_list
+
+
+def primeFromCALSTARS(night_dir, config):
+    """ Prime or refresh the master blacklist from an already-processed night's CALSTARS file.
+
+    Runs the same stationary-detection analysis the nightly pipeline runs and merges the result
+    into the master list in the config directory. Useful for bootstrapping the list from an
+    archived night (e.g. one processed before the filter existed) without waiting for the next
+    capture - the live gate picks the file up on the next FF, even mid-capture.
+
+    Return:
+        clusters: [list of dict] The stationary clusters found, or None if no CALSTARS file exists.
+    """
+
+    from RMS.Formats import CALSTARS as CALSTARSFormat
+
+    calstars_files = [f for f in sorted(os.listdir(night_dir))
+        if f.startswith('CALSTARS') and f.endswith('.txt')]
+
+    if not calstars_files:
+        return None
+
+    calstars_data = CALSTARSFormat.readCALSTARS(night_dir, calstars_files[0])
+
+    if not calstars_data:
+        return None
+
+    star_list = calstars_data[0]
+
+    # Derive the night date from the earliest FF entry
+    times = [t for t in (_ffTime(ff_name) for ff_name, _ in star_list) if t is not None]
+
+    if not times:
+        return None
+
+    clusters = findStationaryDetections(star_list, config)
+
+    hp_data = loadHotPixels(config.config_file_path, config)
+    hp_data = updateHotPixelList(hp_data, clusters, min(times).date(), config)
+
+    saveHotPixels(hp_data, config.config_file_path, config)
+
+    # Also drop a copy into the night dir - tools opened on the night dir (e.g. SkyFit2 loading
+    # the night's archived .config copy) resolve the blacklist night-dir-first
+    saveHotPixels(hp_data, night_dir, config)
+
+    return clusters
+
+
+if __name__ == "__main__":
+
+    import argparse
+
+    import RMS.ConfigReader as cr
+
+    arg_parser = argparse.ArgumentParser(description="Manage the persistent hot pixel blacklist. "
+        "With no arguments, lists the current blacklist.")
+
+    arg_parser.add_argument('-p', '--prime', metavar='NIGHT_DIR', type=str,
+        help="Prime/refresh the blacklist from the CALSTARS file in the given night directory.")
+
+    arg_parser.add_argument('-r', '--remove', nargs=2, metavar=('X', 'Y'), type=float,
+        help="Remove the blacklist entry within the match radius of the given X Y position.")
+
+    arg_parser.add_argument('-c', '--config', nargs=1, metavar='CONFIG_PATH', type=str,
+        help="Path to a config file which will be used instead of the default one.")
+
+    cml_args = arg_parser.parse_args()
+
+    config = cr.loadConfigFromDirectory(cml_args.config,
+        cml_args.prime if cml_args.prime else os.getcwd())
+
+    master_path = os.path.join(config.config_file_path, config.hot_pixels_file)
+
+    if cml_args.prime:
+
+        clusters = primeFromCALSTARS(os.path.abspath(cml_args.prime), config)
+
+        if clusters is None:
+            print("No usable CALSTARS file found in {:s}".format(cml_args.prime))
+            sys.exit(1)
+
+        print("Found {:d} stationary (hot pixel) positions:".format(len(clusters)))
+        for c in clusters:
+            print("  ({:7.2f}, {:7.2f})  on {:d} FFs over {:.0f} min".format(
+                c["x"], c["y"], c["n_ff"], c["span_minutes"]))
+        print("Master list updated: {:s}".format(master_path))
+
+    elif cml_args.remove:
+
+        rx, ry = cml_args.remove
+        hp_data = loadHotPixels(config.config_file_path, config)
+
+        kept = [p for p in hp_data["pixels"]
+            if (p["x"] - rx)**2 + (p["y"] - ry)**2 > config.hot_pixels_radius**2]
+
+        n_removed = len(hp_data["pixels"]) - len(kept)
+        hp_data["pixels"] = kept
+
+        saveHotPixels(hp_data, config.config_file_path, config)
+        print("Removed {:d} entries within {:.1f} px of ({:.1f}, {:.1f})".format(
+            n_removed, config.hot_pixels_radius, rx, ry))
+
+    else:
+
+        hp_data = loadHotPixels(config.config_file_path, config)
+
+        if not hp_data["pixels"]:
+            print("Blacklist is empty ({:s})".format(master_path))
+        else:
+            print("{:d} blacklisted pixels in {:s}:".format(len(hp_data["pixels"]), master_path))
+            print("  {:>8s} {:>8s}  {:>10s} {:>10s} {:>7s} {:>9s}".format(
+                "X", "Y", "first", "last", "nights", "hits"))
+            for p in hp_data["pixels"]:
+                print("  {:8.2f} {:8.2f}  {:>10s} {:>10s} {:7d} {:9d}".format(
+                    p["x"], p["y"], p.get("first_seen", "?"), p.get("last_seen", "?"),
+                    p.get("nights_seen", 0), p.get("hits_last_night", 0)))

--- a/Tests/test_hot_pixels.py
+++ b/Tests/test_hot_pixels.py
@@ -1,0 +1,261 @@
+""" Tests for the persistent hot pixel blacklist (RMS/HotPixels.py). """
+
+import datetime
+import json
+import os
+
+import numpy as np
+import pytest
+
+from RMS import HotPixels
+
+
+class HPConfig(object):
+    """ Minimal config stub with the hot pixel and file-resolution attributes. """
+
+    def __init__(self, config_dir=None):
+        self.hot_pixels_filter = True
+        self.hot_pixels_file = 'hotpixels.json'
+        self.hot_pixels_radius = 2.0
+        self.hot_pixels_min_count = 15
+        self.hot_pixels_min_frac = 0.01
+        self.hot_pixels_min_span_minutes = 45.0
+        self.hot_pixels_max_age_days = 14
+        self.config_file_path = config_dir
+
+
+def makeFFName(dt):
+    return "FF_US005A_{:s}_0000000.fits".format(dt.strftime("%Y%m%d_%H%M%S_%f")[:-3])
+
+
+def makeNight(n_ff=240, start=None, hot_pixels=(), hot_jitter=0.3, drift_px_per_min=0.5,
+        hot_ff_slice=None, seed=1):
+    """ Build a synthetic CALSTARS-style star list: rows are (y, x, intensity, amplitude, fwhm,
+        bg, snr, nsat). One FF per minute. Real stars drift; hot pixels recur with sub-pixel
+        jitter.
+    """
+
+    rng = np.random.RandomState(seed)
+
+    if start is None:
+        start = datetime.datetime(2026, 8, 25, 20, 30, 0)
+
+    star_list = []
+
+    for i in range(n_ff):
+
+        dt = start + datetime.timedelta(minutes=i)
+        rows = []
+
+        # Drifting "real" stars
+        for s in range(5):
+            x = 100.0 + 80*s + drift_px_per_min*i
+            y = 150.0 + 60*s + 0.3*drift_px_per_min*i
+            rows.append((y, x, 500, 50, 2.5, 30, 10, 0))
+
+        # Hot pixels: same spot every FF (within jitter)
+        in_slice = hot_ff_slice is None or (hot_ff_slice[0] <= i < hot_ff_slice[1])
+        if in_slice:
+            for hx, hy in hot_pixels:
+                rows.append((hy + hot_jitter*rng.uniform(-1, 1),
+                             hx + hot_jitter*rng.uniform(-1, 1), 800, 200, 1.0, 30, 20, 0))
+
+        star_list.append([makeFFName(dt), rows])
+
+    return star_list
+
+
+def clusterPositions(clusters):
+    return [(c["x"], c["y"]) for c in clusters]
+
+
+def test_hot_pixel_found_drifting_stars_ignored():
+    config = HPConfig()
+    star_list = makeNight(hot_pixels=[(600.4, 400.7)])
+
+    clusters = HotPixels.findStationaryDetections(star_list, config)
+
+    assert len(clusters) == 1
+    cx, cy = clusterPositions(clusters)[0]
+    assert abs(cx - 600.4) < 1.0
+    assert abs(cy - 400.7) < 1.0
+
+
+def test_no_hot_pixels_no_clusters():
+    config = HPConfig()
+    star_list = makeNight(hot_pixels=[])
+
+    assert HotPixels.findStationaryDetections(star_list, config) == []
+
+
+def test_short_recurrence_not_flagged():
+    config = HPConfig()
+
+    # Hot pixel visible for only 20 minutes - below the 45 min span gate
+    star_list = makeNight(hot_pixels=[(600.4, 400.7)], hot_ff_slice=(0, 20))
+
+    assert HotPixels.findStationaryDetections(star_list, config) == []
+
+
+def test_min_count_gate():
+    config = HPConfig()
+
+    # Recurs on only 12/240 FFs - below the absolute floor of 15, even though it spans hours
+    star_list = makeNight(hot_pixels=[(600.4, 400.7)])
+    thinned = []
+    for i, (ff_name, rows) in enumerate(star_list):
+        if i % 20 == 0:
+            thinned.append([ff_name, rows])
+        else:
+            thinned.append([ff_name, [r for r in rows if abs(r[1] - 600.4) > 5]])
+
+    assert HotPixels.findStationaryDetections(thinned, config) == []
+
+
+def test_sparse_recurrence_across_night_is_flagged():
+    config = HPConfig()
+
+    # The PSF roundness filter hides hot pixels on most FFs: only every 4th FF sees it (25 > 15
+    # hits), but the hits cover the whole night - still a hot pixel
+    star_list = makeNight(hot_pixels=[(600.4, 400.7)])
+    thinned = []
+    for i, (ff_name, rows) in enumerate(star_list):
+        if i % 4 == 0:
+            thinned.append([ff_name, rows])
+        else:
+            thinned.append([ff_name, [r for r in rows if abs(r[1] - 600.4) > 5]])
+
+    clusters = HotPixels.findStationaryDetections(thinned, config)
+    assert len(clusters) == 1
+
+
+def test_slow_near_pole_star_not_flagged():
+    config = HPConfig()
+
+    # A near-pole star drifting 0.04 px/min sits inside the 2 px match circle for ~100 min - more
+    # hits than a typical hot pixel, above the span gate, but confined to one contiguous block of
+    # the night (and with a net drift across the circle). Verified failure mode from a real
+    # US005A night: 383 hits in one 65 min window.
+    star_list = []
+    start = datetime.datetime(2026, 8, 25, 20, 30, 0)
+    for i in range(240):
+        dt = start + datetime.timedelta(minutes=i)
+        rows = [(400.0, 550.0 + 0.04*i, 500, 50, 2.5, 30, 10, 0)]
+        star_list.append([makeFFName(dt), rows])
+
+    assert HotPixels.findStationaryDetections(star_list, config) == []
+
+
+def test_multiple_hot_pixels():
+    config = HPConfig()
+    star_list = makeNight(hot_pixels=[(600.4, 400.7), (50.1, 700.9)])
+
+    clusters = HotPixels.findStationaryDetections(star_list, config)
+    positions = sorted(clusterPositions(clusters))
+
+    assert len(clusters) == 2
+    assert abs(positions[0][0] - 50.1) < 1.0
+    assert abs(positions[1][0] - 600.4) < 1.0
+
+
+def test_match_hot_pixels_radius():
+    hp_xy = np.array([[100.0, 200.0]])
+
+    matched = HotPixels.matchHotPixels([100.5, 103.0], [200.5, 200.0], hp_xy, 2.0)
+
+    assert matched.tolist() == [True, False]
+    assert HotPixels.matchHotPixels([], [], hp_xy, 2.0).tolist() == []
+    assert HotPixels.matchHotPixels([1.0], [1.0], np.empty((0, 2)), 2.0).tolist() == [False]
+
+
+def test_filter_star_list():
+    hp_xy = np.array([[600.0, 400.0]])
+    star_list = [
+        ["FF1", [(400.3, 600.2, 1, 1, 1, 1, 1, 0), (100.0, 100.0, 1, 1, 1, 1, 1, 0)]],
+        ["FF2", [(400.1, 599.8, 1, 1, 1, 1, 1, 0)]],
+    ]
+
+    filtered, n_removed = HotPixels.filterStarList(star_list, hp_xy, 2.0)
+
+    assert n_removed == 2
+    # FF2 lost its only star and is dropped entirely
+    assert len(filtered) == 1
+    assert filtered[0][0] == "FF1"
+    assert len(filtered[0][1]) == 1
+    assert filtered[0][1][0][0] == 100.0
+
+
+def test_update_add_refresh_age():
+    config = HPConfig()
+    night1 = datetime.date(2026, 8, 25)
+
+    # New pixel added
+    hp_data = {"version": 1, "updated": None, "pixels": []}
+    clusters = [{"x": 600.4, "y": 400.7, "n_det": 200, "n_ff": 200, "span_minutes": 239.0}]
+    hp_data = HotPixels.updateHotPixelList(hp_data, clusters, night1, config)
+
+    assert len(hp_data["pixels"]) == 1
+    assert hp_data["pixels"][0]["last_seen"] == "2026-08-25"
+    assert hp_data["pixels"][0]["nights_seen"] == 1
+
+    # Seen again the next night - refreshed
+    night2 = datetime.date(2026, 8, 26)
+    hp_data = HotPixels.updateHotPixelList(hp_data, clusters, night2, config)
+
+    assert len(hp_data["pixels"]) == 1
+    assert hp_data["pixels"][0]["last_seen"] == "2026-08-26"
+    assert hp_data["pixels"][0]["nights_seen"] == 2
+
+    # Reprocessing an older night must not roll last_seen back or age anything out
+    hp_data = HotPixels.updateHotPixelList(hp_data, clusters, night1, config)
+    assert hp_data["pixels"][0]["last_seen"] == "2026-08-26"
+
+    # Not seen for longer than max_age_days - aged out
+    night_late = night2 + datetime.timedelta(days=config.hot_pixels_max_age_days + 1)
+    hp_data = HotPixels.updateHotPixelList(hp_data, [], night_late, config)
+
+    assert hp_data["pixels"] == []
+
+
+def test_apply_hot_pixels_end_to_end(tmp_path):
+    config_dir = tmp_path/"station"
+    night_dir = tmp_path/"night"
+    config_dir.mkdir()
+    night_dir.mkdir()
+
+    config = HPConfig(config_dir=str(config_dir))
+    star_list = makeNight(hot_pixels=[(600.4, 400.7)])
+    n_rows_before = sum(len(rows) for _, rows in star_list)
+
+    filtered = HotPixels.applyHotPixels(star_list, str(night_dir), config)
+
+    # All ~240 hot pixel rows removed, drifting stars untouched
+    n_rows_after = sum(len(rows) for _, rows in filtered)
+    assert n_rows_before - n_rows_after == 240
+
+    # Master list and the night-dir audit copy were written
+    for d in [config_dir, night_dir]:
+        with open(os.path.join(str(d), config.hot_pixels_file)) as f:
+            hp_data = json.load(f)
+        assert len(hp_data["pixels"]) == 1
+        assert abs(hp_data["pixels"][0]["x"] - 600.4) < 1.0
+
+    # The live gate now sees the blacklist via the config-dir fallback
+    hp_xy = HotPixels.loadHotPixelCoords(str(tmp_path/"nonexistent"), config)
+    assert len(hp_xy) == 1
+
+
+def test_load_missing_and_corrupt(tmp_path):
+    config = HPConfig(config_dir=str(tmp_path))
+
+    assert HotPixels.loadHotPixels(str(tmp_path), config)["pixels"] == []
+
+    with open(str(tmp_path/"hotpixels.json"), "w") as f:
+        f.write("not json{")
+
+    assert HotPixels.loadHotPixels(str(tmp_path), config)["pixels"] == []
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
For cameras with in-camera hot/stuck pixel filtering disabled. Detections recurring at the same pixel across the night — spread over ≥3 quarters of it, with no net drift — are blacklisted in `hotpixels.json`, removed from CALSTARS, and excluded from the `ff_min_stars` meteor gate live during capture. The file is re-read on every FF, so priming or manual edits apply mid-capture; entries unseen for 14 days age out.

- `RMS/HotPixels.py`: detection, persistence, matching; CLI (`python -m RMS.HotPixels` to list, `-p <night_dir>` to prime from CALSTARS, `-r X Y` to remove)
- Pipeline hooks in `DetectStarsAndMeteors` (live gate + nightly update), `ExtractStars.extractStarsAndSave`, `ExtractStarsFrameInterface` — all CALSTARS writers curate
- Config options in `[StarExtraction]` (`hot_pixels_*`), on by default
- 12 tests; gates validated on real US005A nights (a slow near-pole star with 383 recurrent hits is correctly rejected; the quarters+drift gates, not counts, discriminate)

Note: `flux-empirical-lm` already contains the SkyFit2 amber-marker UI (030cfbae) which imports `RMS.HotPixels` — this PR supplies the module, so it should merge first. Supersedes branch `hot-pixel-blacklist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoBAW8t3qgi9nixYhnLwc1