### PR TITLE
Stop a git credential prompt from blocking nightly processing

### DIFF
--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -47,11 +47,20 @@ import tempfile
 import ephem
 
 from RMS.ConfigReader import parse
-from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, UTCFromTimestamp
+from RMS.Misc import niceFormat, isRaspberryPi, sanitise, getRMSStyleFileName, getRmsRootDir, \
+    UTCFromTimestamp
+from RMS.Misc import runGitCommand, GitCommandTimeout, hostReachable, gitUrlHost, \
+    gitUrlHostAndPort, sanitiseGitUrl, anonymousHttpsGitUrl, GIT_ALLOWED_HOSTS, \
+    GIT_NETWORK_TIMEOUT, GIT_LOCAL_TIMEOUT
+from RMS.Logger import getLogger
 from RMS.Formats.FFfits import filenameToDatetimeStr
 from RMS.Formats.Platepar import Platepar
 from RMS.CaptureDuration import captureDuration
 from RMS.CaptureModeSwitcher import SWITCH_HORIZON_DEG
+
+
+# Get the logger from the main module
+log = getLogger("rmslogger")
 
 
 if sys.version_info.major > 2:
@@ -749,47 +758,154 @@ def nightSummaryData(config, night_data_dir):
             time_first_fits_file, time_last_fits_file, total_expected_fits, total_expected_fits_ephemeris
 
 
-def updateCommitHistoryDirectory(remote_urls, target_directory):
+def filterCloneableRemotes(remote_list, allowed_hosts=GIT_ALLOWED_HOSTS):
+
+    """ Keep only the remotes which can be cloned anonymously, i.e. without any chance of a
+        credential prompt.
+
+        Only remotes on known hosts and without embedded credentials are kept, as a remote on an
+        unknown host may well be a private fork which would ask for credentials. An ssh remote on
+        an allowed host is rewritten to its anonymous https equivalent, so that checkouts which
+        were cloned over ssh are still covered, without ever needing a key or a passphrase.
+
+    Arguments:
+        remote_list: [list] list of [remote_name, url] pairs, as returned by getRemoteUrls.
+
+    Keyword arguments:
+        allowed_hosts: [tuple of str] host names from which cloning is allowed.
+
+    Return:
+        [list] list of [remote_name, url] pairs with anonymous https URLs.
+    """
+
+    allowed_hosts_lower = [host.lower() for host in allowed_hosts]
+
+    cloneable_remotes = []
+
+    for remote_name, url in remote_list:
+
+        host = gitUrlHost(url)
+
+        if (host is None) or (host.lower() not in allowed_hosts_lower):
+            log.debug("Skipping git remote {:s}, the host {:s} is not in the list of allowed hosts"
+                      .format(remote_name, str(host)))
+            continue
+
+        # Rewrite the URL so that it can be cloned without any credentials
+        https_url = anonymousHttpsGitUrl(url)
+
+        if https_url is None:
+            log.debug("Skipping git remote {:s}, its URL cannot be used anonymously".format(remote_name))
+            continue
+
+        if [remote_name, https_url] not in cloneable_remotes:
+            cloneable_remotes.append([remote_name, https_url])
+
+    return cloneable_remotes
+
+
+def updateCommitHistoryDirectory(remote_urls, target_directory, timeout=GIT_NETWORK_TIMEOUT):
 
     """ Clone only the commit history of a remote repository.
 
+        Every git operation runs with the interactive prompts disabled and with a hard timeout, so
+        that an unhealthy remote can never block the processing chain.
+
     Arguments:
-        remote_urls: [url] the remote url to be cloned/
+        remote_urls: [list] list of [remote_name, url] pairs to be cloned/fetched.
         target_directory: [path] the directory into which to clone.
+
+    Keyword arguments:
+        timeout: [float] hard timeout of every git operation which touches the network, in seconds.
 
     Return:
         commit_repo_directory: [path] directory of the repository
     """
 
+    # Keep only the remotes which can be cloned without any chance of a credential prompt
+    remote_urls = filterCloneableRemotes(remote_urls)
 
-    if os.path.exists(target_directory):
-        shutil.rmtree(target_directory)
+    if len(remote_urls) == 0:
+        raise RuntimeError("No anonymously cloneable git remote was found")
 
-    os.makedirs(target_directory)
-    first_remote = True
-    for remote_url in remote_urls:
-        local_name, url = remote_url[0], remote_url[1]
+    if not os.path.exists(target_directory):
+        os.makedirs(target_directory)
 
-        if first_remote:
-            first_remote = False
-            p = subprocess.Popen(["git", "clone", url, "--filter=blob:none", "--no-checkout"], cwd=target_directory,
-                             stdout=subprocess.PIPE)
-            p.wait()
-            # this first remote might have been pulled in with the wrong local_name so rename it
-            commit_repo_directory = os.path.join(target_directory, os.listdir(target_directory)[0])
-            downloaded_remote_name = subprocess.check_output(["git", "remote"], cwd = commit_repo_directory).strip().decode('utf-8')
+    # Clone into a directory named here, so that the location of the clone does not have to be
+    # guessed from a directory listing afterwards
+    clone_directory = os.path.join(target_directory, "commit_history")
 
-            if downloaded_remote_name != local_name:
-                p = subprocess.Popen(["git", "remote", "rename", downloaded_remote_name, local_name], cwd = commit_repo_directory)
-                p.wait()
+    if os.path.exists(clone_directory):
+        shutil.rmtree(clone_directory)
 
-        else:
-            # this is not the first remote so add another remote
+    commit_repo_directory = None
 
-            p = subprocess.Popen(["git", "remote", "add", local_name, url], cwd = commit_repo_directory)
-            p.wait()
-            p = subprocess.Popen(["git", "fetch", "--filter=blob:none", local_name], cwd = commit_repo_directory)
-            p.wait()
+    for local_name, url in remote_urls:
+
+        host, port = gitUrlHostAndPort(url)
+
+        # Fail fast if the host cannot even be reached, instead of waiting out the git timeout
+        if not hostReachable(host, port):
+            log.warning("Skipping git remote {:s}, the host {:s} is not reachable".format(
+                local_name, str(host)))
+            continue
+
+        try:
+
+            if commit_repo_directory is None:
+
+                # Clone the commit history of the first reachable remote
+                returncode, _, stderr = runGitCommand(
+                    ["clone", url, "--filter=blob:none", "--no-checkout", clone_directory],
+                    timeout=timeout, network=True)
+
+                if returncode != 0:
+                    log.warning("Cloning the commit history from {:s} failed with code {:d}: {:s}"
+                                .format(sanitiseGitUrl(url), returncode, stderr.strip()[:500]))
+                    continue
+
+                commit_repo_directory = clone_directory
+
+                # This first remote might have been pulled in with the wrong local name, so rename it
+                returncode, stdout, _ = runGitCommand(["remote"], cwd=commit_repo_directory,
+                                                      timeout=GIT_LOCAL_TIMEOUT)
+                downloaded_remote_name = stdout.strip()
+
+                if (returncode == 0) and (len(downloaded_remote_name) > 0) \
+                        and (downloaded_remote_name != local_name):
+
+                    runGitCommand(["remote", "rename", downloaded_remote_name, local_name],
+                                  cwd=commit_repo_directory, timeout=GIT_LOCAL_TIMEOUT)
+
+            else:
+
+                # The history is already there, so only add the additional remote and fetch it. A
+                # failure here is not fatal, as the lag can still be measured against the remote
+                # which was cloned first.
+                returncode, _, stderr = runGitCommand(["remote", "add", local_name, url],
+                                                      cwd=commit_repo_directory,
+                                                      timeout=GIT_LOCAL_TIMEOUT)
+
+                if returncode != 0:
+                    log.warning("Adding the git remote {:s} failed: {:s}".format(
+                        local_name, stderr.strip()[:500]))
+                    continue
+
+                returncode, _, stderr = runGitCommand(["fetch", "--filter=blob:none", local_name],
+                                                      cwd=commit_repo_directory, timeout=timeout,
+                                                      network=True)
+
+                if returncode != 0:
+                    log.warning("Fetching the git remote {:s} failed: {:s}".format(
+                        local_name, stderr.strip()[:500]))
+
+        except GitCommandTimeout as e:
+            log.warning("Git operation on the remote {:s} timed out: {:s}".format(local_name, repr(e)))
+            continue
+
+    if commit_repo_directory is None:
+        raise RuntimeError("Could not clone the commit history from any git remote")
+
     return commit_repo_directory
 
 def getCommit(repo):
