### PR TITLE
CameraControl: add Isp commands (isp_ctl/hisp_ctl pass-through)

### DIFF
--- a/Utils/CameraControl.py
+++ b/Utils/CameraControl.py
@@ -615,6 +615,41 @@ def setAutoReboot(cam, opts):
     cam.set_info("General.AutoMaintain", info)
 
 
+def ispControl(camera_ip, cmd_line, port=9600, timeout=5):
+    """Send a command to the isp_ctl TCP daemon running on the camera.
+
+    The isp_ctl daemon listens for one text command per TCP connection,
+    sends the response, then closes. This provides true ISP manual
+    exposure/gain control that DVRIP cannot achieve.
+
+    Args:
+        camera_ip (str): Camera IP address
+        cmd_line (str): Command to send (e.g. "query", "manual -a 2048", "auto")
+        port (int): TCP port (default 9600)
+        timeout (int): Socket timeout in seconds
+
+    Returns:
+        str: Response text from isp_ctl, or None on error
+    """
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect((camera_ip, port))
+        s.sendall((cmd_line + "\n").encode())
+        s.shutdown(socket.SHUT_WR)
+        chunks = []
+        while True:
+            data = s.recv(4096)
+            if not data:
+                break
+            chunks.append(data)
+        s.close()
+        return b"".join(chunks).decode(errors="replace")
+    except Exception as e:
+        log.error("isp_ctl connection to %s:%d failed: %s", camera_ip, port, e)
+        return None
+
+
 def manageCloudConnection(cam, opts):
     if len(opts) < 1 or opts[0] not in ['on', 'off', 'get']:
         log.info('usage: CloudConnection on|off|get')
@@ -955,6 +990,35 @@ def dvripCall(cam, cmd, opts, camera_settings_path='./camera_settings.json'):
         upgradeFirmware(cam, firmware_path, skip_confirm)
         return
 
+    elif cmd == 'IspQuery':
+        resp = ispControl(cam.ip, "query")
+        if resp:
+            log.info(resp.rstrip())
+        return
+
+    elif cmd == 'IspManual':
+        # opts: ["-a", "2048", "-e", "500", ...]
+        resp = ispControl(cam.ip, "manual " + " ".join(opts))
+        if resp:
+            log.info(resp.rstrip())
+        return
+
+    elif cmd == 'IspAuto':
+        # opts: ["--max-again", "4096", ...] or empty for full auto
+        resp = ispControl(cam.ip, "auto " + " ".join(opts))
+        if resp:
+            log.info(resp.rstrip())
+        return
+
+    elif cmd == 'Isp':
+        # Generic pass-through to the isp_ctl/hisp_ctl daemon on :9600.
+        # Forward all opts verbatim, e.g. Isp wb unity | Isp wb 512 256 256 |
+        # Isp gain 4096 | Isp ae | Isp status | Isp drc off. Empty -> status.
+        resp = ispControl(cam.ip, " ".join(opts) if opts else "status")
+        if resp:
+            log.info(resp.rstrip())
+        return
+
     # -- If we get here, command is not recognized:
     else:
         log.error("Unrecognized command '%s' in dvripCall. Options were: %s", cmd, opts)
@@ -1028,7 +1092,8 @@ if __name__ == '__main__':
         'reboot', 'GetHostname', 'GetSettings','GetDeviceInformation','GetNetConfig',
         'GetCameraParams','GetEncodeParams','SetParam','SaveSettings','LoadSettings',
         'SetColor','SetOSD','SetAutoReboot','GetIP','GetAutoReboot','CloudConnection',
-        'CameraTime','SwitchMode','UpgradeFirmware'
+        'CameraTime','SwitchMode','UpgradeFirmware',
+        'IspQuery','IspManual','IspAuto','Isp'
     ]
     opthelp = (
         'optional parameters for SetParam for example Camera ElecLevel 70 \n'


### PR DESCRIPTION
## What
Adds camera-side ISP control to `Utils/CameraControl.py` via the `isp_ctl`/`hisp_ctl` TCP daemon on port 9600:

- `ispControl(ip, cmd_line)` — sends one text command per TCP connection and returns the reply.
- `IspQuery` / `IspManual` / `IspAuto` — fixed-string convenience commands.
- `Isp <anything>` — generic pass-through, e.g. `Isp wb unity`, `Isp gain 4096`, `Isp ae`, `Isp status`, `Isp drc off`.
- All four registered in `cmd_list`.

## Why
DVRIP cannot reach true manual ISP exposure/gain or individual pipeline stages (gamma, WB, DRC, NR, DPC, encoder bitrate/QP). The on-camera `isp_ctl`/`hisp_ctl` daemon exposes those; this gives CameraControl a first-class way to drive it.

## Notes
- Commands target `cam.ip`, so they work in config mode today; they pair with the standalone `--ip` flag (#983) for config-free bench use.
- Requires the `isp_ctl`/`hisp_ctl` daemon on the camera (firmware-side, out of scope for this PR). Without it, `ispControl` logs a connection error and returns `None`.

## Draft — before un-drafting
- Wire per-command usage into `opthelp` / argparse help.
- Confirm reviewers are OK depending on a firmware-side daemon (document where it comes from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)