@@ -802,10 +918,13 @@ def getCommit(repo):
         commit: [string] latest commit hash
     """
 
-    commit = subprocess.check_output(["git", "log", "-n 1", "--pretty=format:%H"], cwd=repo).decode(
-        "utf-8")
+    returncode, stdout, stderr = runGitCommand(["log", "-n 1", "--pretty=format:%H"], cwd=repo,
+                                               timeout=GIT_LOCAL_TIMEOUT)
 
-    return commit
+    if returncode != 0:
+        raise RuntimeError("Could not read the latest local commit: " + stderr.strip()[:500])
+
+    return stdout
 
 def getDateOfCommit(repo, commit):
     """Get the date of a commit
@@ -820,7 +939,16 @@ def getDateOfCommit(repo, commit):
 
     if commit is None:
         return datetime.datetime.strptime("2000-01-01 00:00:00 +00:00", "%Y-%m-%d %H:%M:%S %z")
-    commit_date  = subprocess.check_output(["git", "show", "-s", "--format=%ci", commit], cwd=repo).decode('utf8').replace("\n","")
+
+    returncode, stdout, stderr = runGitCommand(["show", "-s", "--format=%ci", commit], cwd=repo,
+                                               timeout=GIT_LOCAL_TIMEOUT)
+
+    if returncode != 0:
+        raise RuntimeError("Could not read the date of the commit {:s}: {:s}".format(
+            str(commit), stderr.strip()[:500]))
+
+    commit_date = stdout.replace("\n", "")
+
     return datetime.datetime.strptime(commit_date, "%Y-%m-%d %H:%M:%S %z")
 
 def getRemoteUrls(repo):
@@ -832,7 +960,12 @@ def getRemoteUrls(repo):
         list of [remote, url] where remote is the local name of a remote and URL is the URL of the remote
     """
 
-    urls_and_remotes = subprocess.check_output(["git", "remote", "-v"], cwd=repo).decode("utf-8").split("\n")
+    returncode, stdout, stderr = runGitCommand(["remote", "-v"], cwd=repo, timeout=GIT_LOCAL_TIMEOUT)
+
+    if returncode != 0:
+        raise RuntimeError("Could not read the git remotes: " + stderr.strip()[:500])
+
+    urls_and_remotes = stdout.split("\n")
     url_remote_list_to_return = []
     for url_and_remote in urls_and_remotes:
         url_and_remote = url_and_remote.split("\t")
@@ -854,8 +987,10 @@ def getBranchOfCommit(repo, commit):
         local_branch: [str] A local branch where a commit exists.
     """
 
-    local_branch = subprocess.check_output(["git", "branch", "-a", "--contains", commit], cwd=repo).decode(
-         "utf-8").split("\n")[0].replace("*", "").strip()
+    _, stdout, _ = runGitCommand(["branch", "-a", "--contains", commit], cwd=repo,
+                                 timeout=GIT_LOCAL_TIMEOUT)
+
+    local_branch = stdout.split("\n")[0].replace("*", "").strip()
     return local_branch
 
 def getLatestCommit(repo, commit_branch):
@@ -872,7 +1007,9 @@ def getLatestCommit(repo, commit_branch):
     if commit_branch.startswith("remotes/"):
         commit_branch = commit_branch[len("remotes/"):]
 
-    commit_list = subprocess.check_output(["git", "branch", "-r", "-v"], cwd=repo).decode("utf-8").split("\n")
+    _, stdout, _ = runGitCommand(["branch", "-r", "-v"], cwd=repo, timeout=GIT_LOCAL_TIMEOUT)
+
+    commit_list = stdout.split("\n")
     commit = None
     for branch in commit_list:
 
@@ -899,10 +1036,12 @@ def getRemoteBranchNameForCommit(repo, commit):
 
     local_branch_list = []
     try:
-        local_branch_list = subprocess.check_output(["git", "branch", "-a", "--contains", commit], cwd=repo).decode(
-            "utf-8").split("\n")
-    except:
-        pass
+        _, stdout, _ = runGitCommand(["branch", "-a", "--contains", commit], cwd=repo,
+                                     timeout=GIT_LOCAL_TIMEOUT)
+        local_branch_list = stdout.split("\n")
+
+    except Exception as e:
+        log.debug("Could not list the branches containing the commit: " + repr(e))
 
     remote_branch_name = None
     for branch in local_branch_list:
@@ -912,32 +1051,53 @@ def getRemoteBranchNameForCommit(repo, commit):
 
     return remote_branch_name
 
-def daysBehind():
+def daysBehind(timeout=GIT_NETWORK_TIMEOUT):
     """Measure how far behind the latest commit on the active branch is behind a branch with that commit on the remote
     repository.
 
-    Arguments:
-        syscon: [config] RMS config object.
+    Keyword arguments:
+        timeout: [float] hard timeout of every git operation which touches the network, in seconds.
 
     Return:
-        number of days behind the latest remote commit that the latest local commit is on the active branch.
+        (days_behind, remote_branch): number of days behind the latest remote commit that the latest
+            local commit is on the active branch, and the remote branch it was measured against.
+            (None, None) if the lag could not be determined.
     """
 
-    latest_local_commit = getCommit(os.getcwd())
-    latest_local_date = getDateOfCommit(os.getcwd(), latest_local_commit)
+    repo_directory = getRmsRootDir()
+
+    latest_local_commit = getCommit(repo_directory)
+    latest_local_date = getDateOfCommit(repo_directory, latest_local_commit)
+
+    remote_urls = getRemoteUrls(repo_directory)
+
     target_directory_obj = tempfile.TemporaryDirectory()
-    target_directory = target_directory_obj.name
-    remote_urls = getRemoteUrls(os.getcwd())
-    commit_repo_directory = updateCommitHistoryDirectory(remote_urls, target_directory)
-    remote_branch_of_commit = getRemoteBranchNameForCommit(commit_repo_directory, latest_local_commit)
-    if not remote_branch_of_commit is None:
+
+    try:
+
+        commit_repo_directory = updateCommitHistoryDirectory(remote_urls, target_directory_obj.name,
+                                                             timeout=timeout)
+
+        remote_branch_of_commit = getRemoteBranchNameForCommit(commit_repo_directory, latest_local_commit)
+
+        if remote_branch_of_commit is None:
+            log.warning("The latest local commit was not found on any remote branch, "
+                        "the repository lag could not be measured")
+            return None, None
+
         latest_remote_date = getDateOfCommit(commit_repo_directory, remote_branch_of_commit)
         days_behind = (latest_remote_date - latest_local_date).total_seconds()/(60 * 60 * 24)
-        target_directory_obj.cleanup()
+
         return days_behind, remote_branch_of_commit
-    else:
-        target_directory_obj.cleanup()
-        return "Unable to determine"
+
+    finally:
+
+        try:
+            target_directory_obj.cleanup()
+
+        except Exception as e:
+            log.debug("Could not clean up the temporary commit history directory: " + repr(e))
+
 
 def retrieveObservationData(conn, config, night_directory=None, ordering=None):
     """ Query the database to get the data more recent than the time passed in.
@@ -1263,9 +1423,18 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
 
     try:
         days_behind, remote_branch = daysBehind()
-        addObsParam(obs_db_conn, "repository_lag_remote_days", days_behind)
-        addObsParam(obs_db_conn, "remote_branch", os.path.basename(remote_branch))
-    except:
+
+        if days_behind is None:
+            addObsParam(obs_db_conn, "repository_lag_remote_days", "Not determined")
+
+        else:
+            addObsParam(obs_db_conn, "repository_lag_remote_days", days_behind)
+
+            if remote_branch is not None:
+                addObsParam(obs_db_conn, "remote_branch", os.path.basename(remote_branch))
+
+    except Exception as e:
+        log.warning("Could not determine the repository lag: " + repr(e))
         addObsParam(obs_db_conn, "repository_lag_remote_days", "Not determined")
     obs_db_conn.close()
 

--- a/RMS/Formats/ObservationSummary.py
+++ b/RMS/Formats/ObservationSummary.py
@@ -778,12 +778,14 @@ def filterCloneableRemotes(remote_list, allowed_hosts=GIT_ALLOWED_HOSTS):
         [list] list of [remote_name, url] pairs with anonymous https URLs.
     """
 
+    # Compare host names in lower case, as they are not case sensitive
     allowed_hosts_lower = [host.lower() for host in allowed_hosts]
 
     cloneable_remotes = []
 
     for remote_name, url in remote_list:
 
+        # A remote on an unknown host is skipped without even looking at it
         host = gitUrlHost(url)
 
         if (host is None) or (host.lower() not in allowed_hosts_lower):
@@ -798,6 +800,7 @@ def filterCloneableRemotes(remote_list, allowed_hosts=GIT_ALLOWED_HOSTS):
             log.debug("Skipping git remote {:s}, its URL cannot be used anonymously".format(remote_name))
             continue
 
+        # Two remotes can point at the same repository, so keep the list unique
         if [remote_name, https_url] not in cloneable_remotes:
             cloneable_remotes.append([remote_name, https_url])
 
@@ -825,6 +828,7 @@ def updateCommitHistoryDirectory(remote_urls, target_directory, timeout=GIT_NETW
     # Keep only the remotes which can be cloned without any chance of a credential prompt
     remote_urls = filterCloneableRemotes(remote_urls)
 
+    # Without a usable remote there is nothing to measure the lag against
     if len(remote_urls) == 0:
         raise RuntimeError("No anonymously cloneable git remote was found")
 
@@ -835,9 +839,11 @@ def updateCommitHistoryDirectory(remote_urls, target_directory, timeout=GIT_NETW
     # guessed from a directory listing afterwards
     clone_directory = os.path.join(target_directory, "commit_history")
 
+    # Clear out anything left over from an earlier run
     if os.path.exists(clone_directory):
         shutil.rmtree(clone_directory)
 
+    # Set once the first remote has been cloned successfully
     commit_repo_directory = None
 
     for local_name, url in remote_urls:
@@ -854,11 +860,13 @@ def updateCommitHistoryDirectory(remote_urls, target_directory, timeout=GIT_NETW
 
             if commit_repo_directory is None:
 
-                # Clone the commit history of the first reachable remote
+                # Clone the commit history of the first reachable remote. The blob filter and the
+                # missing checkout keep this down to a few MB, as only the commit dates are needed.
                 returncode, _, stderr = runGitCommand(
                     ["clone", url, "--filter=blob:none", "--no-checkout", clone_directory],
                     timeout=timeout, network=True)
 
+                # Try the next remote if this one did not work
                 if returncode != 0:
                     log.warning("Cloning the commit history from {:s} failed with code {:d}: {:s}"
                                 .format(sanitiseGitUrl(url), returncode, stderr.strip()[:500]))
@@ -871,6 +879,7 @@ def updateCommitHistoryDirectory(remote_urls, target_directory, timeout=GIT_NETW
                                                       timeout=GIT_LOCAL_TIMEOUT)
                 downloaded_remote_name = stdout.strip()
 
+                # The rename only matters for matching up the branch names later on
                 if (returncode == 0) and (len(downloaded_remote_name) > 0) \
                         and (downloaded_remote_name != local_name):
 
@@ -886,23 +895,28 @@ def updateCommitHistoryDirectory(remote_urls, target_directory, timeout=GIT_NETW
                                                       cwd=commit_repo_directory,
                                                       timeout=GIT_LOCAL_TIMEOUT)
 
+                # There is nothing to fetch from if the remote could not be added
                 if returncode != 0:
                     log.warning("Adding the git remote {:s} failed: {:s}".format(
                         local_name, stderr.strip()[:500]))
                     continue
 
+                # Pull in the commit history of this remote as well
                 returncode, _, stderr = runGitCommand(["fetch", "--filter=blob:none", local_name],
                                                       cwd=commit_repo_directory, timeout=timeout,
                                                       network=True)
 
+                # Only note the failure, the remote cloned first is still usable
                 if returncode != 0:
                     log.warning("Fetching the git remote {:s} failed: {:s}".format(
                         local_name, stderr.strip()[:500]))
 
+        # A remote which went quiet halfway through should not hold up the whole night
         except GitCommandTimeout as e:
             log.warning("Git operation on the remote {:s} timed out: {:s}".format(local_name, repr(e)))
             continue
 
+    # Every remote was unreachable or refused the clone
     if commit_repo_directory is None:
         raise RuntimeError("Could not clone the commit history from any git remote")
 
@@ -918,9 +932,11 @@ def getCommit(repo):
         commit: [string] latest commit hash
     """
 
+    # Ask for the hash of the newest commit only
     returncode, stdout, stderr = runGitCommand(["log", "-n 1", "--pretty=format:%H"], cwd=repo,
                                                timeout=GIT_LOCAL_TIMEOUT)
 
+    # An empty or broken repository, nothing further can be measured
     if returncode != 0:
         raise RuntimeError("Could not read the latest local commit: " + stderr.strip()[:500])
 
@@ -940,9 +956,11 @@ def getDateOfCommit(repo, commit):
     if commit is None:
         return datetime.datetime.strptime("2000-01-01 00:00:00 +00:00", "%Y-%m-%d %H:%M:%S %z")
 
+    # Ask for the committer date in the ISO like format
     returncode, stdout, stderr = runGitCommand(["show", "-s", "--format=%ci", commit], cwd=repo,
                                                timeout=GIT_LOCAL_TIMEOUT)
 
+    # The commit is not in this repository
     if returncode != 0:
         raise RuntimeError("Could not read the date of the commit {:s}: {:s}".format(
             str(commit), stderr.strip()[:500]))
@@ -960,6 +978,7 @@ def getRemoteUrls(repo):
         list of [remote, url] where remote is the local name of a remote and URL is the URL of the remote
     """
 
+    # List every remote together with its fetch and push URL
     returncode, stdout, stderr = runGitCommand(["remote", "-v"], cwd=repo, timeout=GIT_LOCAL_TIMEOUT)
 
     if returncode != 0:
@@ -987,6 +1006,7 @@ def getBranchOfCommit(repo, commit):
         local_branch: [str] A local branch where a commit exists.
     """
 
+    # List every branch holding this commit and take the first one
     _, stdout, _ = runGitCommand(["branch", "-a", "--contains", commit], cwd=repo,
                                  timeout=GIT_LOCAL_TIMEOUT)
 
@@ -1007,6 +1027,7 @@ def getLatestCommit(repo, commit_branch):
     if commit_branch.startswith("remotes/"):
         commit_branch = commit_branch[len("remotes/"):]
 
+    # List the remote branches together with the hash they point at
     _, stdout, _ = runGitCommand(["branch", "-r", "-v"], cwd=repo, timeout=GIT_LOCAL_TIMEOUT)
 
     commit_list = stdout.split("\n")
@@ -1036,6 +1057,8 @@ def getRemoteBranchNameForCommit(repo, commit):
 
     local_branch_list = []
     try:
+
+        # List every branch holding this commit, local and remote alike
         _, stdout, _ = runGitCommand(["branch", "-a", "--contains", commit], cwd=repo,
                                      timeout=GIT_LOCAL_TIMEOUT)
         local_branch_list = stdout.split("\n")
@@ -1043,6 +1066,7 @@ def getRemoteBranchNameForCommit(repo, commit):
     except Exception as e:
         log.debug("Could not list the branches containing the commit: " + repr(e))
 
+    # Keep the last remote branch found, the local ones are of no use here
     remote_branch_name = None
     for branch in local_branch_list:
         branch_stripped = branch.strip()
@@ -1066,11 +1090,13 @@ def daysBehind(timeout=GIT_NETWORK_TIMEOUT):
 
     repo_directory = getRmsRootDir()
 
+    # Find out when the code running on this station was committed
     latest_local_commit = getCommit(repo_directory)
     latest_local_date = getDateOfCommit(repo_directory, latest_local_commit)
 
     remote_urls = getRemoteUrls(repo_directory)
 
+    # The commit history is only needed for this measurement, so keep it out of the way
     target_directory_obj = tempfile.TemporaryDirectory()
 
     try:
@@ -1078,13 +1104,16 @@ def daysBehind(timeout=GIT_NETWORK_TIMEOUT):
         commit_repo_directory = updateCommitHistoryDirectory(remote_urls, target_directory_obj.name,
                                                              timeout=timeout)
 
+        # Find the remote branch which the local commit sits on
         remote_branch_of_commit = getRemoteBranchNameForCommit(commit_repo_directory, latest_local_commit)
 
+        # This happens on a local branch which was never pushed
         if remote_branch_of_commit is None:
             log.warning("The latest local commit was not found on any remote branch, "
                         "the repository lag could not be measured")
             return None, None
 
+        # The lag is the age difference between the local commit and the tip of that branch
         latest_remote_date = getDateOfCommit(commit_repo_directory, remote_branch_of_commit)
         days_behind = (latest_remote_date - latest_local_date).total_seconds()/(60 * 60 * 24)
 
@@ -1092,6 +1121,7 @@ def daysBehind(timeout=GIT_NETWORK_TIMEOUT):
 
     finally:
 
+        # Always remove the temporary clone, also when the measurement failed
         try:
             target_directory_obj.cleanup()
 
@@ -1424,6 +1454,7 @@ def finalizeObservationSummary(config, night_data_dir, platepar=None):
     try:
         days_behind, remote_branch = daysBehind()
 
+        # The lag could not be measured, e.g. GitHub was unreachable
         if days_behind is None:
             addObsParam(obs_db_conn, "repository_lag_remote_days", "Not determined")
 

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -205,10 +205,14 @@ def gitSafeEnv(env=None):
         [dict] Copy of the environment with the no-prompt variables set.
     """
 
+    # Start from the current environment, unless another one was given
     if env is None:
         env = os.environ
 
+    # Work on a copy, so that the environment of this process is not touched
     safe_env = dict(env)
+
+    # Override the prompt related variables
     safe_env.update(GIT_NO_PROMPT_ENV)
 
     return safe_env
@@ -222,6 +226,7 @@ def disableGitPrompts():
         deliberate override from the outside still works.
     """
 
+    # setdefault leaves any variable which is already set alone
     for name, value in GIT_NO_PROMPT_ENV.items():
         os.environ.setdefault(name, value)
 
@@ -237,9 +242,13 @@ def sanitiseGitUrl(url):
     """
 
     try:
+
+        # Drop the userinfo part which sits between the scheme and the host
         return re.sub(r'([A-Za-z][A-Za-z0-9+.\-]*://)[^/@]+@', r'\1', url)
 
     except Exception:
+
+        # Never risk writing a URL which might still hold a password
         return "[URL_REDACTED]"
 
 
@@ -261,6 +270,7 @@ def gitUrlHost(url):
 
     url = url.strip()
 
+    # A local repository has no host to connect to
     if not url or url.startswith("file://"):
         return None
 
@@ -315,6 +325,7 @@ def anonymousHttpsGitUrl(url):
 
     url = url.strip()
 
+    # A URL without a host is a local path, which cannot be rewritten
     host = gitUrlHost(url)
 
     if host is None:
@@ -334,6 +345,7 @@ def anonymousHttpsGitUrl(url):
     # ssh://[user@]host[:port]/path
     ssh_match = re.match(r'^ssh://(?:[^@/]+@)?[^/]+/(.+)$', url, re.IGNORECASE)
 
+    # Keep the path and swap the transport for https
     if ssh_match is not None:
         return "https://{:s}/{:s}".format(host, ssh_match.group(1).lstrip("/"))
 
@@ -343,6 +355,7 @@ def anonymousHttpsGitUrl(url):
     if scp_match is not None:
         return "https://{:s}/{:s}".format(host, scp_match.group(1).lstrip("/"))
 
+    # An unrecognized form, better to skip it than to guess
     return None
 
 
@@ -356,6 +369,7 @@ def gitUrlHostAndPort(url):
         (host, port): [str, int] Host name and port, or (None, None) for a local path.
     """
 
+    # A local path has neither a host nor a port
     host = gitUrlHost(url)
 
     if host is None:
@@ -374,9 +388,11 @@ def gitUrlHostAndPort(url):
     if url.lower().startswith("https://"):
         return host, 443
 
+    # Both ssh:// and the scp-like syntax go over ssh
     if url.lower().startswith("ssh://") or ("@" in url):
         return host, 22
 
+    # Assume https for anything else
     return host, 443
 
 
@@ -397,20 +413,27 @@ def hostReachable(host, port=443, timeout=GIT_REACHABILITY_TIMEOUT):
         [bool] True if the connection succeeded.
     """
 
+    # Without a host there is nothing to connect to
     if host is None:
         return False
 
     sock = None
 
     try:
+
+        # Open a connection and drop it straight away, only reachability matters here
         sock = socket.create_connection((host, port), timeout=timeout)
         return True
 
     except Exception as e:
+
+        # A refused connection, a DNS failure and a timeout are all treated the same way
         log.debug("Host {:s}:{:d} is not reachable: {:s}".format(str(host), int(port), repr(e)))
         return False
 
     finally:
+
+        # Always release the socket, even when the connection failed halfway through
         if sock is not None:
             try:
                 sock.close()
@@ -429,15 +452,18 @@ def killProcessGroup(proc):
     """
 
     try:
+
+        # Kill the whole group, so that the transport helper goes down with git itself
         if (os.name == 'posix') and hasattr(os, 'killpg'):
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
 
+        # Windows has no process groups, so only the process itself can be killed
         else:
             proc.kill()
 
     except Exception:
 
-        # Fall back to killing just the process itself
+        # The group might have already gone away, so fall back to the process itself
         try:
             proc.kill()
         except Exception:
@@ -472,8 +498,10 @@ def runGitCommand(args, cwd=None, timeout=GIT_NETWORK_TIMEOUT, network=False):
         # Abort a transfer which delivers less than 1 kB/s for 30 s
         cmd += ["-c", "http.lowSpeedLimit=1000", "-c", "http.lowSpeedTime=30"]
 
+    # Append the arguments of the actual git subcommand
     cmd += list(args)
 
+    # Log the command with any credentials stripped out of the URLs
     log.debug("Running git command: {:s}".format(" ".join([sanitiseGitUrl(arg) for arg in cmd])))
 
     # Redirect the output into temporary files instead of pipes. Pipes would have to be drained
@@ -488,14 +516,17 @@ def runGitCommand(args, cwd=None, timeout=GIT_NETWORK_TIMEOUT, network=False):
     # Put the child into its own process group, so that the whole group can be killed on a timeout
     popen_kwargs = {}
 
+    # Python 3 calls setsid in the child on its own
     if sys.version_info[0] >= 3:
         popen_kwargs['start_new_session'] = True
 
+    # On Python 2 it has to be done by hand
     elif os.name == 'posix':
         popen_kwargs['preexec_fn'] = os.setsid
 
     try:
 
+        # Run git with the prompts disabled and with nothing to read on stdin
         proc = subprocess.Popen(cmd, cwd=cwd, env=gitSafeEnv(), stdin=devnull_file,
                                 stdout=stdout_file, stderr=stderr_file, **popen_kwargs)
 
@@ -505,12 +536,14 @@ def runGitCommand(args, cwd=None, timeout=GIT_NETWORK_TIMEOUT, network=False):
 
         while proc.poll() is None:
 
+            # The command has run for too long, take it and its transport helper down
             if time.time() > deadline:
                 killProcessGroup(proc)
                 proc.wait()
                 timed_out = True
                 break
 
+            # Poll gently, so that waiting does not burn a core
             time.sleep(0.1)
 
         # Read back whatever the command managed to write
@@ -519,6 +552,7 @@ def runGitCommand(args, cwd=None, timeout=GIT_NETWORK_TIMEOUT, network=False):
         stdout = stdout_file.read().decode('utf-8', 'replace')
         stderr = stderr_file.read().decode('utf-8', 'replace')
 
+        # Report the timeout together with anything git said before it was killed
         if timed_out:
             raise GitCommandTimeout("git {:s} timed out after {:.0f} s and was killed. stderr: {:s}"
                                     .format(sanitiseGitUrl(" ".join(args)), timeout, stderr.strip()[:500]))
@@ -527,6 +561,7 @@ def runGitCommand(args, cwd=None, timeout=GIT_NETWORK_TIMEOUT, network=False):
 
     finally:
 
+        # Release the temporary output files and the /dev/null handle
         for file_handle in (stdout_file, stderr_file, devnull_file):
             try:
                 file_handle.close()

--- a/RMS/Misc.py
+++ b/RMS/Misc.py
@@ -16,6 +16,9 @@ import datetime
 import tarfile
 import threading
 import signal
+import socket
+import tempfile
+import time
 
 # tkinter import that works on both Python 2 and 3
 if sys.version_info[0] < 3:
@@ -142,6 +145,396 @@ def runWithTimeout(func, args=(), kwargs=None, timeout=60):
     else:
         # Timed out
         return (False, None, None)
+
+
+### Safe git invocation ###
+
+# Hosts from which RMS is allowed to fetch, i.e. hosts which are known to serve the RMS
+# repositories anonymously. Remotes on any other host are skipped, as they may well be private
+# forks which would ask for credentials.
+GIT_ALLOWED_HOSTS = ("github.com", )
+
+# Default timeout for git operations which touch the network [s]
+GIT_NETWORK_TIMEOUT = 120
+
+# Default timeout for purely local git operations [s]
+GIT_LOCAL_TIMEOUT = 30
+
+# Timeout of the TCP reachability pre-check performed before any network git operation [s]
+GIT_REACHABILITY_TIMEOUT = 5
+
+# Environment variables which disable every interactive prompt git or ssh might produce. Without
+# these, a git operation against an unhealthy server (e.g. GitHub answering an anonymous HTTPS
+# request with a 401) asks for a user name on the terminal and blocks the whole processing chain
+# indefinitely.
+GIT_NO_PROMPT_ENV = {
+
+    # git >= 2.3 - fail with an error instead of asking for a user name and a password
+    "GIT_TERMINAL_PROMPT": "0",
+
+    # OpenSSH >= 8.4 - never fall back to SSH_ASKPASS
+    "SSH_ASKPASS_REQUIRE": "never",
+
+    # Do not ask for a passphrase or for a host key confirmation on ssh remotes
+    "GIT_SSH_COMMAND": "ssh -oBatchMode=yes -oConnectTimeout=10",
+
+    # Git Credential Manager, in case it is ever installed
+    "GCM_INTERACTIVE": "Never",
+    }
+
+# Never pop up a helper to ask for a password, /bin/echo returns an empty string immediately. Only
+# set this where /bin/echo exists, as pointing git at a missing helper only produces a warning and
+# GIT_TERMINAL_PROMPT already covers that case anyway.
+if os.path.exists("/bin/echo"):
+    GIT_NO_PROMPT_ENV["GIT_ASKPASS"] = "/bin/echo"
+    GIT_NO_PROMPT_ENV["SSH_ASKPASS"] = "/bin/echo"
+
+
+class GitCommandTimeout(Exception):
+    """ Raised when a git command had to be killed because it exceeded its timeout. """
+    pass
+
+
+def gitSafeEnv(env=None):
+    """ Return a copy of the environment with all interactive git and ssh prompts disabled.
+
+    Keyword arguments:
+        env: [dict] Environment to start from. None by default, in which case os.environ is used.
+
+    Return:
+        [dict] Copy of the environment with the no-prompt variables set.
+    """
+
+    if env is None:
+        env = os.environ
+
+    safe_env = dict(env)
+    safe_env.update(GIT_NO_PROMPT_ENV)
+
+    return safe_env
+
+
+def disableGitPrompts():
+    """ Disable interactive git and ssh prompts for this process and all its children.
+
+        This is a process-wide safety net which also covers git invocations that do not go through
+        runGitCommand, e.g. GitPython. Variables which are already set are left alone, so that a
+        deliberate override from the outside still works.
+    """
+
+    for name, value in GIT_NO_PROMPT_ENV.items():
+        os.environ.setdefault(name, value)
+
+
+def sanitiseGitUrl(url):
+    """ Remove any embedded credentials from a git URL, so that it is safe to write to the log.
+
+    Arguments:
+        url: [str] URL, or any other command line argument.
+
+    Return:
+        [str] The URL with the userinfo part removed.
+    """
+
+    try:
+        return re.sub(r'([A-Za-z][A-Za-z0-9+.\-]*://)[^/@]+@', r'\1', url)
+
+    except Exception:
+        return "[URL_REDACTED]"
+
+
+def gitUrlHost(url):
+    """ Extract the host name from a git remote URL.
+
+        Handles URLs with a scheme (https://host/path, ssh://user@host:port/path) and the scp-like
+        syntax (user@host:path).
+
+    Arguments:
+        url: [str] Git remote URL.
+
+    Return:
+        [str] Host name, or None for local paths and file:// URLs.
+    """
+
+    if url is None:
+        return None
+
+    url = url.strip()
+
+    if not url or url.startswith("file://"):
+        return None
+
+    # Match a URL with an explicit scheme
+    scheme_match = re.match(r'^[A-Za-z][A-Za-z0-9+.\-]*://([^/]+)', url)
+
+    if scheme_match is not None:
+        netloc = scheme_match.group(1)
+
+    elif ("@" in url) and (":" in url.split("@", 1)[1]):
+
+        # scp-like syntax, e.g. git@github.com:user/repo.git
+        netloc = url.split("@", 1)[1].split(":", 1)[0]
+
+    else:
+        # A plain local path
+        return None
+
+    # Strip the userinfo part
+    if "@" in netloc:
+        netloc = netloc.rsplit("@", 1)[1]
+
+    # Strip the port
+    if netloc.startswith("["):
+
+        # IPv6 literal
+        netloc = netloc.split("]", 1)[0].lstrip("[")
+
+    elif ":" in netloc:
+        netloc = netloc.split(":", 1)[0]
+
+    return netloc if netloc else None
+
+
+def anonymousHttpsGitUrl(url):
+    """ Convert a git remote URL into the equivalent anonymous https URL.
+
+        Public repositories are served over plain https without any credentials, while an ssh
+        remote needs a key or an agent and can block on a passphrase prompt. Rewriting the URL
+        keeps the remote usable for read-only operations on checkouts which were cloned over ssh.
+
+    Arguments:
+        url: [str] Git remote URL.
+
+    Return:
+        [str] The equivalent anonymous https URL, or None if the URL cannot be used anonymously
+            (a local path, or a URL which carries credentials).
+    """
+
+    if url is None:
+        return None
+
+    url = url.strip()
+
+    host = gitUrlHost(url)
+
+    if host is None:
+        return None
+
+    if url.lower().startswith(("http://", "https://")):
+
+        # Reject an http(s) URL which carries credentials, as it points to a private repository.
+        # Note that a user name in an ssh URL is only the login name, not a credential, so this
+        # check is deliberately limited to http(s).
+        if re.match(r'^[A-Za-z][A-Za-z0-9+.\-]*://[^/@]+@', url) is not None:
+            return None
+
+        # A plain http(s) URL can be used as it is
+        return url
+
+    # ssh://[user@]host[:port]/path
+    ssh_match = re.match(r'^ssh://(?:[^@/]+@)?[^/]+/(.+)$', url, re.IGNORECASE)
+
+    if ssh_match is not None:
+        return "https://{:s}/{:s}".format(host, ssh_match.group(1).lstrip("/"))
+
+    # scp-like syntax, e.g. git@github.com:user/repo.git
+    scp_match = re.match(r'^(?:[^@/]+@)?[^:/]+:(.+)$', url)
+
+    if scp_match is not None:
+        return "https://{:s}/{:s}".format(host, scp_match.group(1).lstrip("/"))
+
+    return None
+
+
+def gitUrlHostAndPort(url):
+    """ Extract the host name and the port to connect to from a git remote URL.
+
+    Arguments:
+        url: [str] Git remote URL.
+
+    Return:
+        (host, port): [str, int] Host name and port, or (None, None) for a local path.
+    """
+
+    host = gitUrlHost(url)
+
+    if host is None:
+        return None, None
+
+    # An explicit port in the URL takes precedence
+    port_match = re.search(r'^[A-Za-z][A-Za-z0-9+.\-]*://(?:[^/@]+@)?(?:\[[^\]]+\]|[^/:]+):(\d+)', url)
+
+    if port_match is not None:
+        return host, int(port_match.group(1))
+
+    # Otherwise fall back to the default port of the scheme
+    if url.lower().startswith("http://"):
+        return host, 80
+
+    if url.lower().startswith("https://"):
+        return host, 443
+
+    if url.lower().startswith("ssh://") or ("@" in url):
+        return host, 22
+
+    return host, 443
+
+
+def hostReachable(host, port=443, timeout=GIT_REACHABILITY_TIMEOUT):
+    """ Check that a TCP connection to the given host and port can be established.
+
+        This is a cheap pre-check which fails fast on a DNS failure, a dead link or a blackholed
+        route, so that a slow network operation is not even attempted.
+
+    Arguments:
+        host: [str] Host name or IP address.
+
+    Keyword arguments:
+        port: [int] TCP port. 443 by default.
+        timeout: [float] Connection timeout in seconds.
+
+    Return:
+        [bool] True if the connection succeeded.
+    """
+
+    if host is None:
+        return False
+
+    sock = None
+
+    try:
+        sock = socket.create_connection((host, port), timeout=timeout)
+        return True
+
+    except Exception as e:
+        log.debug("Host {:s}:{:d} is not reachable: {:s}".format(str(host), int(port), repr(e)))
+        return False
+
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except Exception:
+                pass
+
+
+def killProcessGroup(proc):
+    """ Kill a process and, on POSIX systems, its whole process group.
+
+        Killing only the process itself is not enough for git, which delegates the transfer to a
+        helper process (e.g. git-remote-https) that would keep the connection open.
+
+    Arguments:
+        proc: [Popen object] The process to kill.
+    """
+
+    try:
+        if (os.name == 'posix') and hasattr(os, 'killpg'):
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+
+        else:
+            proc.kill()
+
+    except Exception:
+
+        # Fall back to killing just the process itself
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+
+def runGitCommand(args, cwd=None, timeout=GIT_NETWORK_TIMEOUT, network=False):
+    """ Run a git command with all interactive prompts disabled and with a hard timeout.
+
+    Arguments:
+        args: [list of str] Git arguments, without the leading "git".
+
+    Keyword arguments:
+        cwd: [str] Directory in which to run the command. None by default.
+        timeout: [float] Hard timeout in seconds, after which the process group is killed.
+        network: [bool] True if the command touches the network, in which case git is also told to
+            abort a transfer which has stalled. False by default.
+
+    Return:
+        (returncode, stdout, stderr): [int, str, str] Exit code and the decoded output.
+
+    Raises:
+        GitCommandTimeout: If the command did not finish within the timeout.
+    """
+
+    # Clear the credential helper list, so that a configured helper (store, cache, manager) cannot
+    # block or supply stale credentials either
+    cmd = ["git", "-c", "credential.helper="]
+
+    if network:
+
+        # Abort a transfer which delivers less than 1 kB/s for 30 s
+        cmd += ["-c", "http.lowSpeedLimit=1000", "-c", "http.lowSpeedTime=30"]
+
+    cmd += list(args)
+
+    log.debug("Running git command: {:s}".format(" ".join([sanitiseGitUrl(arg) for arg in cmd])))
+
+    # Redirect the output into temporary files instead of pipes. Pipes would have to be drained
+    # concurrently, otherwise a command which produces more output than the pipe buffer deadlocks.
+    stdout_file = tempfile.TemporaryFile()
+    stderr_file = tempfile.TemporaryFile()
+
+    # Read stdin from /dev/null, so that a credential prompt which somehow slips past the
+    # environment variables gets an immediate EOF instead of blocking forever
+    devnull_file = open(os.devnull, 'r')
+
+    # Put the child into its own process group, so that the whole group can be killed on a timeout
+    popen_kwargs = {}
+
+    if sys.version_info[0] >= 3:
+        popen_kwargs['start_new_session'] = True
+
+    elif os.name == 'posix':
+        popen_kwargs['preexec_fn'] = os.setsid
+
+    try:
+
+        proc = subprocess.Popen(cmd, cwd=cwd, env=gitSafeEnv(), stdin=devnull_file,
+                                stdout=stdout_file, stderr=stderr_file, **popen_kwargs)
+
+        # Poll until the command finishes or the timeout expires
+        deadline = time.time() + timeout
+        timed_out = False
+
+        while proc.poll() is None:
+
+            if time.time() > deadline:
+                killProcessGroup(proc)
+                proc.wait()
+                timed_out = True
+                break
+
+            time.sleep(0.1)
+
+        # Read back whatever the command managed to write
+        stdout_file.seek(0)
+        stderr_file.seek(0)
+        stdout = stdout_file.read().decode('utf-8', 'replace')
+        stderr = stderr_file.read().decode('utf-8', 'replace')
+
+        if timed_out:
+            raise GitCommandTimeout("git {:s} timed out after {:.0f} s and was killed. stderr: {:s}"
+                                    .format(sanitiseGitUrl(" ".join(args)), timeout, stderr.strip()[:500]))
+
+        return proc.returncode, stdout, stderr
+
+    finally:
+
+        for file_handle in (stdout_file, stderr_file, devnull_file):
+            try:
+                file_handle.close()
+            except Exception:
+                pass
+
+
+### ###
 
 
 def mkdirP(path):

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -42,7 +42,7 @@ from Utils.PlotTimeIntervals import plotFFTimeIntervals
 from RMS.Formats.ObservationSummary import addObsParam, getObsDBConn
 from RMS.Formats.ObservationSummary import serialize, finalizeObservationSummary
 from Utils.AuditConfig import compareConfigs
-from RMS.Misc import RmsDateTime, tarWithProgress
+from RMS.Misc import RmsDateTime, tarWithProgress, disableGitPrompts
 from RMS.RunExternalScript import runExternalScript
 
 # Get the logger from the main module
@@ -782,6 +782,10 @@ def processFramesFiles(config):
 
 
 if __name__ == "__main__":
+
+    # Make sure that no git invocation from this process, or from any of its children, can ever
+    # stop and ask for credentials on the terminal and block the whole processing chain
+    disableGitPrompts()
 
     ### COMMAND LINE ARGUMENTS
 

--- a/RMS/StartCapture.py
+++ b/RMS/StartCapture.py
@@ -46,7 +46,7 @@ from RMS.Compression import Compressor
 from RMS.DeleteOldObservations import deleteOldObservations
 from RMS.DetectStarsAndMeteors import detectStarsAndMeteors
 from RMS.Formats.FFfile import validFFName
-from RMS.Misc import mkdirP, RmsDateTime, UTCFromTimestamp
+from RMS.Misc import mkdirP, RmsDateTime, UTCFromTimestamp, disableGitPrompts
 from RMS.QueuedPool import QueuedPool
 from RMS.Reprocess import getPlatepar, processNight, processFramesFiles
 from RMS.RunExternalScript import runExternalScript
@@ -1026,6 +1026,10 @@ def processIncompleteCaptures(config, upload_manager):
 
 
 if __name__ == "__main__":
+
+    # Make sure that no git invocation from this process, or from any of its children, can ever
+    # stop and ask for credentials on the terminal and block the whole processing chain
+    disableGitPrompts()
 
     ### COMMAND LINE ARGUMENTS
 

--- a/Scripts/RMS_Update.sh
+++ b/Scripts/RMS_Update.sh
@@ -40,6 +40,33 @@ readonly GIT_RETRY_LIMIT=5
 
 readonly GIT_RETRY_DELAY=15  # Seconds between git operation retries
 
+# Hard timeout for any git operation which touches the network [s]
+readonly GIT_NET_TIMEOUT=${GIT_NET_TIMEOUT:-300}
+
+# Disable every interactive prompt git or ssh might produce. Without these, a git operation against
+# an unhealthy server (e.g. GitHub answering an anonymous HTTPS request with a 401) asks for a user
+# name on the terminal and blocks this script forever. That is especially damaging here, because
+# RMS_FirstRun.sh runs this script unattended at boot, before capture is started.
+export GIT_TERMINAL_PROMPT=0   # git >= 2.3: fail with an error instead of asking for credentials
+export GIT_ASKPASS=/bin/echo   # never pop up a helper, /bin/echo returns an empty string at once
+export SSH_ASKPASS=/bin/echo
+export SSH_ASKPASS_REQUIRE=never                         # OpenSSH >= 8.4
+export GIT_SSH_COMMAND="ssh -oBatchMode=yes -oConnectTimeout=10"
+export GCM_INTERACTIVE=Never                             # Git Credential Manager, if installed
+
+# Run a git command which touches the network, with a hard timeout and with stdin closed, so that
+# it can never hang. The credential helper list is cleared, so that a configured helper cannot
+# block either, and a transfer which stalls below 1 kB/s for 30 s is aborted by git itself.
+git_net() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout -k 10 "$GIT_NET_TIMEOUT" git -c credential.helper= \
+            -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@" < /dev/null
+    else
+        git -c credential.helper= \
+            -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@" < /dev/null
+    fi
+}
+
 # Remote/branch tracking inferred at runtime (initialized to avoid -u unbound errors)
 BRANCH_REMOTE=""
 UPSTREAM_BRANCH=""
@@ -279,7 +306,7 @@ check_git_setup() {
     
     # Verify we can reach the RMS repository
     print_status "info" "Verifying connection to RMS remote..."
-    if ! git ls-remote --exit-code "$RMS_REMOTE" >/dev/null 2>&1; then
+    if ! git_net ls-remote --exit-code "$RMS_REMOTE" >/dev/null 2>&1; then
         print_status "error" "Cannot reach RMS repository. Please check your internet connection"
         exit 1
     else
@@ -304,7 +331,7 @@ resolve_branch_remote() {
 
     # Else, try to find a remote that has this branch
     for r in $(git remote); do
-        if git ls-remote --exit-code --heads "$r" "refs/heads/$branch" >/dev/null 2>&1; then
+        if git_net ls-remote --exit-code --heads "$r" "refs/heads/$branch" >/dev/null 2>&1; then
             BRANCH_REMOTE="$r"
             UPSTREAM_BRANCH="$branch"
             return
@@ -810,7 +837,7 @@ git_with_retry() {
                         return 1
                     fi
 
-                    if git clone --config http.version=HTTP/1.1 --config http.sslverify=false https://github.com/CroatianMeteorNetwork/RMS.git "$RMSSOURCEDIR"; then
+                    if git_net clone --config http.version=HTTP/1.1 --config http.sslverify=false https://github.com/CroatianMeteorNetwork/RMS.git "$RMSSOURCEDIR"; then
                         print_status "success" "Repository successfully recloned using HTTP/1.1"
                         cd "$RMSSOURCEDIR" || exit 1
 
@@ -844,7 +871,7 @@ git_with_retry() {
         # Ensure Git Fails Properly Before Retrying
         case $cmd in
             "fetch")
-                if ! git "${git_config_args[@]}" fetch --all --prune --force --quiet $depth_arg; then
+                if ! git_net "${git_config_args[@]}" fetch --all --prune --force --quiet $depth_arg; then
                     print_status "warning" "Git fetch failed, retrying..."
                 else
                     return 0
@@ -933,7 +960,7 @@ switch_to_branch() {
     # If no explicit remote, try to find any remote carrying this branch
     if [ -z "$remote_candidate" ]; then
         for r in $(git remote); do
-            if git ls-remote --exit-code --heads "$r" "refs/heads/$target_branch" >/dev/null 2>&1; then
+            if git_net ls-remote --exit-code --heads "$r" "refs/heads/$target_branch" >/dev/null 2>&1; then
                 remote_candidate="$r"
                 break
             fi
@@ -1158,7 +1185,7 @@ main() {
             [[ -z "$RMS_BRANCH" ]] && RMS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
             resolve_branch_remote "$RMS_BRANCH"
 
-            REMOTE_SHA=$(git ls-remote --quiet --heads "$BRANCH_REMOTE" "refs/heads/$UPSTREAM_BRANCH" | cut -f1)
+            REMOTE_SHA=$(git_net ls-remote --quiet --heads "$BRANCH_REMOTE" "refs/heads/$UPSTREAM_BRANCH" | cut -f1)
             LOCAL_SHA=$(git rev-parse HEAD)
 
             if [[ -z "$REMOTE_SHA" ]]; then


### PR DESCRIPTION
During the GitHub outage on 2026-09-03, around 15 stations got stuck in the middle of nightly processing. The log stopped here:

```
2026/09/03 04:01:40-INFO-Reprocess-line:510 - Generate config audit report
Cloning into 'RMS'...
Username for 'https://github.com':
```

Pressing ENTER twice got them going again, and processing continued to archive creation. This happened on stations running continuous capture too.

## What was actually happening

The config audit report is not the problem, it is just the last thing that logs before the hang. `Utils/AuditConfig.py` only reads local files.

The real culprit is the next step, the repository lag check. `Reprocess.py` calls `finalizeObservationSummary`, which calls `daysBehind()`, which clones the commit history of every remote to see how far behind the station is. That clone was:

```python
p = subprocess.Popen(["git", "clone", url, "--filter=blob:none", "--no-checkout"],
                     cwd=target_directory, stdout=subprocess.PIPE)
p.wait()
```

Three things went wrong at once:

1. stdin was inherited. RMS runs in a terminal, so git had a real tty to ask on.
2. `GIT_TERMINAL_PROMPT=0` was never set, so git asked instead of failing. GitHub was answering anonymous HTTPS requests with a 401 during the outage, and a 401 is exactly what makes git ask for credentials, even on a public repository.
3. There was no timeout at all, just a bare `p.wait()`.

So git asked for a username, then a password. That is the two blind ENTERs.

The `try/except` around the call could not help, because nothing was ever raised, the process simply stopped. It was also a bare `except:`, which is why nobody saw this coming: when the lag check failed for any reason, it silently recorded "Not determined" and never wrote a single line to the log.

`Scripts/RMS_Update.sh` had the same problem and it is arguably worse. It runs unattended at boot from `RMS_FirstRun.sh`, before capture starts, and its `git ls-remote` check sends stdout and stderr to `/dev/null` but not stdin. During the same outage that would hang with no visible prompt at all.

## The fix

The idea is that no git call from RMS should ever be able to ask a question or wait forever, and that it should give up early rather than late.

**New helpers in `RMS/Misc.py`:**

- `runGitCommand()` runs git with every interactive prompt disabled, stdin on `/dev/null`, a hard timeout (120 s for network operations, 30 s for local ones), and output going to temp files instead of pipes. On a timeout it kills the whole process group, not just git, because git hands the transfer to a `git-remote-https` child that would otherwise keep the connection open. It also clears the credential helper list and tells git to give up on a transfer that stalls below 1 kB/s for 30 s.
- `hostReachable()` does a plain TCP connect with a 5 s timeout, so a dead link or a DNS failure is caught before anything slow is attempted.
- `gitUrlHost()`, `gitUrlHostAndPort()`, `anonymousHttpsGitUrl()`, `sanitiseGitUrl()` for picking apart remote URLs and keeping credentials out of the log.
- `disableGitPrompts()` sets the same environment variables for the whole process, which is called at the top of `StartCapture.py` and `Reprocess.py`. This is the safety net: it also covers GitPython and any git call added later that forgets to use `runGitCommand`.

**In `RMS/Formats/ObservationSummary.py`:**

- All 11 git calls now go through `runGitCommand`, so a stuck local git (a stale `index.lock`, say) cannot block either.
- Only remotes on known hosts are used. Previously `daysBehind()` cloned *every* remote from `git remote -v`, so a station with a private fork configured would hit a credential prompt even when GitHub was perfectly healthy.
- An ssh remote on an allowed host is rewritten to its anonymous https equivalent rather than skipped, so checkouts cloned over ssh still get a lag number without needing a key or a passphrase.
- The module now has a logger. When the lag check fails it says why, instead of quietly writing "Not determined".

**In `Scripts/RMS_Update.sh`:** the same environment variables plus a `git_net()` wrapper that adds `timeout` and closes stdin, applied to all six network git calls. The existing failure paths already degrade nicely ("Cannot reach RMS repository. Please check your internet connection"), they just were not being reached.

## Bugs fixed along the way

All of these were on the same code path and were being hidden by the bare `except:`:

- `os.listdir(target_directory)[0]` raised `IndexError` when the clone failed. The clone now goes into a directory we name ourselves, so there is nothing to guess.
- `commit_repo_directory` was only assigned inside the first-remote branch, so an empty remote list raised `UnboundLocalError`.
- `daysBehind()` returned a 2-tuple on success but a bare string `"Unable to determine"` on failure, so the caller's tuple unpack raised `TypeError`.
- The temporary directory was only cleaned up on the two success paths, never in a `finally`.
- `getCommit()` and friends used `os.getcwd()`, so the whole thing silently depended on the process being started from the RMS directory. Now uses `getRmsRootDir()`.
- Return codes of all four git calls were never checked.

## Tested

- 401 repository: returns rc=128 in 0.2 s with no prompt. Before the fix this is where it hung.
- Blackholed address (`https://10.255.255.1/x.git`, timeout 15 s): killed at exactly 15 s, no orphan `git-remote-https` left behind.
- Unreachable host: warns and skips without attempting a clone.
- Remote filtering: drops ssh remotes on unknown hosts, URLs with embedded credentials, and local paths; rewrites `git@github.com:...` to `https://github.com/...`.
- Happy path unchanged: `days_behind=20.194`, branch `remotes/walesto/master`, 6 s, temp directory cleaned up.
- `disableGitPrompts()` verified with a plain `subprocess` git clone that does not go through `runGitCommand`, to confirm the safety net works.
- `git_net()` tested on its own: rc=128 immediately on a 401, rc=124 at the timeout.
- `python -m py_compile` on all four Python files, imports of `RMS.Reprocess` and `RMS.StartCapture`, `bash -n` on `RMS_Update.sh`.

## Still to test before merging

I could not run these on my machine, so they need doing on a real station:

1. **A full night through `Reprocess.py`**, with and without GitHub reachable (easiest way to fake it is a `127.0.0.1 github.com` line in `/etc/hosts`). There is no captured data on my dev box. What to look for: `Generate config audit report` is followed by `Archiving detections to ...`, the archive and `observation_summary.txt`/`.json` are produced, and in the broken-network run the summary shows `repository_lag_remote_days: Not determined` with a warning in the log and no stall.
2. **`Scripts/RMS_Update.sh` end to end.** I deliberately did not run it, since it does `git stash`, `fetch` and `reset --hard` on the working repo. Needs a run with GitHub reachable to confirm a normal update still works, and a run with it blackholed to confirm it exits with the "Cannot reach RMS repository" message instead of hanging. Also worth a run on a station with https remotes, since my machine only has ssh ones.
3. **A Raspberry Pi.** `timeout` is from coreutils and is present on Raspberry Pi OS, but the fallback branch in `git_net()` has not been exercised. Also worth confirming the git version on the oldest station image is at least 2.3, which is when `GIT_TERMINAL_PROMPT` appeared. Anything older falls back to `GIT_ASKPASS`, which still works, but it would be good to know.
4. **A station with an ssh remote**, to confirm the https rewrite produces a sensible lag number rather than "Not determined". My dev machine has four ssh remotes and it worked there, but stations are set up differently.
5. **Whether 120 s is enough** on the slowest rural links. A blobless clone of the RMS history took 5 s here. If a slow station starts reporting "Not determined" the timeout is the first thing to raise.
6. **`daysBehind()` picks the first remote alphabetically** as the base clone, not `origin`. That is pre-existing behaviour and I did not change it, but on my machine it means the lag is measured against `remotes/walesto/master`, which is probably not what was intended. Worth deciding separately whether it should prefer `origin`.

## Not in this PR

The sweep turned up other unbounded calls that are real but separate problems: `urlopen` with no timeout in `EventMonitor.py`, `StarCatalog.py` and `AstrometryNetNova.py`; the clock-status subprocesses in `ObservationSummary.py`; `du` in `DeleteOldObservations.py`; and the ffmpeg calls in `GenerateMP4s.py` and `FRbinViewer.py` that are missing `-nostdin`. Happy to open an issue for those.
